### PR TITLE
feat: add pluggable commit message generator for bit ci merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,3 +177,9 @@ This repository is built using Bit itself, demonstrating the "dogfooding" approa
 - Use `bit watch` for faster development cycles
 - E2E tests run in parallel on CI
 - Component compilation can be parallelized
+
+### Aspect Configuration
+
+- Aspects accept config as 2nd parameter in `provider` method: `provider(deps, config)`
+- Define TypeScript interface for config and inject into main class constructor
+- Configure in `workspace.jsonc` under aspect ID key

--- a/scopes/git/ci/ci.docs.mdx
+++ b/scopes/git/ci/ci.docs.mdx
@@ -115,3 +115,40 @@ bit ci merge [--message <string>] [--build]
 ### CI hint
 
 Gate this step behind a branch-protection rule so only fast-forward merges trigger a release.
+
+---
+
+## Configuration
+
+The CI aspect supports configuration in `workspace.jsonc`:
+
+```json
+{
+  "teambit.git/ci": {
+    "commitMessageScript": "node scripts/generate-commit-message.js"
+  }
+}
+```
+
+### `commitMessageScript`
+
+**Optional.** Path to a script that generates custom commit messages for the `bit ci merge` command.
+
+- **Default**: Uses `"chore: update .bitmap and lockfiles as needed [skip ci]"`
+- **Usage**: The script should output the desired commit message to stdout
+- **Security**: Commands are parsed to avoid shell injection - no chaining allowed
+- **Working Directory**: Script runs in the workspace root directory
+
+**Example script:**
+
+```javascript
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+try {
+  const version = execSync('npm show @my/package version', { encoding: 'utf8' }).trim();
+  console.log(`bump version to ${version} [skip ci]`);
+} catch {
+  console.log('chore: update .bitmap and lockfiles as needed [skip ci]');
+}
+```

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -10,6 +10,7 @@ import { ExportAspect, type ExportMain } from '@teambit/export';
 import { ImporterAspect, type ImporterMain } from '@teambit/importer';
 import { CheckoutAspect, type CheckoutMain } from '@teambit/checkout';
 import { SwitchLaneOptions } from '@teambit/lanes';
+import execa from 'execa';
 import chalk from 'chalk';
 import { CiAspect } from './ci.aspect';
 import { CiCmd } from './ci.cmd';
@@ -143,7 +144,6 @@ export class CiMain {
 
       if (commitMessageScript) {
         this.logger.console(chalk.blue(`Running custom commit message script: ${commitMessageScript}`));
-        const { execa } = await import('execa');
 
         // Parse the command to avoid shell injection
         const parts = commitMessageScript.split(' ');

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -361,7 +361,7 @@ export class CiMain {
     // This prevents issues when multiple PRs are merged in sequence
     const defaultBranch = await this.getDefaultBranchName();
     this.logger.console(chalk.blue(`Pulling latest git changes from ${defaultBranch} branch`));
-    await git.pull('origin', defaultBranch);
+    await git.pull('origin', defaultBranch, { '--rebase': 'true' });
     this.logger.console(chalk.green('Pulled latest git changes'));
 
     this.logger.console('🔄 Checking out to main head');
@@ -415,7 +415,7 @@ export class CiMain {
       await git.commit('chore: update .bitmap and lockfiles as needed [skip ci]');
 
       // Pull latest changes and push the commit to the remote repository
-      await git.pull('origin', defaultBranch);
+      await git.pull('origin', defaultBranch, { '--rebase': 'true' });
       await git.push('origin', defaultBranch);
     } else {
       this.logger.console(chalk.yellow('No components were tagged, skipping export and git operations'));

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -138,7 +138,7 @@ export class CiMain {
     }
   }
 
-  async getCustomCommitMessage() {
+  private async getCustomCommitMessage() {
     try {
       const commitMessageScript = this.config.commitMessageScript;
 

--- a/scripts/generate-merge-commit-message.js
+++ b/scripts/generate-merge-commit-message.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+
+try {
+  // Get the current version of @teambit/bit from npm
+  const version = execSync('npm show @teambit/bit version', { encoding: 'utf8' }).trim();
+
+  // Generate the commit message with the version
+  console.log(`bump teambit version to ${version} [skip ci]`);
+} catch {
+  // Fallback to default message if version lookup fails
+  console.log('chore: update .bitmap and lockfiles as needed [skip ci]');
+}

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -827,5 +827,8 @@
     "components/semantics/doc-parser": {
       "teambit.pkg/pkg": {}
     }
+  },
+  "teambit.git/ci": {
+    "commitMessageScript": "node scripts/generate-merge-commit-message.js"
   }
 }


### PR DESCRIPTION
Enables custom commit message generation for `bit ci merge` through workspace configuration.

- Adds `commitMessageScript` configuration option to `teambit.git/ci` aspect
- Executes custom script to generate commit messages when configured
- Includes script for Bit repository to maintain version-aware commit messages
- Falls back to default message when no script is configured
- Uses secure command execution without shell injection risks

Replaces hardcoded commit messages with configurable, repository-specific logic while keeping the CI command generic for all users.