### PR TITLE
fix(ci-merge): fix the checkout-head before snapping on main

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -8,7 +8,7 @@ import { LanesAspect, type LanesMain } from '@teambit/lanes';
 import { SnappingAspect, SnapResults, tagResultOutput, snapResultOutput, type SnappingMain } from '@teambit/snapping';
 import { ExportAspect, type ExportMain } from '@teambit/export';
 import { ImporterAspect, type ImporterMain } from '@teambit/importer';
-import { CheckoutAspect, type CheckoutMain } from '@teambit/checkout';
+import { CheckoutAspect, checkoutOutput, type CheckoutMain } from '@teambit/checkout';
 import { SwitchLaneOptions } from '@teambit/lanes';
 import chalk from 'chalk';
 import { CiAspect } from './ci.aspect';
@@ -381,11 +381,18 @@ export class CiMain {
     this.logger.console(chalk.green('Pulled latest git changes'));
 
     this.logger.console('🔄 Checking out to main head');
-    await this.checkout.checkout({
+    await this.importer.importCurrentObjects();
+
+    const checkoutProps = {
+      ids: this.workspace.listIds(),
       forceOurs: true,
       head: true,
       skipNpmInstall: true,
-    });
+    };
+    const checkoutResults = await this.checkout.checkout(checkoutProps);
+    await this.workspace.bitMap.write('checkout head');
+    // all: true is to make it less verbose in the output. this workaround will be fixed later.
+    this.logger.console(checkoutOutput(checkoutResults, { ...checkoutProps, all: true }));
 
     const { code, data, status } = await this.verifyWorkspaceStatusInternal(strict);
     if (code !== 0) return { code, data };


### PR DESCRIPTION
Previously, the checkout-head step didn't have any id to checkout and it didn't write anything to the `.bitmap` file.