### PR TITLE
feat: add version bump flags to bit ci merge command

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -12,6 +12,7 @@ import { CheckoutAspect, checkoutOutput, type CheckoutMain } from '@teambit/chec
 import { SwitchLaneOptions } from '@teambit/lanes';
 import execa from 'execa';
 import chalk from 'chalk';
+import { ReleaseType } from 'semver';
 import { CiAspect } from './ci.aspect';
 import { CiCmd } from './ci.cmd';
 import { CiVerifyCmd } from './commands/verify.cmd';
@@ -371,7 +372,21 @@ export class CiMain {
     }
   }
 
-  async mergePr({ message: argMessage, build, strict }: { message?: string; build?: boolean; strict?: boolean }) {
+  async mergePr({
+    message: argMessage,
+    build,
+    strict,
+    releaseType,
+    preReleaseId,
+    incrementBy,
+  }: {
+    message?: string;
+    build?: boolean;
+    strict?: boolean;
+    releaseType?: ReleaseType;
+    preReleaseId?: string;
+    incrementBy?: number;
+  }) {
     const message = argMessage || (await this.getGitCommitMessage());
     if (!message) {
       throw new Error('Failed to get commit message from git. Please provide a message using --message option.');
@@ -437,6 +452,9 @@ export class CiMain {
       build,
       failFast: true,
       persist: hasSoftTaggedComponents,
+      releaseType,
+      preReleaseId,
+      incrementBy,
     });
 
     if (tagResults) {

--- a/scopes/git/ci/commands/merge.cmd.ts
+++ b/scopes/git/ci/commands/merge.cmd.ts
@@ -1,12 +1,21 @@
 import type { Command, CommandOptions } from '@teambit/cli';
 import type { Logger } from '@teambit/logger';
 import { OutsideWorkspaceError, type Workspace } from '@teambit/workspace';
+import { ReleaseType } from 'semver';
+import { validateOptions } from '@teambit/snapping';
 import { CiMain } from '../ci.main.runtime';
 
 type Options = {
   message?: string;
   build?: boolean;
   strict?: boolean;
+  increment?: ReleaseType;
+  patch?: boolean;
+  minor?: boolean;
+  major?: boolean;
+  preRelease?: string;
+  prereleaseId?: string;
+  incrementBy?: number;
 };
 
 export class CiMergeCmd implements Command {
@@ -18,6 +27,21 @@ export class CiMergeCmd implements Command {
     ['m', 'message <message>', 'If set, use it as the snap message, if not, try and grab from git-commit-message'],
     ['b', 'build', 'Set to true to build the app locally, false (default) will build on Ripple CI'],
     ['s', 'strict', 'Set to true to fail on warnings as well as errors, false (default) only fails on errors'],
+    [
+      'l',
+      'increment <level>',
+      'options are: [major, premajor, minor, preminor, patch, prepatch, prerelease], default to patch',
+    ],
+    ['', 'prerelease-id <id>', 'prerelease identifier (e.g. "dev" to get "1.0.0-dev.1")'],
+    ['p', 'patch', 'syntactic sugar for "--increment patch"'],
+    ['', 'minor', 'syntactic sugar for "--increment minor"'],
+    ['', 'major', 'syntactic sugar for "--increment major"'],
+    ['', 'pre-release [identifier]', 'syntactic sugar for "--increment prerelease" and `--prerelease-id <identifier>`'],
+    [
+      '',
+      'increment-by <number>',
+      '(default to 1) increment semver flag (patch/minor/major) by. e.g. incrementing patch by 2: 0.0.1 -> 0.0.3.',
+    ],
   ];
 
   constructor(
@@ -31,6 +55,15 @@ export class CiMergeCmd implements Command {
     this.logger.console('🚀 Initializing Merge command');
     if (!this.workspace) throw new OutsideWorkspaceError();
 
-    return this.ci.mergePr({ message: options.message, build: options.build, strict: options.strict });
+    const { releaseType, preReleaseId } = validateOptions(options);
+
+    return this.ci.mergePr({
+      message: options.message,
+      build: options.build,
+      strict: options.strict,
+      releaseType,
+      preReleaseId,
+      incrementBy: options.incrementBy,
+    });
   }
 }


### PR DESCRIPTION
Adds version bump control flags to `bit ci merge` command, similar to those available in `bit tag`.

## New flags:
- `--increment <level>` - specify version bump level (major, minor, patch, prerelease, etc.)
- `--patch`, `--minor`, `--major` - shortcuts for increment levels  
- `--pre-release [identifier]` - prerelease with optional identifier
- `--prerelease-id <id>` - specify prerelease identifier
- `--increment-by <number>` - increment by more than 1

This allows users to control version bumping during CI merge operations instead of being limited to the default patch increment.