### PR TITLE
fix: default export routes conflict on api ref pages

### DIFF
--- a/components/models/api-reference-model/api-reference-model.ts
+++ b/components/models/api-reference-model/api-reference-model.ts
@@ -121,6 +121,8 @@ export class APIReferenceModel {
 
     const exportedAPINodes: APINode[] = exportedSchemaNodes.map((schemaNode) => {
       const targetNode = ExportSchema.isExportSchema(schemaNode) ? schemaNode.exportNode : schemaNode;
+      // @ts-ignore
+      targetNode.name = schemaNode.name === 'default' ? `${targetNode.name} (default)` : targetNode.name;
       return {
         componentId,
         api: targetNode,


### PR DESCRIPTION
## Proposed Changes

- added a ` (default)` suffix to default export on API Ref pages to solve the route conflict if there is another named export like `export { Foo }` and `export default Foo`

<img width="312" height="263" alt="image" src="https://github.com/user-attachments/assets/e54e146e-847b-4027-9598-985fcd258e9f" />
