### PR TITLE
fix(lane-import-branch): avoid changing the branch name. keep it the same as the lane-id

### DIFF
--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -649,17 +649,16 @@ please create a new lane instead, which will include all components of this lane
       }
 
       const gitExecutablePath = getGitExecutablePath();
-      const branchName = laneName.replace(/[^a-zA-Z0-9-_]/g, '-'); // Sanitize branch name
 
       // Create and checkout to the new git branch
-      await execa(gitExecutablePath, ['checkout', '-b', branchName], {
+      await execa(gitExecutablePath, ['checkout', '-b', laneName], {
         cwd: this.workspace.path,
       });
 
-      this.logger.info(`Created and checked out git branch: ${branchName}`);
+      this.logger.info(`Created and checked out git branch: ${laneName}`);
     } catch (err: any) {
       // Don't fail the lane import if git branch creation fails
-      this.logger.warn(`Failed to create git branch: ${err.message}`);
+      this.logger.warn(`Failed to create git branch "${laneName}": ${err.message}`);
     }
   }
 


### PR DESCRIPTION
This is for `bit lane import <lane-id> --branch` flag.