### PR TITLE
fix(ci): commit all changed files instead of only .bitmap and lockfiles

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -455,6 +455,7 @@ export class CiMain {
     preReleaseId,
     incrementBy,
     explicitVersionBump,
+    verbose,
   }: {
     message?: string;
     build?: boolean;
@@ -463,6 +464,7 @@ export class CiMain {
     preReleaseId?: string;
     incrementBy?: number;
     explicitVersionBump?: boolean;
+    verbose?: boolean;
   }) {
     const message = argMessage || (await this.getGitCommitMessage());
     if (!message) {
@@ -564,8 +566,23 @@ export class CiMain {
         this.logger.console(chalk.gray(`  ${file.working_dir}${file.index} ${file.path}`));
       });
 
-      // Commit the .bitmap and pnpm-lock.yaml files using Git
-      await git.add(['.bitmap', 'pnpm-lock.yaml']);
+      // Show git diff if there are uncommitted changes
+      if (verbose && statusBeforeCommit.files.length > 0) {
+        try {
+          const diff = await git.diff();
+          if (diff) {
+            this.logger.console(chalk.blue('Git diff before commit:'));
+            this.logger.console(diff);
+          }
+        } catch (error) {
+          this.logger.console(chalk.yellow(`Failed to show git diff: ${error}`));
+        }
+      }
+
+      // Previously we committed only .bitmap and pnpm-lock.yaml files.
+      // However, it's possible that "bit checkout head" we did above, modified other files as well.
+      // So now we commit all files that were changed.
+      await git.add(['.']);
 
       const commitMessage = await this.getCustomCommitMessage();
       await git.commit(commitMessage);
@@ -577,49 +594,7 @@ export class CiMain {
         this.logger.console(chalk.gray(`  ${file.working_dir}${file.index} ${file.path}`));
       });
 
-      // Show git diff if there are uncommitted changes
-      if (statusAfterCommit.files.length > 0) {
-        try {
-          const diff = await git.diff();
-          if (diff) {
-            this.logger.console(chalk.blue('Git diff after commit:'));
-            this.logger.console(diff);
-          }
-        } catch (error) {
-          this.logger.console(chalk.yellow(`Failed to show git diff: ${error}`));
-        }
-      }
-
-      // Pull latest changes and push the commit to the remote repository
-      // Check if there are any unstaged changes before pulling
-      const hasUnstagedChanges = statusAfterCommit.files.length > 0;
-
-      if (hasUnstagedChanges) {
-        this.logger.console(chalk.yellow('Stashing uncommitted changes before final rebase'));
-        await git.stash(['push', '-u', '-m', 'CI merge post-commit stash']);
-      }
-
       await git.pull('origin', defaultBranch, { '--rebase': 'true' });
-
-      if (hasUnstagedChanges) {
-        this.logger.console(chalk.yellow('Restoring stashed changes after final rebase'));
-        await git.stash(['pop']);
-
-        // Show git diff after stash pop to see what changes remain
-        try {
-          const finalStatus = await git.status();
-          if (finalStatus.files.length > 0) {
-            const diff = await git.diff();
-            if (diff) {
-              this.logger.console(chalk.blue('Git diff after stash pop:'));
-              this.logger.console(diff);
-            }
-          }
-        } catch (error) {
-          this.logger.console(chalk.yellow(`Failed to show git diff after stash pop: ${error}`));
-        }
-      }
-
       await git.push('origin', defaultBranch);
     } else {
       this.logger.console(chalk.yellow('No components were tagged, skipping export and git operations'));

--- a/scopes/git/ci/commands/merge.cmd.ts
+++ b/scopes/git/ci/commands/merge.cmd.ts
@@ -16,6 +16,7 @@ type Options = {
   preRelease?: string;
   prereleaseId?: string;
   incrementBy?: number;
+  verbose?: boolean;
 };
 
 export class CiMergeCmd implements Command {
@@ -42,6 +43,7 @@ export class CiMergeCmd implements Command {
       'increment-by <number>',
       '(default to 1) increment semver flag (patch/minor/major) by. e.g. incrementing patch by 2: 0.0.1 -> 0.0.3.',
     ],
+    ['', 'verbose', 'show verbose output'],
   ];
 
   constructor(
@@ -70,6 +72,7 @@ export class CiMergeCmd implements Command {
       preReleaseId,
       incrementBy: options.incrementBy,
       explicitVersionBump,
+      verbose: options.verbose,
     });
   }
 }


### PR DESCRIPTION
Previously the CI merge process only committed .bitmap and pnpm-lock.yaml files. However, the "bit checkout head" operation can modify other files as well, so this change ensures all modified files are committed during the CI merge process.