### PR TITLE
fix: avoid error ComponentsPendingImport when bit-watch or IDE extension starts

### DIFF
--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -437,6 +437,10 @@ export class APIForIDE {
     return this.adjustCheckoutResultsToIde(results);
   }
 
+  async importObjectsIfOutdatedAgainstBitmap(): Promise<void> {
+    return this.workspace.importObjectsIfOutdatedAgainstBitmap();
+  }
+
   async getTemplates() {
     const templates = await this.generator.listTemplates();
     return templates;

--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -111,6 +111,7 @@ if this doesn't work well for you, run "bit config set watch_use_polling true" t
       import: !skipImport,
       trigger: trigger ? ComponentID.fromString(trigger) : undefined,
       generateTypes: watchCmdOpts.generateTypes,
+      preImport: !skipImport,
     };
     await this.watcher.watch(watchOpts, getMessages(this.logger));
   }

--- a/scopes/workspace/watcher/watcher.main.runtime.ts
+++ b/scopes/workspace/watcher/watcher.main.runtime.ts
@@ -30,6 +30,9 @@ export class WatcherMain {
 
   async watch(opts: WatchOptions, msgs?: EventMessages) {
     if (!this.workspace) throw new OutsideWorkspaceError();
+    if (opts.preImport) {
+      await this.workspace.importObjectsIfOutdatedAgainstBitmap();
+    }
     const watcher = new Watcher(this.workspace, this.pubsub, this, opts, msgs);
     await watcher.watch();
   }

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -56,7 +56,8 @@ export type WatchOptions = {
   checkTypes?: CheckTypes; // if enabled, the spawnTSServer becomes true.
   preCompile?: boolean; // whether compile all components before start watching
   compile?: boolean; // whether compile modified/added components during watch process
-  import?: boolean; // whether import objects when .bitmap got version changes
+  import?: boolean; // whether import objects during watch when .bitmap got version changes
+  preImport?: boolean; // whether import objects before starting the watch process in case .bitmap is more updated than local scope.
   generateTypes?: boolean; // whether generate d.ts files for typescript files during watch process (hurts performance)
   trigger?: ComponentID; // trigger onComponentChange for the specified component-id. helpful when this comp must be a bundle, and needs to be recompile on any dep change.
 };


### PR DESCRIPTION
Fixes the issue where `bit watch` or the IDE extension shows "your workspace has outdated objects. please use 'bit import' to pull the latest objects from the remote scope".
This is happening when the user is running `git pull`, which updates `.bitmap` file, but the local scope objects are not updated yet ("bit import" is not run yet).
To fix it, this PR checks before those two operations whether there are out of date components against .bitmap, and if it found some, it fetches the objects for them.
