### PR TITLE
fix(schema): handle default export type references

### DIFF
--- a/scopes/typescript/typescript/transformers/export-assignment.ts
+++ b/scopes/typescript/typescript/transformers/export-assignment.ts
@@ -1,4 +1,4 @@
-import { ExportSchema, SchemaNode } from '@teambit/semantics.entities.semantic-schema';
+import { ExportSchema, SchemaNode, TypeRefSchema } from '@teambit/semantics.entities.semantic-schema';
 import { Node, SyntaxKind, ExportAssignment as ExportAssignmentNode } from 'typescript';
 import { ExportIdentifier } from '../export-identifier';
 import { SchemaExtractorContext } from '../schema-extractor-context';
@@ -25,9 +25,22 @@ export class ExportAssignmentTransformer implements SchemaTransformer {
     const exportNode = await context.getTypeRef(specifier.getText(), absoluteFilePath, location);
 
     if (exportNode) {
-      return new ExportSchema(location, 'default', exportNode);
+      return new ExportSchema(
+        location,
+        `${exportNode.name} (default)`,
+        new TypeRefSchema(
+          exportNode.location,
+          exportNode.name,
+          exportNode.componentId,
+          exportNode.packageName,
+          exportNode.internalFilePath
+        ),
+        `${exportNode.name} (default)`
+      );
     }
 
-    return new ExportSchema(location, 'default', await context.computeSchema(specifier));
+    const schemaNode = await context.computeSchema(specifier);
+    const nodeName = schemaNode.name ? `${schemaNode.name} (default)` : 'default';
+    return new ExportSchema(location, nodeName, schemaNode, nodeName);
   }
 }


### PR DESCRIPTION
This PR correctly extracts default exports and correctly links the type referenced via them. 

https://github.com/user-attachments/assets/f6f705db-5ed0-4281-b618-d14ae1a27388

