### PR TITLE
fix(mcp): resolve template file path issue in cli-mcp-server rules command

### DIFF
--- a/components/mcp/mcp-config-writer/mcp-config-writer.ts
+++ b/components/mcp/mcp-config-writer/mcp-config-writer.ts
@@ -485,16 +485,16 @@ export class McpConfigWriter {
   /**
    * Get default Bit MCP rules content from template file
    */
-  static async getDefaultRulesContent(consumerProject: boolean = false, templateBaseDir?: string): Promise<string> {
+  static async getDefaultRulesContent(consumerProject: boolean = false): Promise<string> {
     const templateName = consumerProject ? 'bit-rules-consumer-template.md' : 'bit-rules-template.md';
-    const templatePath = path.join(templateBaseDir || __dirname, templateName);
+    const templatePath = path.join(__dirname, templateName);
     return fs.readFile(templatePath, 'utf8');
   }
 
   /**
    * Write Bit MCP rules file for VS Code
    */
-  static async writeVSCodeRules(options: RulesOptions, templateBaseDir?: string): Promise<void> {
+  static async writeVSCodeRules(options: RulesOptions): Promise<void> {
     const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
@@ -504,14 +504,14 @@ export class McpConfigWriter {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, templateBaseDir);
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
     await fs.writeFile(promptsPath, rulesContent);
   }
 
   /**
    * Write Bit MCP rules file for Cursor
    */
-  static async writeCursorRules(options: RulesOptions, templateBaseDir?: string): Promise<void> {
+  static async writeCursorRules(options: RulesOptions): Promise<void> {
     const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
@@ -521,14 +521,14 @@ export class McpConfigWriter {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, templateBaseDir);
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
     await fs.writeFile(promptsPath, rulesContent);
   }
 
   /**
    * Write Bit MCP rules file for Roo Code
    */
-  static async writeRooCodeRules(options: RulesOptions, templateBaseDir?: string): Promise<void> {
+  static async writeRooCodeRules(options: RulesOptions): Promise<void> {
     const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
@@ -538,14 +538,14 @@ export class McpConfigWriter {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, templateBaseDir);
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
     await fs.writeFile(promptsPath, rulesContent);
   }
 
   /**
    * Write Bit MCP rules file for Cline
    */
-  static async writeClineRules(options: RulesOptions, templateBaseDir?: string): Promise<void> {
+  static async writeClineRules(options: RulesOptions): Promise<void> {
     const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
@@ -555,14 +555,14 @@ export class McpConfigWriter {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, templateBaseDir);
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
     await fs.writeFile(promptsPath, rulesContent);
   }
 
   /**
    * Write Bit MCP rules file for Claude Code
    */
-  static async writeClaudeCodeRules(options: RulesOptions, templateBaseDir?: string): Promise<void> {
+  static async writeClaudeCodeRules(options: RulesOptions): Promise<void> {
     const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
@@ -572,7 +572,7 @@ export class McpConfigWriter {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Get base rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, templateBaseDir);
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
 
     // Add integration instructions at the top
     const integrationInstructions = `<!--
@@ -622,7 +622,7 @@ This will automatically include all Bit-specific instructions in your Claude Cod
   /**
    * Write rules file for a specific editor
    */
-  static async writeRulesFile(editor: string, options: RulesOptions, templateBaseDir?: string): Promise<void> {
+  static async writeRulesFile(editor: string, options: RulesOptions): Promise<void> {
     const supportedEditors = ['vscode', 'cursor', 'roo', 'cline', 'claude-code'];
     const editorLower = editor.toLowerCase();
 
@@ -631,15 +631,15 @@ This will automatically include all Bit-specific instructions in your Claude Cod
     }
 
     if (editorLower === 'vscode') {
-      await this.writeVSCodeRules(options, templateBaseDir);
+      await this.writeVSCodeRules(options);
     } else if (editorLower === 'cursor') {
-      await this.writeCursorRules(options, templateBaseDir);
+      await this.writeCursorRules(options);
     } else if (editorLower === 'roo') {
-      await this.writeRooCodeRules(options, templateBaseDir);
+      await this.writeRooCodeRules(options);
     } else if (editorLower === 'cline') {
-      await this.writeClineRules(options, templateBaseDir);
+      await this.writeClineRules(options);
     } else if (editorLower === 'claude-code') {
-      await this.writeClaudeCodeRules(options, templateBaseDir);
+      await this.writeClaudeCodeRules(options);
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1283,14 +1283,11 @@ export class CliMcpServerMain {
       rulesOptions.workspaceDir = workspaceDir;
     }
 
-    // Pass the template base directory to the component
-    const templateBaseDir = path.join(__dirname);
-    await McpConfigWriter.writeRulesFile(editor, rulesOptions, templateBaseDir);
+    await McpConfigWriter.writeRulesFile(editor, rulesOptions);
   }
 
   async getRulesContent(consumerProject: boolean = false): Promise<string> {
-    const templateBaseDir = path.join(__dirname);
-    return McpConfigWriter.getDefaultRulesContent(consumerProject, templateBaseDir);
+    return McpConfigWriter.getDefaultRulesContent(consumerProject);
   }
 
   static slots = [];

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
@@ -688,4 +688,63 @@ describe('CliMcpServer Direct Aspect Tests', function () {
       });
     });
   });
+
+  describe('Rules Methods', () => {
+    it('should get rules content without error', async () => {
+      // This test reproduces the bug where bit-rules-template.md was not found
+      const rulesContent = await mcpServer.getRulesContent(false);
+      expect(rulesContent).to.be.a('string');
+      expect(rulesContent).to.contain('# Bit MCP Agent Instructions');
+      expect(rulesContent).to.contain('Core Objectives');
+    });
+
+    it('should get consumer project rules content without error', async () => {
+      const rulesContent = await mcpServer.getRulesContent(true);
+      expect(rulesContent).to.be.a('string');
+      expect(rulesContent).to.contain('## How to Install and Use Bit Components');
+      expect(rulesContent).to.contain('Bit Components are reusable pieces of code');
+    });
+
+    it('should write rules file for VS Code without error', async () => {
+      await mcpServer.writeRulesFile(
+        'vscode',
+        {
+          isGlobal: false,
+          consumerProject: false,
+        },
+        workspacePath
+      );
+
+      // Check that the rules file was created
+      const rulesPath = path.join(workspacePath, '.github', 'instructions', 'bit.instructions.md');
+      const rulesExists = await fs.pathExists(rulesPath);
+      expect(rulesExists).to.be.true;
+
+      // Check content
+      const rulesContent = await fs.readFile(rulesPath, 'utf8');
+      expect(rulesContent).to.contain('# Bit MCP Agent Instructions');
+      expect(rulesContent).to.contain('Core Objectives');
+    });
+
+    it('should write consumer project rules file without error', async () => {
+      await mcpServer.writeRulesFile(
+        'vscode',
+        {
+          isGlobal: false,
+          consumerProject: true,
+        },
+        workspacePath
+      );
+
+      // Check that the rules file was created
+      const rulesPath = path.join(workspacePath, '.github', 'instructions', 'bit.instructions.md');
+      const rulesExists = await fs.pathExists(rulesPath);
+      expect(rulesExists).to.be.true;
+
+      // Check content is different for consumer project
+      const rulesContent = await fs.readFile(rulesPath, 'utf8');
+      expect(rulesContent).to.contain('## How to Install and Use Bit Components');
+      expect(rulesContent).to.contain('Bit Components are reusable pieces of code');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fix ENOENT error when running `bit mcp-server rules` command.

## Root Cause
The `cli-mcp-server` was looking for template files in its own directory, but they're located in the `mcp-config-writer` component.

## Changes
- Remove `templateBaseDir` parameter from `McpConfigWriter` methods
- Let `McpConfigWriter` handle its own template file resolution internally
- Add test coverage to prevent regression

## Test Plan
- [x] `bit mcp-server rules --print` works correctly
- [x] `bit mcp-server rules --print --consumer-project` works correctly
- [x] All existing tests pass