### PR TITLE
fix(lanes): show warning when git branch already exists during lane import with --branch

### DIFF
--- a/components/legacy/e2e-helper/e2e-git-helper.ts
+++ b/components/legacy/e2e-helper/e2e-git-helper.ts
@@ -23,8 +23,12 @@ export default class GitHelper {
     const hookPath = path.join(this.scopes.localPath, '.git', 'hooks', hookName);
     return fs.outputFileSync(hookPath, content);
   }
-  initNewGitRepo() {
-    return this.command.runCmd('git init');
+  initNewGitRepo(setTestUser = false) {
+    this.command.runCmd('git init');
+    if (setTestUser) {
+      this.addGitConfig('user.name', 'Test User');
+      this.addGitConfig('user.email', 'test@example.com');
+    }
   }
 
   addGitConfig(key: string, val: string, location = 'local') {

--- a/e2e/harmony/ci-commands.e2e.ts
+++ b/e2e/harmony/ci-commands.e2e.ts
@@ -1,0 +1,240 @@
+import chai, { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('ci commands', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  function setupWorkspaceWithGitRemote() {
+    helper.scopeHelper.setWorkspaceWithRemoteScope();
+
+    // Create a bare git repository to serve as remote
+    const { scopePath } = helper.scopeHelper.getNewBareScope();
+    const bareRepoPath = scopePath.replace('.bit', '.git');
+    helper.command.runCmd(`git init --bare ${bareRepoPath}`);
+
+    // Initialize git in workspace and set up remote
+    helper.git.initNewGitRepo();
+    helper.git.addGitConfig('user.name', 'Test User');
+    helper.git.addGitConfig('user.email', 'test@example.com');
+    helper.command.runCmd(`git remote add origin ${bareRepoPath}`);
+
+    return bareRepoPath;
+  }
+
+  function setupComponentsAndInitialCommit(numComponents = 2) {
+    // Create components and initial export
+    helper.fixtures.populateComponents(numComponents);
+    helper.command.tagAllWithoutBuild();
+    helper.command.export();
+
+    // Create .gitignore file
+    helper.fs.outputFile('.gitignore', 'node_modules/\n.bit/\n');
+
+    // Initial git commit and push to remote
+    helper.command.runCmd('git add .');
+    helper.command.runCmd('git commit -m "initial commit"');
+
+    // Get the current branch name (could be main or master depending on git version)
+    const currentBranch = helper.command.runCmd('git branch --show-current').trim();
+    helper.command.runCmd(`git push -u origin ${currentBranch}`);
+
+    // Store the default branch name for later use
+    return currentBranch;
+  }
+
+  describe('bit ci pr workflow', () => {
+    let prOutput: string;
+    before(() => {
+      setupWorkspaceWithGitRemote();
+      setupComponentsAndInitialCommit();
+
+      // Create a feature branch
+      helper.command.runCmd('git checkout -b feature/test-pr');
+
+      // Make some changes
+      helper.fs.outputFile('comp1/comp1.js', 'console.log("updated component");');
+      helper.command.runCmd('git add comp1/comp1.js');
+      helper.command.runCmd('git commit -m "feat: update component"');
+
+      // in real world scenario, you would push the branch to the remote
+      // and this "bit ci" command would be run in a CI environment
+
+      prOutput = helper.command.runCmd('bit ci pr --message "test pr message"');
+    });
+    it('should complete successfully', () => {
+      expect(prOutput).to.include('PR command executed successfully');
+    });
+    it('should create a lane with the components and switch back to main', () => {
+      const lanes = helper.command.listLanesParsed();
+      expect(lanes.currentLane).to.equal('main');
+      expect(lanes.lanes).to.have.lengthOf(2);
+      expect(lanes.lanes[0].name).to.equal('feature-test-pr');
+      expect(lanes.lanes[0].components).to.have.lengthOf(1);
+    });
+    it('should export the lane to the remote', () => {
+      const remoteLanes = helper.command.listRemoteLanesParsed();
+      expect(remoteLanes.lanes[0].name).to.equal('feature-test-pr');
+      expect(remoteLanes.lanes[0].components).to.have.lengthOf(1);
+    });
+    describe('importing the lane to a new workspace', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.importLane(`feature-test-pr`, '-x');
+      });
+      it('should import the lane successfully', () => {
+        const lanes = helper.command.listLanesParsed();
+        expect(lanes.currentLane).to.equal(`feature-test-pr`);
+      });
+      it('should save the git message into the snap message', () => {
+        const log = helper.command.logParsed('comp1');
+        const lastLog = log[log.length - 1];
+        expect(lastLog.message).to.include('test pr message');
+      });
+    });
+  });
+
+  describe('bit ci merge workflow', () => {
+    let mergeOutput: string;
+    before(() => {
+      setupWorkspaceWithGitRemote();
+      const defaultBranch = setupComponentsAndInitialCommit();
+
+      // Create feature branch and make changes
+      helper.command.runCmd('git checkout -b feature/test-merge');
+      helper.fs.outputFile('comp1/comp1.js', 'console.log("merge test");');
+      helper.command.runCmd('git add comp1/comp1.js');
+      helper.command.runCmd('git commit -m "fix: component update for merge"');
+
+      // Simulate PR merge scenario by going back to default branch
+      helper.command.runCmd(`git checkout ${defaultBranch}`);
+      helper.command.runCmd('git merge feature/test-merge');
+
+      // Run bit ci merge command
+      mergeOutput = helper.command.runCmd('bit ci merge --message "test merge message"');
+    });
+    it('should complete successfully', () => {
+      expect(mergeOutput).to.include('Merged PR');
+    });
+    it('should tag the component', () => {
+      const list = helper.command.listParsed();
+      const comp1 = list.find((comp) => comp.id.includes('comp1'));
+      expect(comp1).to.exist;
+      expect(comp1?.currentVersion).to.equal('0.0.2');
+    });
+    it('status should be clean', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+      helper.command.expectStatusToBeClean();
+    });
+    it('should export tagged components to remote', () => {
+      const list = helper.command.listRemoteScopeParsed();
+      const comp1 = list.find((comp) => comp.id.includes('comp1'));
+      expect(comp1?.localVersion).to.equal('0.0.2');
+    });
+    it('should save the "ci pr" message into the tag message', () => {
+      const log = helper.command.logParsed('comp1');
+      const lastLog = log[log.length - 1];
+      expect(lastLog.message).to.include('test merge message');
+    });
+  });
+
+  describe('multi-workspace scenario', () => {
+    let prOutput: string;
+    before(() => {
+      // Original workspace setup with git remote
+      setupComponentsAndInitialCommit(1);
+
+      // Create and push feature branch
+      helper.command.runCmd('git checkout -b feature/multi-workspace');
+      helper.fs.outputFile('comp1/comp1.js', 'console.log("multi workspace test");');
+      helper.command.runCmd('git add comp1/comp1.js');
+      helper.command.runCmd('git commit -m "feat: multi workspace changes"');
+      helper.command.runCmd('git push -u origin feature/multi-workspace');
+
+      // Simulate cloning to new workspace using git helpers
+      helper.git.mimicGitCloneLocalProjectHarmony();
+      helper.scopeHelper.addRemoteScope();
+
+      // Set up git remote in the new workspace
+      helper.command.runCmd('git fetch origin');
+      helper.command.runCmd('git checkout feature/multi-workspace');
+
+      // Run ci pr command in the "cloned" workspace
+      prOutput = helper.command.runCmd(`bit ci pr --lane ${helper.scopes.remote}/test-clone-lane`);
+    });
+    it('should complete successfully', () => {
+      expect(prOutput).to.include('PR command executed successfully');
+    });
+    it('should create the specified lane', () => {
+      const lanes = helper.command.listLanesParsed();
+      expect(lanes.currentLane).to.equal('main');
+      expect(lanes.lanes).to.have.lengthOf(2);
+      expect(lanes.lanes[0].name).to.equal('test-clone-lane');
+      expect(lanes.lanes[0].components).to.have.lengthOf(1);
+    });
+    it('should export the lane to the remote', () => {
+      const remoteLanes = helper.command.listRemoteLanesParsed();
+      expect(remoteLanes.lanes[0].name).to.equal('test-clone-lane');
+      expect(remoteLanes.lanes[0].components).to.have.lengthOf(1);
+    });
+  });
+
+  describe('bit ci merge when checked out to a lane', () => {
+    let mergeOutput: string;
+    before(() => {
+      setupWorkspaceWithGitRemote();
+      const defaultBranch = setupComponentsAndInitialCommit();
+
+      helper.fs.outputFile('comp1/comp1.js', 'console.log("merge test");');
+      helper.command.createLane('test-merge-lane');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.command.runCmd('git checkout -b feature/test-merge');
+      helper.command.runCmd('git add .');
+      helper.command.runCmd('git commit -m "fix: component update for merge"');
+
+      // Simulate PR merge scenario by going back to default branch
+      helper.command.runCmd(`git checkout ${defaultBranch}`);
+      helper.command.runCmd('git merge feature/test-merge');
+
+      // Run bit ci merge command
+      mergeOutput = helper.command.runCmd('bit ci merge');
+    });
+    it('should complete successfully', () => {
+      expect(mergeOutput).to.include('Merged PR');
+    });
+    it('should tag the component', () => {
+      const list = helper.command.listParsed();
+      const comp1 = list.find((comp) => comp.id.includes('comp1'));
+      expect(comp1).to.exist;
+      expect(comp1?.currentVersion).to.equal('0.0.2');
+    });
+    it('status should be clean', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+      helper.command.expectStatusToBeClean();
+    });
+    it('should export tagged components to remote', () => {
+      const list = helper.command.listRemoteScopeParsed();
+      const comp1 = list.find((comp) => comp.id.includes('comp1'));
+      expect(comp1?.localVersion).to.equal('0.0.2');
+    });
+    it('should delete the remote lane', () => {
+      const remoteLanes = helper.command.listRemoteLanesParsed();
+      expect(remoteLanes.lanes).to.have.lengthOf(0);
+    });
+  });
+});

--- a/e2e/harmony/ci-commands.e2e.ts
+++ b/e2e/harmony/ci-commands.e2e.ts
@@ -24,9 +24,7 @@ describe('ci commands', function () {
     helper.command.runCmd(`git init --bare ${bareRepoPath}`);
 
     // Initialize git in workspace and set up remote
-    helper.git.initNewGitRepo();
-    helper.git.addGitConfig('user.name', 'Test User');
-    helper.git.addGitConfig('user.email', 'test@example.com');
+    helper.git.initNewGitRepo(true);
     helper.command.runCmd(`git remote add origin ${bareRepoPath}`);
 
     return bareRepoPath;

--- a/e2e/harmony/lanes/lane-import-git-branch.e2e.ts
+++ b/e2e/harmony/lanes/lane-import-git-branch.e2e.ts
@@ -24,8 +24,7 @@ describe('bit lane import with --branch flag', function () {
       // Initialize a new workspace and setup git
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
-      helper.git.initNewGitRepo();
-
+      helper.git.initNewGitRepo(true);
       const laneNameWithoutScope = 'my-test-lane';
 
       helper.command.importLane(laneNameWithoutScope, '--branch');

--- a/e2e/harmony/lanes/lane-import-git-branch.e2e.ts
+++ b/e2e/harmony/lanes/lane-import-git-branch.e2e.ts
@@ -54,7 +54,7 @@ describe('bit lane import with --branch flag', function () {
       // Initialize a new workspace and setup git
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
-      helper.git.initNewGitRepo();
+      helper.git.initNewGitRepo(true);
       helper.fs.outputFile('.gitignore', 'node_modules/\n.bit/\n');
       helper.command.runCmd('git add .');
       helper.command.runCmd('git commit -m "initial commit"');

--- a/e2e/harmony/lanes/lane-import-git-branch.e2e.ts
+++ b/e2e/harmony/lanes/lane-import-git-branch.e2e.ts
@@ -1,0 +1,81 @@
+import chai, { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('bit lane import with --branch flag', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('basic case', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane('my-test-lane');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      // Initialize a new workspace and setup git
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.git.initNewGitRepo();
+
+      const laneNameWithoutScope = 'my-test-lane';
+
+      helper.command.importLane(laneNameWithoutScope, '--branch');
+    });
+    it('should import the lane successfully', () => {
+      const laneNameWithoutScope = 'my-test-lane';
+      helper.command.expectCurrentLaneToBe(laneNameWithoutScope);
+    });
+    it('should checkout to the branch with the same name as the lane id', () => {
+      const laneNameWithoutScope = 'my-test-lane';
+      const fullLaneName = `${helper.scopes.remote}/${laneNameWithoutScope}`;
+      const currentBranch = helper.command.runCmd('git branch --show-current').trim();
+      expect(currentBranch).to.equal(fullLaneName);
+    });
+  });
+
+  describe('when git branch already exists', () => {
+    let remoteScope: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane('my-test-lane');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      remoteScope = helper.scopes.remote;
+
+      // Initialize a new workspace and setup git
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.git.initNewGitRepo();
+      helper.fs.outputFile('.gitignore', 'node_modules/\n.bit/\n');
+      helper.command.runCmd('git add .');
+      helper.command.runCmd('git commit -m "initial commit"');
+    });
+
+    it('should show a warning when git branch already exists', () => {
+      const laneNameWithoutScope = 'my-test-lane';
+      const fullLaneName = `${remoteScope}/${laneNameWithoutScope}`;
+
+      // Create a git branch with the same name as the lane
+      helper.command.runCmd(`git branch ${fullLaneName}`);
+
+      const result = helper.command.importLane(laneNameWithoutScope, '--branch');
+
+      // The import should succeed but show a warning about the existing branch
+      expect(result).to.contain('Failed to create git branch');
+      expect(result).to.contain(`fatal: a branch named '${fullLaneName}' already exists`);
+
+      // The lane should still be imported successfully
+      helper.command.expectCurrentLaneToBe(laneNameWithoutScope);
+    });
+  });
+});

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -110,6 +110,7 @@ export type ApplyVersionResults = {
   installationError?: Error; // in case the package manager failed, it won't throw, instead, it'll return error here
   compilationError?: Error; // in case the compiler failed, it won't throw, instead, it'll return error here
   workspaceConfigUpdateResult?: WorkspaceConfigUpdateResult;
+  gitBranchWarning?: string; // warning message when git branch creation fails
 };
 
 export class MergingMain {

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -602,10 +602,11 @@ export class CiMain {
 
     if (currentLane) {
       this.logger.console('🗑️ Lane Cleanup');
-      const laneId = currentLane.id;
-      this.logger.console(chalk.blue(`Archiving lane ${laneId.toString()}`));
-      const archiveLane = await this.lanes.removeLanes([laneId()]);
-      if (archiveLane) {
+      const laneId = currentLane.id();
+      this.logger.console(chalk.blue(`Archiving lane ${laneId}`));
+      // force means to remove the lane even if it was not merged. in this case, we don't care much because main already has the changes.
+      const archiveLane = await this.lanes.removeLanes([laneId], { remote: true, force: true });
+      if (archiveLane.length) {
         this.logger.console(chalk.green('Lane archived'));
       } else {
         this.logger.console(chalk.yellow('Failed to archive lane'));

--- a/scopes/lanes/lanes/switch.cmd.ts
+++ b/scopes/lanes/lanes/switch.cmd.ts
@@ -80,7 +80,7 @@ ${COMPONENT_PATTERN_HELP}`,
       branch?: boolean;
     }
   ) {
-    const { components, failedComponents, installationError, compilationError } = await this.lanes.switchLanes(lane, {
+    const switchResult = await this.lanes.switchLanes(lane, {
       head,
       alias,
       merge: autoMergeResolve,
@@ -91,6 +91,8 @@ ${COMPONENT_PATTERN_HELP}`,
       skipDependencyInstallation,
       branch,
     });
+    const { components, failedComponents, installationError, compilationError, gitBranchWarning } = switchResult;
+
     if (getAll) {
       this.lanes.logger.warn('the --get-all flag is deprecated and currently the default behavior');
     }
@@ -120,9 +122,14 @@ ${COMPONENT_PATTERN_HELP}`,
       return chalk.bold(title) + applyVersionReport(components, true, false) + laneSwitched;
     };
 
+    const getGitBranchWarningOutput = () => {
+      return gitBranchWarning ? chalk.yellow(`Warning: ${gitBranchWarning}`) : null;
+    };
+
     return compact([
       getFailureOutput(),
       getSuccessfulOutput(),
+      getGitBranchWarningOutput(),
       installationErrorOutput(installationError),
       compilationErrorOutput(compilationError),
     ]).join('\n\n');


### PR DESCRIPTION
## Summary

Fixes the issue where `bit lane import <lane> --branch` would silently fail to create a git branch when a branch with the same name already exists.

## Changes

- Modified `createGitBranchForLane` to return warning messages instead of just logging them
- Added `gitBranchWarning` property to `ApplyVersionResults` type for proper type safety  
- Updated switch command to display git branch warnings to the user with yellow styling

## Test Plan

- Added e2e test `lane-import-git-branch.e2e.ts` that reproduces the original bug and validates the fix
- Test covers both success and failure scenarios for git branch creation
- Existing lane import functionality remains unchanged