### PR TITLE
ci: add back some missing scripts that should run before tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,6 +616,11 @@ jobs:
       - run:
           name: setting npmjs registry with publishing permission
           command: echo "//registry.npmjs.org/:_authToken=${npmjsRegistryToken}" >> ~/.npmrc
+      - run: cd bit && npm run generate-cli-reference
+      - run: cd bit && npm run generate-cli-reference-json
+      - run: cd bit && npm run generate-cli-reference-docs
+      - run: cd bit && bit status # just to make sure that the new cli-reference.mdx file is valid
+      - run: cd bit && npm run generate-core-aspects-ids
       - run:
           name: 'bit ci merge'
           command: 'cd bit && bit ci merge --build ${BIT_CI_MERGE_EXTRA_FLAGS}'


### PR DESCRIPTION
They stopped running since we moved to "bit ci merge" command. This PR adds them back. 