### PR TITLE
refactor: consolidate aspect constants to reduce circular dependencies

### DIFF
--- a/components/legacy/constants/constants.ts
+++ b/components/legacy/constants/constants.ts
@@ -531,11 +531,15 @@ export enum Extensions {
   compiler = 'teambit.compilation/compiler',
   envs = 'teambit.envs/envs',
   builder = 'teambit.pipelines/builder',
+  tester = 'teambit.defender/tester',
   deprecation = 'teambit.component/deprecation',
   forking = 'teambit.component/forking',
   renaming = 'teambit.component/renaming',
   lanes = 'teambit.lanes/lanes',
   remove = 'teambit.component/remove',
+  workspace = 'teambit.workspace/workspace',
+  typescript = 'teambit.typescript/typescript',
+  aspect = 'teambit.harmony/aspect',
 }
 
 export enum BuildStatus {

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -13,14 +13,13 @@ import { ComponentID } from '@teambit/component-id';
 import type { Harmony } from '@teambit/harmony';
 import type { Workspace, WorkspaceComponentLoadOptions } from '@teambit/workspace';
 import { WorkspaceAspect } from '@teambit/workspace';
-import { PkgAspect } from '@teambit/pkg';
-import { RenamingAspect } from '@teambit/renaming';
 import { AbstractVinyl, DataToPersist } from '@teambit/component.sources';
 import { EnvsAspect } from '@teambit/envs';
 import { NewComponentHelperAspect } from './new-component-helper.aspect';
 import { incrementPathRecursively } from '@teambit/component-writer';
+import { Extensions } from '@teambit/legacy.constants';
 
-const aspectsConfigToIgnore: string[] = [PkgAspect.id, RenamingAspect.id];
+const aspectsConfigToIgnore: string[] = [Extensions.pkg, Extensions.renaming];
 type File = { path: string; content: string };
 
 export class NewComponentHelperMain {

--- a/scopes/pipelines/builder/build-pipeline-order.ts
+++ b/scopes/pipelines/builder/build-pipeline-order.ts
@@ -1,11 +1,11 @@
 import { Graph, Node, Edge } from '@teambit/graph.cleargraph';
-import { TesterAspect } from '@teambit/tester';
 import type { EnvDefinition, Environment } from '@teambit/envs';
 import type { BuildTask } from './build-task';
 import { BuildTaskHelper } from './build-task';
 import type { TaskSlot } from './builder.main.runtime';
 import { TasksQueue } from './tasks-queue';
 import type { PipeFunctionNames } from './builder.service';
+import { Extensions } from '@teambit/legacy.constants';
 
 type TaskDependenciesGraph = Graph<string, string>;
 type Location = 'start' | 'middle' | 'end';
@@ -80,7 +80,7 @@ export function calculatePipelineOrder(
     );
   }
   if (skipTests) {
-    tasksQueue = new TasksQueue(...tasksQueue.filter(({ task }) => task.aspectId !== TesterAspect.id));
+    tasksQueue = new TasksQueue(...tasksQueue.filter(({ task }) => task.aspectId !== Extensions.tester));
   }
   if (skipTasks.length) {
     tasksQueue = new TasksQueue(

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -16,7 +16,6 @@ import type { SlotRegistry } from '@teambit/harmony';
 import { Slot } from '@teambit/harmony';
 import type { Logger, LoggerMain } from '@teambit/logger';
 import { LoggerAspect } from '@teambit/logger';
-import { AspectAspect } from '@teambit/aspect';
 import type { ScopeMain } from '@teambit/scope';
 import { ScopeAspect } from '@teambit/scope';
 import type { Workspace } from '@teambit/workspace';
@@ -54,6 +53,7 @@ import { BuilderRoute } from './builder.route';
 import { ComponentsHaveIssues } from './exceptions/components-have-issues';
 import type { ConfigStoreMain } from '@teambit/config-store';
 import { ConfigStoreAspect } from '@teambit/config-store';
+import { Extensions } from '@teambit/legacy.constants';
 
 export type TaskSlot = SlotRegistry<BuildTask[]>;
 export type OnTagResults = { builderDataMap: ComponentMap<RawBuilderData>; pipeResults: TaskResultsList[] };
@@ -147,7 +147,7 @@ export class BuilderMain {
       {
         ...builderOptions,
         // even when build is skipped (in case of tag-from-scope), the pre-build/post-build and teambit.harmony/aspect tasks are needed
-        tasks: populateArtifactsFrom ? [AspectAspect.id] : undefined,
+        tasks: populateArtifactsFrom ? [Extensions.aspect] : undefined,
       },
       { ignoreIssues: '*' }
     );

--- a/scopes/pkg/pkg/pack.task.ts
+++ b/scopes/pkg/pkg/pack.task.ts
@@ -1,7 +1,7 @@
 import type { BuildContext, BuiltTaskResult, BuildTask, TaskLocation } from '@teambit/builder';
-import { TypescriptAspect } from '@teambit/typescript';
 import type { Logger } from '@teambit/logger';
 import type { Packer } from './packer';
+import { Extensions } from '@teambit/legacy.constants';
 
 /**
  * pack components to a .tgz file
@@ -10,7 +10,7 @@ export class PackTask implements BuildTask {
   readonly name = 'PackComponents';
   readonly description = 'Packing components into a .tgz file';
   readonly location: TaskLocation = 'end';
-  readonly dependencies = [TypescriptAspect.id];
+  readonly dependencies = [Extensions.typescript];
   constructor(
     readonly aspectId: string,
     private packer: Packer,

--- a/scripts/circular-deps-check/baseline-cycles.json
+++ b/scripts/circular-deps-check/baseline-cycles.json
@@ -1,5 +1,5 @@
 {
-  "totalCycles": 2066,
+  "totalCycles": 2061,
   "uniqueComponents": 324,
-  "timestamp": "2025-07-29T14:00:29.829Z"
+  "timestamp": "2025-07-30T15:18:40.643Z"
 }


### PR DESCRIPTION
This PR consolidates aspect constants to the `Extensions` enum in `legacy.constants` to reduce circular dependencies in the codebase.

## Changes
- Added `tester`, `workspace`, `typescript`, and `aspect` constants to the `Extensions` enum in `legacy.constants`
- Replaced direct aspect imports with references to `Extensions` enum in affected files
- Updated circular dependency baseline from 2066 to 2061 cycles