### PR TITLE
fix(ci-merge): reset components that were created on a lane to new after switching to main

### DIFF
--- a/components/legacy/bit-map/bit-map.ts
+++ b/components/legacy/bit-map/bit-map.ts
@@ -287,8 +287,10 @@ export class BitMap {
   }
 
   resetLaneComponentsToNew() {
+    let hasChanged = false;
     this.components = this.components.map((component) => {
       if (component.isAvailableOnCurrentLane) return component;
+      hasChanged = true;
       return new ComponentMap({
         id: component.id.changeVersion(undefined).changeScope(component.scope || (component.defaultScope as string)),
         mainFile: component.mainFile,
@@ -299,6 +301,9 @@ export class BitMap {
         onLanesOnly: false,
       });
     });
+    if (hasChanged) {
+      this.markAsChanged();
+    }
   }
 
   private throwForDuplicateRootDirs(componentsJson: Record<string, any>) {

--- a/components/legacy/consumer/consumer.ts
+++ b/components/legacy/consumer/consumer.ts
@@ -457,6 +457,9 @@ export default class Consumer {
     await Scope.reset(this.scope.path, true);
   }
 
+  /**
+   * components that were created on the lane and considered as non-available on main are reset to be new components.
+   */
   async resetLaneNew() {
     this.bitMap.resetLaneComponentsToNew();
     this.bitMap.laneId = undefined;

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -478,6 +478,11 @@ export class CiMain {
       // out to main lane.
       this.logger.console(chalk.blue(`Currently on lane ${currentLane.name}, switching to main`));
       await this.switchToLane('main');
+      // this is needed to make sure components that were created on the lane are now available on main.
+      // without this, the switch to main above, marks those components as not-available, and won't be tagged later on.
+      await this.workspace.consumer.resetLaneNew();
+      await this.workspace.clearCache();
+      await this.workspace.bitMap.write('reset lane new');
       this.logger.console(chalk.green('Switched to main lane'));
     }
 


### PR DESCRIPTION
Here is the use-case where this bug occurred - a user is running `bit lane import --branch`, which creates a git-branch with the lane data, `bit ci pr` snaps and exports the changes on the lane. Once done, the `bit ci merge` switches to main and tries to tag. However, because all changes were done on the lane, once switched to main, those components are marked as unavailable. 
This PR fixes it by running "bit init --reset-lane-new` programmatically after switching to main. This way, the components that were created on the lane become new components. 