### PR TITLE
fix: use named imports for chai to resolve eslint warnings

### DIFF
--- a/scopes/component/checkout/checkout.spec.ts
+++ b/scopes/component/checkout/checkout.spec.ts
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai';
+import { expect, use } from 'chai';
 import fs from 'fs-extra';
 import type { Harmony } from '@teambit/harmony';
 import type { ComponentID } from '@teambit/component-id';
@@ -15,7 +15,7 @@ import { ListerAspect } from '@teambit/lister';
 import type { CheckoutMain } from './checkout.main.runtime';
 import { CheckoutAspect } from './checkout.aspect';
 
-chai.use(require('chai-fs'));
+use(require('chai-fs'));
 
 describe('CheckoutAspect', function () {
   this.timeout(0);

--- a/scopes/component/renaming/renaming.spec.ts
+++ b/scopes/component/renaming/renaming.spec.ts
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai';
+import { expect, use } from 'chai';
 import { loadManyAspects } from '@teambit/harmony.testing.load-aspect';
 import type { Workspace } from '@teambit/workspace';
 import { WorkspaceAspect } from '@teambit/workspace';
@@ -8,7 +8,7 @@ import { mockComponents } from '@teambit/component.testing.mock-components';
 import type { RenamingMain } from './renaming.main.runtime';
 import { RenamingAspect } from './renaming.aspect';
 
-chai.use(require('chai-fs'));
+use(require('chai-fs'));
 
 describe('Renaming Aspect', function () {
   this.timeout(0);

--- a/scopes/semantics/schema/schema.spec.ts
+++ b/scopes/semantics/schema/schema.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import chai, { expect } from 'chai';
+import { expect, use } from 'chai';
 import { APISchema, UnknownSchema } from '@teambit/semantics.entities.semantic-schema';
 import chaiSubset from 'chai-subset';
 import type { TrackerMain } from '@teambit/tracker';
@@ -14,7 +14,7 @@ import { WorkspaceAspect } from '@teambit/workspace';
 import type { SchemaMain } from './schema.main.runtime';
 import { SchemaAspect } from './schema.aspect';
 
-chai.use(chaiSubset);
+use(chaiSubset);
 
 describe('SchemaAspect', function () {
   this.timeout(0);


### PR DESCRIPTION
Fixes ESLint warnings by replacing `chai.use()` pattern with named imports.

Changed `import chai, { expect } from 'chai'` to `import { expect, use } from 'chai'` in test files to follow ESLint recommendations for better tree-shaking and code clarity.