### PR TITLE
chore: update ESLint configuration rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,91 +12,27 @@ module.exports = {
   },
   parserOptions: {
     project: require.resolve('./tsconfig.json'),
-    // createDefaultProgram: true,
     ecmaFeatures: {
-      jsx: true, // Allows for the parsing of JSX
+      jsx: true,
     },
   },
   extends: [
-    'airbnb-typescript/base',
-    // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    // 'plugin:eslint-comments/recommended',
     'plugin:promise/recommended',
     'plugin:react/recommended',
     'plugin:import/recommended',
-    // 'plugin:unicorn/recommended',
-    // 'plugin:mocha/recommended',
     'prettier',
   ],
-  plugins: [
-    '@typescript-eslint',
-    // 'eslint-comments',
-    'promise',
-    // 'simple-import-sort',
-    // 'mocha',
-    // 'unicorn'
-  ],
+  plugins: ['@typescript-eslint', 'promise'],
+  ignorePatterns: ['.eslintrc.js'],
   rules: {
     complexity: ['error', { max: 25 }],
-    'react/prop-types': 'off',
-    'arrow-body-style': 'off',
-    'prefer-arrow-callback': 'off',
     'no-console': ['error'],
-    '@typescript-eslint/no-unused-vars': ['error', { args: 'after-used' }],
-    '@typescript-eslint/no-use-before-define': [
-      'error',
-      { functions: false, classes: true, variables: true, typedefs: true },
-    ],
-    '@typescript-eslint/return-await': 'error',
-    'no-return-await': 'off',
-    '@typescript-eslint/no-misused-promises': 'error',
-    '@typescript-eslint/default-param-last': 'off',
-    '@typescript-eslint/no-floating-promises': 'error',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/ban-types': 'off',
-    'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': ['error'],
-    // ERRORS OF plugin:@typescript-eslint as a result of upgrade eslint-config-airbnb-typescript from v5 to v12
-    '@typescript-eslint/lines-between-class-members': 'off',
-    '@typescript-eslint/naming-convention': 'off',
-    '@typescript-eslint/no-unused-expressions': 'off',
-    // END ERRORS OF plugin:@typescript-eslint as a result of upgrade eslint-config-airbnb-typescript from v5 to v12
-    // ERRORS OF plugin:@typescript-eslint/recommended
-    '@typescript-eslint/no-var-requires': 'off',
-    '@typescript-eslint/ban-ts-ignore': 'off',
-    '@typescript-eslint/camelcase': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    // END ERRORS OF plugin:@typescript-eslint/recommended
-
-    // ERRORS OF 'plugin:promise/recommended'
-    'promise/always-return': 'off',
-    'promise/no-nesting': 'off',
-    // END ERRORS OF 'plugin:promise/recommended'
-    'import/prefer-default-export': 'off', // typescript works better without default export
-    'import/export': 'off', // typescript does allow multiple export default when overloading. not sure why it's enabled here. rule source: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
-    'prefer-object-spread': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    'import/no-cycle': 'off',
-    'import/no-useless-path-segments': 'off',
-    'lines-between-class-members': 'off',
-    radix: 'off',
-    'no-underscore-dangle': 'off',
-    'no-param-reassign': 'off',
     'no-return-assign': [0, 'except-parens'],
-    'class-methods-use-this': 'off',
-    // 'simple-import-sort/sort': 'error',
-    // 'sort-imports': 'off',
-    // 'import/first': 'error',
-    // 'import/newline-after-import': 'error',
-    'import/no-duplicates': 'error',
-    'prefer-destructuring': 'off',
-    'import/no-extraneous-dependencies': 'off',
-    'no-restricted-syntax': [2, 'ForInStatement', 'LabeledStatement', 'WithStatement'],
-    'no-unused-expressions': 'off',
+    'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
     'max-len': [
-      2,
+      'error',
       120,
       2,
       {
@@ -107,12 +43,21 @@ module.exports = {
         ignoreTemplateLiterals: true,
       },
     ],
-    'max-lines': [2, 2000],
-    'func-names': [0],
+    'max-lines': ['error', 2000],
 
-    // ERRORS OF plugin:react/recommended
-    'react/no-unescaped-entities': 'off',
-
+    // ERRORS OF plugin:@typescript-eslint/recommended
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/no-var-requires': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/return-await': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { args: 'after-used' }],
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { functions: false, classes: true, variables: true, typedefs: true },
+    ],
+    '@typescript-eslint/no-misused-promises': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/consistent-type-imports': [
       'warn',
       {
@@ -120,16 +65,18 @@ module.exports = {
         fixStyle: 'separate-type-imports',
       },
     ],
+    '@typescript-eslint/no-shadow': ['error'],
+
+    // ERRORS OF 'plugin:promise/recommended'
+    'promise/always-return': 'off',
+    'promise/no-nesting': 'off',
+
+    // ERRORS OF 'plugin:import/recommended'
+    'import/no-duplicates': 'error',
+
+    // ERRORS OF plugin:react/recommended
+    'react/prop-types': 'off',
   },
-  // return the no-cycle once "import type" is working
-  // overrides: [
-  //   {
-  //     files: ['src/extensions/**/*.ts'],
-  //     rules: {
-  //       'import/no-cycle': ['error']
-  //     }
-  //   }
-  // ],
   env: {
     browser: true,
     node: true,

--- a/e2e/harmony/ci-commands.e2e.ts
+++ b/e2e/harmony/ci-commands.e2e.ts
@@ -192,7 +192,8 @@ describe('ci commands', function () {
   describe('bit ci merge with versions file', () => {
     let mergeOutput: string;
     before(() => {
-      setupWorkspaceWithGitRemote();
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      setupGitRemote();
       const defaultBranch = setupComponentsAndInitialCommit(3);
 
       // Create feature branch and make changes

--- a/scopes/component/snapping/version-file-parser.ts
+++ b/scopes/component/snapping/version-file-parser.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import { ComponentID, ComponentIdList } from '@teambit/component-id';
+import type { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { BitError } from '@teambit/bit-error';
 import type { TagDataPerComp } from './snapping.main.runtime';
 

--- a/scopes/defender/prettier/prettier.formatter.ts
+++ b/scopes/defender/prettier/prettier.formatter.ts
@@ -7,6 +7,7 @@ import type {
   ComponentFormatResult,
 } from '@teambit/formatter';
 import type { Options as PrettierModuleOptions } from 'prettier';
+// eslint-disable-next-line import/default
 import PrettierLib from 'prettier';
 import mapSeries from 'p-map-series';
 import type { Logger } from '@teambit/logger';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -428,7 +428,7 @@
         "eslint-import-resolver-node": "0.3.4",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-mocha": "6.3.0",
-        "eslint-plugin-promise": "4.3.1",
+        "eslint-plugin-promise": "7.2.1",
         "eslint-plugin-react": "7.33.2",
         "eventemitter2": "6.4.4",
         "events": "^3.3.0",


### PR DESCRIPTION
Cleans up ESLint configuration by removing unnecessary rules and the Airbnb plugin. Many rules were removed as they are no longer needed with current ESLint and TypeScript configurations.