### PR TITLE
fix: remove 186 unused @ts-expect-error directives

### DIFF
--- a/scopes/api-reference/hooks/use-api-ref-url/use-api-ref-url.ts
+++ b/scopes/api-reference/hooks/use-api-ref-url/use-api-ref-url.ts
@@ -14,7 +14,6 @@ export function useAPIRefParam(key: keyof APIRefQueryParams): string | undefined
 export function useUpdatedUrlFromQuery(queryParams: APIRefQueryParams): string {
   const query = useQuery();
   const location = useLocation() || { pathname: '/' };
-  // @ts-ignore
   const queryObj = Object.fromEntries(query.entries());
 
   const updatedObj = { ...queryObj, ...queryParams };

--- a/scopes/api-reference/hooks/use-api/use-api.ts
+++ b/scopes/api-reference/hooks/use-api/use-api.ts
@@ -19,7 +19,6 @@ export function useAPI(
     skipInternals?: boolean;
   }
 ): { apiModel?: APIReferenceModel; loading?: boolean } {
-  // @ts-ignore - remove once graphql versions are aligned (see #8753)
   const { data, loading } = useDataQuery(GET_SCHEMA, {
     variables: {
       componentId,

--- a/scopes/cloud/cloud/cloud.main.runtime.ts
+++ b/scopes/cloud/cloud/cloud.main.runtime.ts
@@ -266,7 +266,7 @@ export class CloudMain {
           });
         })
         .on('error', (err) => {
-          // @ts-ignore
+          // @ts-expect-error
           const { code } = err;
           if (code === 'EADDRINUSE') {
             // set up a new auth listener with new port

--- a/scopes/compilation/bundler/dev-server.service.ts
+++ b/scopes/compilation/bundler/dev-server.service.ts
@@ -172,7 +172,7 @@ export class DevServerService implements EnvService<ComponentServer, DevServerDe
     const entry = await getEntry(context, this.runtimeSlot);
     const componentDirectoryMap = {};
     context.components.forEach((component) => {
-      // @ts-ignore this is usually a workspace component here so it has a workspace
+      // @ts-expect-error this is usually a workspace component here so it has a workspace
       const workspace = component.workspace;
       if (!workspace) return;
       componentDirectoryMap[component.id.toString()] = workspace.componentDir(component.id);

--- a/scopes/compilation/compiler/compiler.cmd.ts
+++ b/scopes/compilation/compiler/compiler.cmd.ts
@@ -61,7 +61,6 @@ export class CompileCmd implements Command {
 
   async json([components]: [string[]], compilerOptions: CompileOptions) {
     compilerOptions.deleteDistDir = true;
-    // @ts-ignore
     const compileResults = await this.compile.compileComponents(components, {
       ...compilerOptions,
       initiator: CompilationInitiator.CmdJson,

--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -213,7 +213,6 @@ once ready, snap/tag the components to persist the changes`;
       const title =
         alternativeTitle ||
         `successfully ${switchedOrReverted} ${chalk.bold(componentName)} to version ${chalk.bold(
-          // @ts-ignore version is defined when !reset
           head || latest ? component.id.version : version
         )}`;
       return chalk.bold(title) + newLine + applyVersionReport(components, false);
@@ -227,7 +226,6 @@ once ready, snap/tag the components to persist the changes`;
       if (head) return 'their head version';
       if (latest) return 'their latest version';
       if (main) return 'their main version';
-      // @ts-ignore version is defined when !reset
       return `version ${chalk.bold(version)}`;
     };
     const versionOutput = getVerOutput();

--- a/scopes/component/checkout/checkout-version.ts
+++ b/scopes/component/checkout/checkout-version.ts
@@ -101,9 +101,8 @@ export async function applyVersion(
 export function updateFileStatus(files: SourceFile[], filesStatus: FilesStatus, componentFromFS?: ConsumerComponent) {
   files.forEach((file) => {
     const fileFromFs = componentFromFS?.files.find((f) => f.relative === file.relative);
-    // @ts-ignore should be fixed after upgrading @types/node from '12.20.4' to > 20
     const areFilesEqual = fileFromFs && Buffer.compare(fileFromFs.contents, file.contents) === 0;
-    // @ts-ignore
+    // @ts-expect-error
     filesStatus[pathNormalizeToLinux(file.relative)] = areFilesEqual ? FileStatus.unchanged : FileStatus.updated;
   });
 }
@@ -129,7 +128,7 @@ export async function removeFilesIfNeeded(
   filePathsFromFS.forEach((file) => {
     const filename = pathNormalizeToLinux(file.relative);
     if (!filesStatus[filename]) {
-      // @ts-ignore todo: typescript has a good point here. it should be the string "removed", not chalk.green(removed).
+      // @ts-expect-error todo: typescript has a good point here. it should be the string "removed", not chalk.green(removed).
       filesStatus[filename] = FileStatus.removed;
     }
     if (filesStatus[filename] === FileStatus.removed) {

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -283,9 +283,9 @@ to move individual files, use bit move.
 to move all component files to a different directory, run bit remove and then bit import --path`);
         }
         const relativeWrittenPath = component.writtenPath;
-        // @ts-ignore relativeWrittenPath is set at this point
+        // @ts-expect-error relativeWrittenPath is set at this point
         const absoluteWrittenPath = this.consumer.toAbsolutePath(relativeWrittenPath);
-        // @ts-ignore this.writeToPath is set at this point
+        // @ts-expect-error this.writeToPath is set at this point
         const absoluteWriteToPath = path.resolve(opts.writeToPath); // don't use consumer.toAbsolutePath, it might be an inner dir
         if (relativeWrittenPath && absoluteWrittenPath !== absoluteWriteToPath) {
           this.mover.moveExistingComponent(component, absoluteWrittenPath, absoluteWriteToPath);

--- a/scopes/component/component-writer/component-writer.ts
+++ b/scopes/component/component-writer/component-writer.ts
@@ -153,7 +153,7 @@ export default class ComponentWriter {
   }
 
   _updateComponentRootPathAccordingToBitMap() {
-    // @ts-ignore this.component.componentMap is set
+    // @ts-expect-error this.component.componentMap is set
     this.writeToPath = this.component.componentMap.getRootDir();
     this.component.writtenPath = this.writeToPath;
     this._updateFilesBasePaths();

--- a/scopes/component/component/component-map/component-map.ts
+++ b/scopes/component/component/component-map/component-map.ts
@@ -66,7 +66,7 @@ export class ComponentMap<T> {
 
     const tuples = await Promise.all(tuplesP);
 
-    // @ts-ignore TODO: fix this type
+    // @ts-expect-error TODO: fix this type
     return new ComponentMap(new Map(tuples));
   }
 

--- a/scopes/component/component/component.route.ts
+++ b/scopes/component/component/component.route.ts
@@ -27,7 +27,7 @@ export class ComponentRoute implements Route {
           const host = this.componentExtension.getHost();
           const compId = await host.resolveComponentId(componentId);
           const component = await host.get(compId);
-          // @ts-ignore
+          // @ts-expect-error
           req.component = component;
         }
         next();
@@ -36,6 +36,6 @@ export class ComponentRoute implements Route {
   }
 
   method = this.registerRoute.method;
-  // @ts-ignore
+  // @ts-expect-error
   middlewares = this.componentMiddlewares.concat(this.registerRoute.middlewares);
 }

--- a/scopes/component/component/show/legacy-show/docs-template.ts
+++ b/scopes/component/component/show/legacy-show/docs-template.ts
@@ -71,6 +71,5 @@ export default (docs: Doclet[] | null | undefined) => {
   if (isEmpty(docs) || isNil(docs)) {
     return '\nNo documentation found';
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return `\n${paintHeader('Documentation')}${docs.map(paintDoc).join('')}`;
 };

--- a/scopes/component/component/show/legacy-show/get-scope-component.ts
+++ b/scopes/component/component/show/legacy-show/get-scope-component.ts
@@ -37,18 +37,18 @@ export async function getScopeComponent({
   let dependenciesInfo: DependenciesInfo[] = [];
   let dependentsInfo: DependenciesInfo[] = [];
   if (showDependents || showDependencies) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const componentDepGraph = await remote.graph(component.id);
     if (showDependents) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       dependentsInfo = componentDepGraph.getDependentsInfo(component.id);
     }
     if (showDependencies) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       dependenciesInfo = componentDepGraph.getDependenciesInfo(component.id);
     }
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return { component, dependentsInfo, dependenciesInfo };
 
   async function showComponentUsingScope(scope: Scope) {

--- a/scopes/component/component/show/legacy-show/legacy-show.ts
+++ b/scopes/component/component/show/legacy-show/legacy-show.ts
@@ -15,7 +15,7 @@ export async function show({
   remote: boolean;
   compare: boolean;
 }) {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return getComponent().then(({ component, componentModel, dependentsInfo, dependenciesInfo }) => ({
     component,
     componentModel,

--- a/scopes/component/component/show/legacy-show/show-legacy-cmd.ts
+++ b/scopes/component/component/show/legacy-show/show-legacy-cmd.ts
@@ -22,7 +22,7 @@ export function actionLegacy(
 ): Promise<any> {
   return show({
     id,
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     json,
     remote,
     compare,
@@ -55,7 +55,6 @@ export function reportLegacy({
     };
     const componentFromFileSystem = makeComponentReadable(component);
     if (component.scopesList) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       componentFromFileSystem.scopesList = component.scopesList;
     }
     const componentFromModel = componentModel ? makeComponentReadable(componentModel) : undefined;
@@ -84,7 +83,6 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
 
   function paintWithoutCompare() {
     const printableComponent = componentToPrintableForDiff(component);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     printableComponent.scopesList = (component.scopesList || []).map((s) => s.name).join('\n');
     const fields = getFields();
     const rows = compact(
@@ -94,20 +92,17 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
         const title = prettifyFieldName(field);
         if (!printableComponent[field]) return null;
 
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         arr.push(c.cyan(title));
         if (!printableComponent[field]) return null;
 
         if (printableComponent[field]) {
           if (printableComponent[field] instanceof Array) {
             arr.push(
-              // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
               printableComponent[field]
                 .map((str) => calculatePadRightLength(str, COLUMN_WIDTH))
                 .join(' ')
                 .trim()
             );
-            // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           } else arr.push(printableComponent[field]);
         }
         return arr;
@@ -121,7 +116,6 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
   function paintWithCompare() {
     if (!componentModel) throw new Error('paintWithCompare, componentModel must be defined');
     const printableOriginalComponent = componentToPrintableForDiff(component);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     printableOriginalComponent.id += ' [file system]';
     const printableComponentToCompare = componentToPrintableForDiff(componentModel);
 
@@ -132,30 +126,30 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
         const arr = [];
         if (!printableOriginalComponent[field] && !printableComponentToCompare[field]) return null;
         const title = `${field[0].toUpperCase()}${field.slice(1)}`.replace(/([A-Z])/g, ' $1').trim();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         arr.push(field in componentsDiffs && field !== 'id' ? c.red(title) : c.cyan(title));
         if (printableComponentToCompare[field] instanceof Array) {
           arr.push(
-            // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+            // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             printableComponentToCompare[field]
               .map((str) => calculatePadRightLength(str, COLUMN_WIDTH))
               .join(' ')
               .trim()
           );
         } else {
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           arr.push(printableComponentToCompare[field]);
         }
         if (printableOriginalComponent[field] instanceof Array) {
           arr.push(
-            // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+            // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             printableOriginalComponent[field]
               .map((str) => calculatePadRightLength(str, COLUMN_WIDTH))
               .join(' ')
               .trim()
           );
         } else {
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           arr.push(printableOriginalComponent[field]);
         }
         return arr;
@@ -193,7 +187,7 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
     }
 
     const dependencyHeader = [];
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     dependencyHeader.push(['Dependencies']);
     const getDependenciesRows = (dependencies, title?: string) => {
       const dependencyRows = [];
@@ -201,7 +195,7 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
         let dependencyId = dependency.id.toString();
         dependencyId = title ? `${dependencyId} (${title})` : dependencyId;
         const row = [dependencyId];
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dependencyRows.push(row);
       });
       return dependencyRows;

--- a/scopes/component/graph/ui/query/node-model.ts
+++ b/scopes/component/graph/ui/query/node-model.ts
@@ -10,7 +10,7 @@ export class NodeModel {
     const node = new NodeModel();
     node.id = rawNode.id;
     // @TODO - component model should not expect all fields to have values
-    // @ts-ignore
+    // @ts-expect-error
     node.component = rawNode.component ? ComponentModel.from(rawNode.component) : undefined;
     node.componentId = node.component ? node.component.id : ComponentID.fromString(rawNode.id);
     return node;

--- a/scopes/component/isolator/capsule/capsule.ts
+++ b/scopes/component/isolator/capsule/capsule.ts
@@ -80,7 +80,7 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
 
   // TODO: refactor this crap and simplify capsule API
   async execute(cmd: string, options?: Record<string, any> | null | undefined) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const execResults = await this.exec({ command: cmd.split(' '), options });
     let stdout = '';
     let stderr = '';
@@ -91,7 +91,6 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
       execResults.stdout.on('error', (error: string) => {
         return reject(error);
       });
-      // @ts-ignore
       execResults.on('close', () => {
         return resolve({ stdout, stderr });
       });

--- a/scopes/component/isolator/capsule/container.ts
+++ b/scopes/component/isolator/capsule/container.ts
@@ -102,7 +102,7 @@ export default class FsContainer implements Container<Exec, AnyFS> {
   start(): Promise<void> {
     return fs.ensureDir(this.wrkDir);
   }
-  // @ts-ignore
+  // @ts-expect-error
   async inspect(): Promise<ContainerStatus> {
     // todo: probably not needed for this container
   }

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1134,7 +1134,7 @@ export class IsolatorMain {
   private wereDependenciesInPackageJsonChanged(capsuleWithPackageData: CapsulePackageJsonData): boolean {
     const { previousPackageJson, currentPackageJson } = capsuleWithPackageData;
     if (!previousPackageJson) return true;
-    // @ts-ignore at this point, currentPackageJson is set
+    // @ts-expect-error at this point, currentPackageJson is set
     return DEPENDENCIES_FIELDS.some((field) => !isEqual(previousPackageJson[field], currentPackageJson[field]));
   }
 
@@ -1402,7 +1402,7 @@ export class IsolatorMain {
     this.logger.debug(`filterUnmodifiedExportedDependencies: filtering ${components.length} components`);
 
     const scope = this.componentAspect.getHost('teambit.scope/scope');
-    // @ts-ignore it's there, but we can't have the type of ScopeMain here to not create a circular dependency
+    // @ts-expect-error it's there, but we can't have the type of ScopeMain here to not create a circular dependency
     const remotes = await scope.getRemoteScopes();
 
     const filtered: Component[] = [];

--- a/scopes/component/lister/list-template.ts
+++ b/scopes/component/lister/list-template.ts
@@ -12,7 +12,6 @@ export function listTemplate(listScopeResults: ListScopeResult[], json: boolean,
     if (!json && showRemoteVersion) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const color = listScopeResult.remoteVersion && semver.gt(listScopeResult.remoteVersion, version!) ? 'red' : null;
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       version = color ? c[color](version) : version;
     }
     const getFormattedId = () => {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -578,7 +578,7 @@ export class MergingMain {
 
   private async resolveMerge(pattern: string, snapMessage: string, build: boolean): Promise<ApplyVersionResults> {
     const ids = await this.getIdsForUnmerged(pattern);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const { snappedComponents } = await this.snapping.snap({
       legacyBitIds: ComponentIdList.fromArray(ids.map((id) => id)),
       build,

--- a/scopes/component/modules/merge-helper/merge-version.ts
+++ b/scopes/component/modules/merge-helper/merge-version.ts
@@ -21,7 +21,7 @@ export const FileStatus = {
 export async function getMergeStrategyInteractive(): Promise<MergeStrategy> {
   try {
     const result = await resolveConflictPrompt();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return mergeOptionsCli[result.mergeStrategy];
   } catch {
     // probably user clicked ^C

--- a/scopes/component/modules/merge-helper/three-way-merge.ts
+++ b/scopes/component/modules/merge-helper/three-way-merge.ts
@@ -110,7 +110,6 @@ export async function threeWayMerge({
   };
   const getFileResult = async (fsFile: SourceFile, baseFile?: SourceFileModel, otherFile?: SourceFileModel) => {
     const filePath: PathLinux = pathNormalizeToLinux(fsFile.relative);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const fsFileHash = sha1(fsFile.contents);
     if (!otherFile) {
       // if !otherFile && !baseFile, the file was created after the last tag, no need to do any
@@ -143,7 +142,7 @@ export async function threeWayMerge({
     }
     // it was changed in both, there is a chance for conflict. (regardless the base)
     fsFile.label = currentLabel;
-    // @ts-ignore it's a hack to pass the data, version is not a valid attribute.
+    // @ts-expect-error it's a hack to pass the data, version is not a valid attribute.
     otherFile.label = otherLabel;
     results.modifiedFiles.push({ filePath, fsFile, baseFile, otherFile, output: null, conflict: null });
   };
@@ -214,11 +213,11 @@ async function getMergeResults(
 ): Promise<MergeFileResult[]> {
   const tmp = new Tmp(scope);
   const conflictResultsP = modifiedFiles.map(async (modifiedFile) => {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const fsFilePathP = tmp.save(modifiedFile.fsFile.contents);
     const writeFile = async (file: SourceFileModel): Promise<PathOsBased> => {
       const content = await file.file.load(scope.objects);
-      // @ts-ignore
+      // @ts-expect-error
       return tmp.save(content.contents.toString());
     };
     const baseFilePathP = modifiedFile.baseFile ? writeFile(modifiedFile.baseFile) : tmp.save('');
@@ -234,7 +233,7 @@ async function getMergeResults(
         path: baseFilePath,
       },
       otherFile: {
-        // @ts-ignore
+        // @ts-expect-error
         label: modifiedFile.otherFile.label,
         path: otherFilePath,
       },

--- a/scopes/component/mover/mover.main.runtime.ts
+++ b/scopes/component/mover/mover.main.runtime.ts
@@ -64,7 +64,6 @@ to change the main-file, use "bit add <component-dir> --main <new-main-file>"`);
     componentMap.updateDirLocation(oldPathRelative, newPathRelative);
     consumer.bitMap.markAsChanged();
     component.dataToPersist.files.forEach((file) => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const newRelative = file.relative.replace(oldPathRelative, newPathRelative);
       file.updatePaths({ newRelative, newBase: newPathRelative });
     });

--- a/scopes/component/remove/delete-cmd.ts
+++ b/scopes/component/remove/delete-cmd.ts
@@ -88,7 +88,7 @@ unless the '--hard' flag is used (not recommended!), in which case, the componen
     if (hard) {
       if (range) throw new BitError(`--range is not supported with --hard flag`);
       const { localResult, remoteResult = [] } = await this.remove.remove({ componentsPattern, remote: true, force });
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       let localMessage = removeTemplate(localResult, false);
       if (localMessage !== '') localMessage += '\n';
       return `${localMessage}${this.paintArray(remoteResult)}`;

--- a/scopes/component/remove/remove-cmd.ts
+++ b/scopes/component/remove/remove-cmd.ts
@@ -68,7 +68,7 @@ export class RemoveCmd implements Command {
     }: {
       localResult: RemovedLocalObjects;
     } = await this.remove.remove({ componentsPattern, force, track, deleteFiles: !keepFiles });
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const localMessage = removeTemplate(localResult, false);
     // if (localMessage !== '')
     //   localMessage +=

--- a/scopes/component/remove/remove-template.ts
+++ b/scopes/component/remove/remove-template.ts
@@ -62,13 +62,13 @@ export function removeTemplate(
   };
 
   return (
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     paintUnRemovedComponents(dependentBits) +
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     paintRemoved(removedComponentIds) +
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     paintMissingComponents(missingComponents) +
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     paintModifiedComponents(modifiedComponents)
   );
 }

--- a/scopes/component/remove/removed-local-objects.ts
+++ b/scopes/component/remove/removed-local-objects.ts
@@ -11,7 +11,7 @@ export class RemovedLocalObjects extends RemovedObjects {
     removedFromLane?: ComponentIdList
   ) {
     super({ removedComponentIds, missingComponents, dependentBits, removedFromLane });
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.modifiedComponents = modifiedComponents;
   }
 }

--- a/scopes/component/snapping/get-flattened-dependencies.ts
+++ b/scopes/component/snapping/get-flattened-dependencies.ts
@@ -119,7 +119,7 @@ this dependency was not included in the tag command.`);
  */
 function getEdges(graph: GraphLib, id: BitIdStr): BitIdStr[] | null {
   if (!graph.hasNode(id)) return null;
-  // @ts-ignore
+  // @ts-expect-error
   const edges = graphlib.alg.preorder(graph, id);
   return tail(edges); // the first item is the component itself
 }

--- a/scopes/component/snapping/reset-component.ts
+++ b/scopes/component/snapping/reset-component.ts
@@ -109,7 +109,7 @@ export async function removeLocalVersionsForMultipleComponents(
     const candidateComponentsIdsStr = candidateComponentsIds.map((id) => id.toString());
     candidateComponentsIds.forEach((bitId: ComponentID) => {
       const dependents = dependencyGraph.getImmediateDependentsPerId(bitId);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const dependentsNotCandidates = dependents.filter((dependent) => !candidateComponentsIdsStr.includes(dependent));
       if (dependentsNotCandidates.length) {
         throw new BitError( // $FlowFixMe

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -299,7 +299,7 @@ export class SnappingMain {
 
     await consumer.onDestroy(`tag (message: ${message || 'N/A'})`);
     await stagedConfig?.write();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return tagResults;
   }
 
@@ -597,7 +597,7 @@ export class SnappingMain {
     snapResults.laneName = currentLane.isDefault() ? null : currentLane.toString();
     await consumer.onDestroy(`snap (message: ${message || 'N/A'})`);
     await stagedConfig?.write();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return snapResults;
 
     async function getIdsToSnap(): Promise<ComponentIdList | null> {

--- a/scopes/component/snapping/version-maker.ts
+++ b/scopes/component/snapping/version-maker.ts
@@ -587,7 +587,7 @@ export class VersionMaker {
   ) {
     let { message } = this.params;
     const { persist, copyLogFromPreviousSnap } = this.params;
-    // @ts-ignore this happens when running `bit tag -m ""`.
+    // @ts-expect-error this happens when running `bit tag -m ""`.
     if (message === true) {
       message = '';
     }

--- a/scopes/component/sources/abstract-vinyl.ts
+++ b/scopes/component/sources/abstract-vinyl.ts
@@ -15,14 +15,13 @@ type AbstractVinylProps = {
   contents: Buffer;
 };
 
-// @ts-ignore
+// @ts-expect-error
 export default class AbstractVinyl extends (Vinyl as FileConstructor) {
   override = true;
   verbose = false;
 
   static fromVinyl(vinyl: Vinyl): AbstractVinyl {
     if (vinyl instanceof AbstractVinyl) return vinyl;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new AbstractVinyl(vinyl);
   }
 
@@ -41,11 +40,10 @@ export default class AbstractVinyl extends (Vinyl as FileConstructor) {
 
   async write(
     writePath?: string,
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     override?: boolean = this.override,
     verbose?: boolean = this.verbose
   ): Promise<string | null | undefined> {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const filePath = writePath || this.path;
     const msg = _verboseMsg(filePath, override);
     if (verbose) {
@@ -53,22 +51,18 @@ export default class AbstractVinyl extends (Vinyl as FileConstructor) {
     }
     logger.debug(msg);
     if (!override && fs.existsSync(filePath)) return null;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     await fs.outputFile(filePath, eol.auto(this.contents));
     return filePath;
   }
 
   toReadableString() {
     return {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       relativePath: this.relative,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       content: this.contents.toString(),
     };
   }
 
   static loadFromParsedStringBase(parsedString: any): AbstractVinylProps {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const contents = Buffer.isBuffer(parsedString._contents)
       ? parsedString._contents
       : Buffer.from(parsedString._contents);
@@ -85,13 +79,12 @@ export default class AbstractVinyl extends (Vinyl as FileConstructor) {
    * then when working on the same components in Windows and Linux they won't appear as modified
    */
   toSourceAsLinuxEOL(): Source {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return Source.from(eol.lf(this.contents));
   }
 
   async _getStatIfFileExists(): Promise<fs.Stats | null | undefined> {
     try {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       return await fs.lstat(this.path);
     } catch {
       return null; // probably file does not exist

--- a/scopes/component/sources/artifact-files.ts
+++ b/scopes/component/sources/artifact-files.ts
@@ -327,7 +327,7 @@ export function getArtifactFilesExcludeExtension(
 export function convertBuildArtifactsToModelObject(extensions: ExtensionDataList) {
   const buildArtifacts = getBuildArtifacts(extensions);
   buildArtifacts.forEach((artifact) => {
-    // @ts-ignore
+    // @ts-expect-error
     artifact.files = refsToModelObjects(artifact.files.refs);
   });
 }
@@ -335,7 +335,7 @@ export function convertBuildArtifactsToModelObject(extensions: ExtensionDataList
 export function convertBuildArtifactsFromModelObject(extensions: ExtensionDataList) {
   const artifactObjects = getBuildArtifacts(extensions);
   artifactObjects.forEach((artifactObject) => {
-    // @ts-ignore
+    // @ts-expect-error
     artifactObject.files = ArtifactFiles.fromModel(artifactObject.files);
   });
 }

--- a/scopes/component/sources/data-to-persist.spec.ts
+++ b/scopes/component/sources/data-to-persist.spec.ts
@@ -4,84 +4,83 @@ import * as path from 'path';
 import { DataToPersist } from './data-to-persist';
 
 describe('DataToPersist', function () {
-  // @ts-ignore
   this.timeout(0);
   describe('addFile', () => {
     describe('dir/file collision', () => {
       it('should not throw when the existing file starts with the added file in the same dir', () => {
         const dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: 'foo/bar.js' });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile = () => dataToPersist.addFile({ path: path.normalize('foo/bar.json') });
         expect(addFile).to.not.throw();
       });
       it('should not throw when the added file starts with the existing file in the same dir', () => {
         const dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: path.normalize('foo/bar.json') });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile = () => dataToPersist.addFile({ path: path.normalize('foo/bar.js') });
         expect(addFile).to.not.throw();
       });
       it('should throw when the added file is a directory of the existing file', () => {
         const dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: path.normalize('foo/bar.js') });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile = () => dataToPersist.addFile({ path: 'foo' });
         expect(addFile).to.throw();
       });
       it('should throw when the existing file is a directory of the added file', () => {
         const dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: 'foo' });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile = () => dataToPersist.addFile({ path: path.normalize('foo/bar.js') });
         expect(addFile).to.throw();
       });
       it('should throw when one is a directory of other with a few levels', () => {
         let dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: path.normalize('foo1/foo2') });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile1 = () => dataToPersist.addFile({ path: path.normalize('foo1/foo2/foo3/foo4') });
         expect(addFile1).to.throw();
 
         dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: path.normalize('foo1/foo2/foo3/foo4') });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile2 = () => dataToPersist.addFile({ path: path.normalize('foo1/foo2') });
         expect(addFile2).to.throw();
       });
       it('should not throw when file are different', () => {
         let dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: 'bar' });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile1 = () => dataToPersist.addFile({ path: 'foo' });
         expect(addFile1).to.not.throw();
 
         dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: 'foo' });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile2 = () => dataToPersist.addFile({ path: 'bar' });
         expect(addFile2).to.not.throw();
       });
       it('should not throw when file are different with the same dir', () => {
         let dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: path.normalize('bar/foo.js') });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile1 = () => dataToPersist.addFile({ path: path.normalize('bar/baz.js') });
         expect(addFile1).to.not.throw();
 
         dataToPersist = new DataToPersist();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         dataToPersist.addFile({ path: path.normalize('bar/baz.js') });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const addFile2 = () => dataToPersist.addFile({ path: path.normalize('bar/foo.js') });
         expect(addFile2).to.not.throw();
       });

--- a/scopes/component/sources/data-to-persist.ts
+++ b/scopes/component/sources/data-to-persist.ts
@@ -19,12 +19,9 @@ export class DataToPersist {
   }
   addFile(file: AbstractVinyl) {
     if (!file) throw new Error('failed adding an empty file into DataToPersist');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!file.path) {
       throw new Error('failed adding a file into DataToPersist as it does not have a path property');
     }
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const existingFileIndex = this.files.findIndex((existingFile) => existingFile.path === file.path);
     if (existingFileIndex !== -1) {
       if (file.override) {
@@ -93,10 +90,7 @@ export class DataToPersist {
     }
     if (file.override === false) {
       // @todo, capsule hack. use capsule.fs once you get it as a component.
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const capsulePath = capsule.container.getPath();
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const absPath = path.join(capsulePath, file.path);
       try {
         await fs.lstat(absPath); // if no errors have been thrown, the file exists
@@ -108,9 +102,6 @@ export class DataToPersist {
         }
       }
     }
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return capsule.outputFile(file.path, file.contents);
   }
   async atomicSymlink(capsule: any, symlink: Symlink) {
@@ -128,9 +119,7 @@ export class DataToPersist {
   }
   addBasePath(basePath: string) {
     this.files.forEach((file) => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       this._assertRelative(file.base);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       file.updatePaths({ newBase: path.join(basePath, file.base) });
     });
     this.symlinks.forEach((symlink) => {
@@ -148,14 +137,12 @@ export class DataToPersist {
    * helps for debugging
    */
   toConsole() {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     console.log(`\nfiles: ${this.files.map((f) => f.path).join('\n')}`); // eslint-disable-line no-console
     console.log(`\nsymlinks: ${this.symlinks.map((s) => `src: ${s.src}, dest: ${s.dest}`).join('\n')}`); // eslint-disable-line no-console
     console.log(`remove: ${this.remove.map((r) => r.path).join('\n')}`); // eslint-disable-line no-console
   }
   filterByPath(filterFunc: Function): DataToPersist {
     const dataToPersist = new DataToPersist();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     dataToPersist.addManyFiles(this.files.filter((f) => filterFunc(f.path)));
     dataToPersist.removeManyPaths(this.remove.filter((r) => filterFunc(r.path)));
     dataToPersist.addManySymlinks(this.symlinks.filter((s) => filterFunc(s.dest)));
@@ -186,7 +173,6 @@ export class DataToPersist {
       }
     };
     this.files.forEach((file) => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       validateAbsolutePath(file.path);
     });
     this.remove.forEach((removePath) => {
@@ -205,7 +191,6 @@ export class DataToPersist {
       }
     };
     this.files.forEach((file) => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       validateRelativePath(file.path);
     });
     this.remove.forEach((removePath) => {
@@ -222,7 +207,6 @@ export class DataToPersist {
       logger.debug(`DataToPersist, paths-to-delete:\n${pathToDeleteStr}`);
     }
     if (this.files.length) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const filesToWriteStr = this.files.map((f) => f.path).join('\n');
       logger.debug(`DataToPersist, paths-to-write:\n${filesToWriteStr}`);
     }
@@ -250,15 +234,9 @@ export class DataToPersist {
    */
   _throwForDirectoryCollision(file: AbstractVinyl) {
     const directoryCollision = this.files.find(
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       (f) => f.path.startsWith(`${file.path}${path.sep}`) || `${file.path}`.startsWith(`${f.path}${path.sep}`)
     );
     if (directoryCollision) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       throw new Error(`unable to add the file "${file.path}", because another file "${directoryCollision.path}" is going to be written.
 one of them is a directory of the other one, and is not possible to have them both`);
     }

--- a/scopes/component/sources/dist.ts
+++ b/scopes/component/sources/dist.ts
@@ -3,7 +3,7 @@ import AbstractVinyl from './abstract-vinyl';
 export default class Dist extends AbstractVinyl {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   clone(opts?: { contents?: boolean; deep?: boolean } | boolean): this {
-    // @ts-ignore
+    // @ts-expect-error
     return new Dist(this);
   }
 }

--- a/scopes/component/sources/json-file.ts
+++ b/scopes/component/sources/json-file.ts
@@ -11,22 +11,15 @@ export class JSONFile extends AbstractVinyl {
     const stat = await this._getStatIfFileExists();
     if (stat) {
       if (stat.isSymbolicLink()) {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         throw new ValidationError(`fatal: trying to write a json file into a symlink file at "${this.path}"`);
       }
       if (!this.override) {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         logger.debug(`json-file.write, ignore existing file ${this.path}`);
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         return this.path;
       }
     }
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     logger.debug(`json-file.write, path ${this.path}`);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     await fs.outputFile(this.path, this.contents);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.path;
   }
 
@@ -42,7 +35,6 @@ export class JSONFile extends AbstractVinyl {
     override?: boolean;
   }): JSONFile {
     const jsonStr = JSON.stringify(content, null, 4);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const jsonFile = new JSONFile({ base, path, contents: Buffer.from(jsonStr) });
     jsonFile.override = override;
     return jsonFile;

--- a/scopes/component/sources/license.ts
+++ b/scopes/component/sources/license.ts
@@ -5,24 +5,19 @@ import AbstractVinyl from './abstract-vinyl';
 
 export default class License extends AbstractVinyl {
   override = true;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   src: string;
 
   write(): Promise<any> {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!this.override && fs.existsSync(this.path)) return Promise.resolve();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return fs.outputFile(this.path, this.contents);
   }
 
   serialize() {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.contents.toString();
   }
 
   static deserialize(str: string) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new License({ path: LICENSE_FILENAME, contents: str ? Buffer.from(str) : undefined });
   }
 }

--- a/scopes/component/sources/package-json-file.ts
+++ b/scopes/component/sources/package-json-file.ts
@@ -1,5 +1,4 @@
 import detectIndent from 'detect-indent';
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import detectNewline from 'detect-newline';
 import fs from 'fs-extra';
 import * as path from 'path';
@@ -163,7 +162,7 @@ export class PackageJsonFile {
       },
       license: `SEE LICENSE IN ${!isEmpty(component.license) ? 'LICENSE' : 'UNLICENSED'}`,
     };
-    // @ts-ignore
+    // @ts-expect-error
     if (addExportProperty) packageJsonObject.exported = component.id.hasScope();
     if (!packageJsonObject.homepage) delete packageJsonObject.homepage;
     return new PackageJsonFile({ filePath, packageJsonObject, fileExist: false });
@@ -180,12 +179,10 @@ export class PackageJsonFile {
   }
 
   addDependencies(dependencies: Record<string, any>) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.packageJsonObject.dependencies = Object.assign({}, this.packageJsonObject.dependencies, dependencies);
   }
 
   addDevDependencies(dependencies: Record<string, any>) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.packageJsonObject.devDependencies = Object.assign({}, this.packageJsonObject.devDependencies, dependencies);
   }
 
@@ -252,7 +249,7 @@ export class PackageJsonFile {
   }
 
   clone(): PackageJsonFile {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const clone = new PackageJsonFile(this);
     clone.packageJsonObject = cloneDeep(this.packageJsonObject);
     return clone;

--- a/scopes/component/sources/remove-path.ts
+++ b/scopes/component/sources/remove-path.ts
@@ -4,7 +4,7 @@ import { removeFilesAndEmptyDirsRecursively } from './remove-files-and-empty-dir
 export class RemovePath {
   path: string;
   removeItsDirIfEmpty: boolean;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   constructor(path: string, removeItsDirIfEmpty? = false) {
     this.path = path;
     this.removeItsDirIfEmpty = removeItsDirIfEmpty;

--- a/scopes/component/sources/source-file.ts
+++ b/scopes/component/sources/source-file.ts
@@ -14,7 +14,6 @@ export default class SourceFile extends AbstractVinyl {
     extendedProps: Record<string, any> = {}
   ): SourceFile {
     try {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const file = new SourceFile(vinylFile.readSync(filePath, { base, cwd: consumerPath }));
       const addToFile = (value, key) => (file[key] = value); /* eslint-disable-line no-return-assign */
       forEach(extendedProps, addToFile);
@@ -41,18 +40,18 @@ export default class SourceFile extends AbstractVinyl {
 
   static loadFromParsedStringArray(arr: Record<string, any>[]): SourceFile[] | null | undefined {
     if (!arr) return null;
-    // @ts-ignore
+    // @ts-expect-error
     return arr.map(this.loadFromParsedString);
   }
 
   static async loadFromSourceFileModel(file: SourceFileModel, repository: Repository): Promise<SourceFile> {
     const content = await file.file.load(repository);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new SourceFile({ base: '.', path: file.relativePath, contents: content.contents, test: file.test });
   }
 
   clone(): this {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new SourceFile(this);
   }
 }

--- a/scopes/component/sources/vinyl-types.ts
+++ b/scopes/component/sources/vinyl-types.ts
@@ -331,7 +331,7 @@ interface File {
 }
 
 // See https://github.com/Microsoft/TypeScript/issues/11796
-// @ts-ignore
+// @ts-expect-error
 interface BufferFile extends File {
   contents: Buffer;
   isStream(): this is never;
@@ -340,7 +340,7 @@ interface BufferFile extends File {
   isDirectory(): this is never;
   isSymbolic(): this is never;
 }
-// @ts-ignore
+// @ts-expect-error
 interface StreamFile extends File {
   contents: NodeJS.ReadableStream;
   isStream(): true;
@@ -349,7 +349,7 @@ interface StreamFile extends File {
   isDirectory(): this is never;
   isSymbolic(): this is never;
 }
-// @ts-ignore
+// @ts-expect-error
 interface NullFile extends File {
   contents: null;
   isStream(): this is never;
@@ -358,12 +358,12 @@ interface NullFile extends File {
   isDirectory(): this is DirectoryFile;
   isSymbolic(): this is SymbolicFile;
 }
-// @ts-ignore
+// @ts-expect-error
 interface DirectoryFile extends NullFile {
   isDirectory(): true;
   isSymbolic(): this is never;
 }
-// @ts-ignore
+// @ts-expect-error
 interface SymbolicFile extends NullFile {
   isDirectory(): this is never;
   isSymbolic(): true;

--- a/scopes/component/status/status-formatter.ts
+++ b/scopes/component/status/status-formatter.ts
@@ -340,7 +340,7 @@ function getInvalidComponentLabel(error: Error) {
     case 'ComponentNotFoundInPath':
       return 'component files were deleted (use "bit remove [component_id]") or moved (use "bit move <old-dir> <new-dir>"). to restore use "bit checkout reset [component_id]"';
     case 'ExtensionFileNotFound':
-      // @ts-ignore error.path is set for ExtensionFileNotFound
+      // @ts-expect-error error.path is set for ExtensionFileNotFound
       return `extension file is missing at ${chalk.bold(error.path)}`;
     case 'ComponentsPendingImport':
       return 'component objects are missing from the scope (use "bit import [component_id] --objects" to get them back)';

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -118,7 +118,7 @@ export class StatusMain {
     const importPendingComponents = allInvalidComponents
       .filter((c) => c.err instanceof ComponentsPendingImport)
       .map((i) => i.id);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const invalidComponents = allInvalidComponents.filter((c) => !(c.error instanceof ComponentsPendingImport));
     const divergeInvalid = await this.divergeDataErrorsToInvalidComp(allComps);
     invalidComponents.push(...divergeInvalid);

--- a/scopes/component/tracker/add-cmd.ts
+++ b/scopes/component/tracker/add-cmd.ts
@@ -103,10 +103,10 @@ export class AddCmd implements Command {
     const normalizedPaths: PathOsBased[] = paths.map((p) => path.normalize(p));
     const { addedComponents, warnings }: AddActionResults = await this.tracker.addForCLI({
       componentPaths: normalizedPaths,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       id,
       main: main ? path.normalize(main) : undefined,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       namespace,
       defaultScope: scope,
       override,

--- a/scopes/component/tracker/add-components.ts
+++ b/scopes/component/tracker/add-components.ts
@@ -36,8 +36,7 @@ export type Warnings = {
 };
 export type AddActionResults = { addedComponents: AddResult[]; warnings: Warnings };
 export type PathOrDSL = PathOsBased | string; // can be a path or a DSL, e.g: tests/{PARENT}/{FILE_NAME}
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+// @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 type PathsStats = { [PathOsBased]: { isDir: boolean } };
 export type AddedComponent = {
   componentId: ComponentID;
@@ -83,7 +82,6 @@ export default class AddComponents {
   override: boolean; // (default = false) replace the files array or only add files.
   trackDirFeature: boolean | null | undefined;
   warnings: Warnings;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   ignoreList: string[];
   gitIgnore: any;
   addedComponents: AddResult[];
@@ -245,12 +243,12 @@ export default class AddComponents {
       const idOfFileIsDifferent = existingIdOfFile && !existingIdOfFile.isEqual(parsedBitId);
       if (idOfFileIsDifferent) {
         // not imported component file but exists in bitmap
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         if (this.warnings.alreadyUsed[existingIdOfFile]) {
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           this.warnings.alreadyUsed[existingIdOfFile].push(file.relativePath);
         } else {
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           this.warnings.alreadyUsed[existingIdOfFile] = [file.relativePath];
         }
         return null;
@@ -267,16 +265,15 @@ export default class AddComponents {
       }
       return file;
     });
-    // @ts-ignore it can't be null due to the filter function
+    // @ts-expect-error it can't be null due to the filter function
     const componentFiles: ComponentMapFile[] = (await Promise.all(componentFilesP)).filter((file) => file);
     if (!componentFiles.length) return { id: component.componentId, files: [] };
     if (foundComponentFromBitMap) {
       this._updateFilesAccordingToExistingRootDir(foundComponentFromBitMap, componentFiles, component);
     }
     if (this.trackDirFeature) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       if (this.bitMap._areFilesArraysEqual(foundComponentFromBitMap.files, componentFiles)) {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         return foundComponentFromBitMap;
       }
     }
@@ -319,7 +316,7 @@ export default class AddComponents {
         defaultScope,
         config: this.config,
         mainFile,
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         override: this.override,
       });
       componentMap.changeRootDirAndUpdateFilesAccordingly(rootDir);
@@ -598,14 +595,14 @@ you can add the directory these files are located at and it'll change the root d
             if (addedComponent && addedComponent.files.length) this.addedComponents.push(addedComponent);
           } catch (err: any) {
             if (!(err instanceof MissingMainFile)) throw err;
-            // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+            // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             missingMainFiles.push(err);
           }
         }
       })
     );
     if (missingMainFiles.length) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       throw new MissingMainFileMultipleComponents(missingMainFiles.map((err) => err.componentId).sort());
     }
   }

--- a/scopes/compositions/compositions/compositions.preview.runtime.ts
+++ b/scopes/compositions/compositions/compositions.preview.runtime.ts
@@ -43,7 +43,6 @@ export class CompositionsPreview {
 
     if (typeof defaultExports === 'function') {
       try {
-        // @ts-ignore Gilad - to fix.
         defaultExports(active, context);
       } catch (err) {
         // last-resort log – loaders already logged their own failures

--- a/scopes/defender/eslint/eslint.linter.ts
+++ b/scopes/defender/eslint/eslint.linter.ts
@@ -162,7 +162,6 @@ export class ESLintLinter implements Linter {
     let totalWarningCount = 0;
     const componentsResults = results.map((result) => {
       totalErrorCount += result.errorCount ?? 0;
-      // @ts-ignore - missing from the @types/eslint lib
       totalFatalErrorCount += result.fatalErrorCount ?? 0;
       totalFixableErrorCount += result.fixableErrorCount ?? 0;
       totalFixableWarningCount += result.fixableWarningCount ?? 0;
@@ -170,7 +169,6 @@ export class ESLintLinter implements Linter {
       return {
         filePath: result.filePath,
         errorCount: result.errorCount,
-        // @ts-ignore - missing from the @types/eslint lib
         fatalErrorCount: result.fatalErrorCount,
         fixableErrorCount: result.fixableErrorCount,
         fixableWarningCount: result.fixableWarningCount,
@@ -211,7 +209,6 @@ export class ESLintLinter implements Linter {
         totalComponentsWithErrorCount += 1;
         isClean = false;
       }
-      // @ts-ignore - missing from the @types/eslint lib
       if (result.totalFatalErrorCount) {
         totalFatalErrorCount += result.totalFatalErrorCount;
         totalComponentsWithFatalErrorCount += 1;

--- a/scopes/defender/eslint/eslint.main.runtime.ts
+++ b/scopes/defender/eslint/eslint.main.runtime.ts
@@ -66,7 +66,7 @@ export class ESLintMain {
     const transformerContext: EslintConfigTransformContext = { fix: !!context.fix };
     const afterMutation = runTransformersWithContext(configMutator.clone(), transformers, transformerContext);
 
-    // @ts-ignore
+    // @ts-expect-error
     return new ESLintLinter(this.logger, afterMutation.raw, ESLintModule);
   }
 
@@ -87,7 +87,7 @@ ESLintAspect.addRuntime(ESLintMain);
  */
 function getOptions(options: ESLintOptions, context: LinterContext): ESLintOptions {
   const mergedConfig: ESLintLib.Options = {
-    // @ts-ignore - this is a bug in the @types/eslint types
+    // @ts-expect-error - this is a bug in the @types/eslint types
     overrideConfig: options.config,
     extensions: context.extensionFormats,
     useEslintrc: false,

--- a/scopes/defender/linter/lint.task.ts
+++ b/scopes/defender/linter/lint.task.ts
@@ -19,7 +19,7 @@ export class LintTask implements BuildTask {
     const rootDir = context.capsuleNetwork.capsulesRootDir;
     const componentsDirMap = this.getComponentsDirectory(rootDir, context.capsuleNetwork.originalSeedersCapsules);
 
-    // @ts-ignore TODO: fix this
+    // @ts-expect-error TODO: fix this
     const linterContext: LinterContext = {
       rootDir,
       componentsDirMap,

--- a/scopes/defender/mocha/mocha.tester.ts
+++ b/scopes/defender/mocha/mocha.tester.ts
@@ -112,7 +112,7 @@ export class MochaTester implements Tester {
   }
 
   version(): string {
-    // @ts-ignore
+    // @ts-expect-error
     return Mocha.prototype.version || 'N/A';
   }
 }

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -240,7 +240,7 @@ function silenceConsoleAndStdout(): () => void {
   // Return a function to restore original behavior
   return () => {
     for (const method of Object.keys(originalConsole) as (keyof Console)[]) {
-      // @ts-ignore
+      // @ts-expect-error
       // eslint-disable-next-line no-console
       console[method] = originalConsole[method];
     }

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -48,7 +48,7 @@ export class TesterTask implements BuildTask {
       if (!compiler) {
         throw new Error(`compiler not found for ${component.id.toString()}`);
       }
-      // @ts-ignore. not sure why ts complain that compiler might be undefined, when we check it above.
+      // @ts-expect-error. not sure why ts complain that compiler might be undefined, when we check it above.
       const distFolder = compiler.getDistDir() || compiler.distDir;
       return {
         componentDir: join(capsule.path, distFolder),
@@ -62,7 +62,7 @@ export class TesterTask implements BuildTask {
 
     const specFilesWithCapsule = ComponentMap.as(components, (component) => {
       const patternEntry = patternsWithCapsule.get(component);
-      // @ts-ignore
+      // @ts-expect-error
       const [, val] = patternEntry;
       return val.paths;
     });
@@ -75,7 +75,7 @@ export class TesterTask implements BuildTask {
     });
 
     // TODO: remove after fix AbstractVinyl on capsule
-    // @ts-ignore
+    // @ts-expect-error
     const testsResults = await tester.test(testerContext);
 
     // write junit files
@@ -91,7 +91,7 @@ export class TesterTask implements BuildTask {
     );
 
     return {
-      artifacts: getArtifactDef(), // @ts-ignore
+      artifacts: getArtifactDef(),
       componentsResults: testsResults.components.map((componentTests) => {
         const componentErrors = componentTests.errors;
         const component = context.capsuleNetwork.graphCapsules.getCapsule(componentTests.componentId)?.component;

--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -67,7 +67,7 @@ export class ApplyOverrides {
     private workspace?: Workspace
   ) {
     this.componentId = component.componentId;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.componentFromModel = this.component.componentFromModel;
     this.allDependencies = {
       dependencies: [],
@@ -420,7 +420,6 @@ export class ApplyOverrides {
       getNotRegularPackages(this.allPackagesDependencies.devPackageDependencies)
     );
     // remove dev dependencies that are also regular dependencies
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const componentDepsIds = new ComponentIdList(...this.allDependencies.dependencies.map((c) => c.id));
     this.allDependencies.devDependencies = this.allDependencies.devDependencies.filter(
       (d) => !componentDepsIds.has(d.id)

--- a/scopes/dependencies/dependencies/dependencies-loader/auto-detect-deps.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/auto-detect-deps.ts
@@ -77,7 +77,7 @@ export class AutoDetectDeps {
     this.componentId = component.componentId;
     // the consumerComponent is coming from the workspace, so it must have the componentMap prop
     this.componentMap = this.component.componentMap as ComponentMap;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.componentFromModel = this.component.componentFromModel;
     this.consumerPath = this.consumer.getPath();
     this.allDependencies = {

--- a/scopes/dependencies/dependencies/dependencies-loader/overrides-dependencies.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/overrides-dependencies.ts
@@ -11,7 +11,6 @@ export default class OverridesDependencies {
   missingPackageDependencies: string[];
   constructor(component: Component) {
     this.component = component;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.componentFromModel = this.component.componentFromModel;
     this.manuallyRemovedDependencies = {};
     this.manuallyAddedDependencies = {};

--- a/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/Config.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/Config.ts
@@ -6,60 +6,58 @@ const path = require('path');
 const debug = require('debug')('tree');
 
 export default function Config(options) {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.filename = options.filename;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.directory = options.directory || options.root;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.visited = options.visited || {};
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.errors = options.errors || {};
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.nonExistent = options.nonExistent || [];
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.isListForm = options.isListForm;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.requireConfig = options.config || options.requireConfig;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.webpackConfig = options.webpackConfig;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.detectiveConfig = options.detective || options.detectiveConfig || {};
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.pathMap = options.pathMap || [];
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.resolveConfig = options.resolveConfig;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.cacheProjectAst = options.cacheProjectAst;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.envDetectors = options.envDetectors;
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.filter = options.filter;
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   if (!this.filename) {
     throw new Error('filename not given');
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   if (!this.directory) {
     throw new Error('directory not given');
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   if (this.filter && typeof this.filter !== 'function') {
     throw new Error('filter must be a function');
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   debug(`given filename: ${this.filename}`);
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   this.filename = path.resolve(process.cwd(), this.filename);
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   debug(`resolved filename: ${this.filename}`);
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   debug('visited: ', this.visited);
 }
 

--- a/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/index.spec.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/index.spec.ts
@@ -18,7 +18,7 @@ const fixtures = path.resolve(`${__dirname}/../fixtures/dependency-tree`);
 function mockfs(obj: any) {
   Object.entries(obj).forEach(([key, value]) => {
     fs.mkdirSync(key, { recursive: true });
-    // @ts-ignore
+    // @ts-expect-error
     Object.entries(value).forEach(([file, content]) => {
       const filePath = path.join(key, file);
       fs.writeFileSync(filePath, content as string);
@@ -31,7 +31,6 @@ function cleanUnitDir() {
 }
 
 describe('dependencyTree', function () {
-  // @ts-ignore
   this.timeout(8000);
   function testTreesForFormat(format, ext = '.js') {
     it('returns an object form of the dependency tree for a file', () => {
@@ -357,14 +356,14 @@ describe('dependencyTree', function () {
 
   describe('throws', () => {
     beforeEach(() => {
-      // @ts-ignore
+      // @ts-expect-error
       this._directory = `${UNIT_TEST_DIR}/commonjs`;
-      // @ts-ignore
+      // @ts-expect-error
       this._revert = dependencyTreeRewired.__set__('traverse', () => []);
     });
 
     afterEach(() => {
-      // @ts-ignore
+      // @ts-expect-error
       this._revert();
     });
 
@@ -372,7 +371,7 @@ describe('dependencyTree', function () {
       assert.throws(() => {
         dependencyTree({
           filename: undefined,
-          // @ts-ignore
+          // @ts-expect-error
           directory: this._directory,
         });
       });
@@ -412,7 +411,7 @@ describe('dependencyTree', function () {
 
   describe('on file error', () => {
     beforeEach(() => {
-      // @ts-ignore
+      // @ts-expect-error
       this._directory = `${UNIT_TEST_DIR}/commonjs`;
     });
 
@@ -420,14 +419,14 @@ describe('dependencyTree', function () {
       assert.doesNotThrow(() => {
         dependencyTree({
           filename: 'foo',
-          // @ts-ignore
+          // @ts-expect-error
           directory: this._directory,
         });
       });
     });
 
     it('returns no dependencies', () => {
-      // @ts-ignore
+      // @ts-expect-error
       const tree = dependencyTree({ filename: 'foo', directory: this._directory });
       assert(!tree.length);
     });
@@ -435,7 +434,7 @@ describe('dependencyTree', function () {
 
   describe('memoization (#2)', () => {
     beforeEach(() => {
-      // @ts-ignore
+      // @ts-expect-error
       this._spy = sinon.spy(dependencyTreeRewired, '_getDependencies');
     });
 
@@ -465,7 +464,7 @@ describe('dependencyTree', function () {
   describe('module formats', () => {
     describe('commonjs', () => {
       beforeEach(() => {
-        // @ts-ignore
+        // @ts-expect-error
         this._directory = path.normalize(`${UNIT_TEST_DIR}/es6`);
         mockcommonjs();
       });
@@ -475,7 +474,7 @@ describe('dependencyTree', function () {
 
     describe('es6', () => {
       beforeEach(() => {
-        // @ts-ignore
+        // @ts-expect-error
         this._directory = path.normalize(`${UNIT_TEST_DIR}/es6`);
         mockes6();
       });
@@ -483,38 +482,38 @@ describe('dependencyTree', function () {
       testTreesForFormat('es6');
 
       it('resolves files that have jsx', () => {
-        // @ts-ignore
+        // @ts-expect-error
         const filename = path.normalize(`${this._directory}/jsx.js`);
         const tree = dependencyTree({
           filename,
-          // @ts-ignore
+          // @ts-expect-error
           directory: this._directory,
         });
-        // @ts-ignore
+        // @ts-expect-error
         assert.ok(tree[filename].includes(path.normalize(`${this._directory}/c.js`)));
       });
 
       it('resolves files with a jsx extension', () => {
-        // @ts-ignore
+        // @ts-expect-error
         const filename = path.normalize(`${this._directory}/foo.jsx`);
         const tree = dependencyTree({
           filename,
-          // @ts-ignore
+          // @ts-expect-error
           directory: this._directory,
         });
-        // @ts-ignore
+        // @ts-expect-error
         assert.ok(tree[filename].includes(path.normalize(`${this._directory}/b.js`)));
       });
 
       it('resolves files that have es7', () => {
-        // @ts-ignore
+        // @ts-expect-error
         const filename = path.normalize(`${this._directory}/es7.js`);
         const tree = dependencyTree({
           filename,
-          // @ts-ignore
+          // @ts-expect-error
           directory: this._directory,
         });
-        // @ts-ignore
+        // @ts-expect-error
         assert.ok(tree[filename].includes(path.normalize(`${this._directory}/c.js`)));
       });
     });
@@ -560,17 +559,17 @@ describe('dependencyTree', function () {
     beforeEach(() => {
       // Note: not mocking because webpack's resolver needs a real project with dependencies;
       // otherwise, we'd have to mock a ton of files.
-      // @ts-ignore
+      // @ts-expect-error
       this._root = path.join(UNIT_TEST_DIR, '../');
-      // @ts-ignore
+      // @ts-expect-error
       this._webpackConfig = `${this._root}/webpack.config.js`;
-      // @ts-ignore
+      // @ts-expect-error
       this._testResolution = (name) => {
         const results = dependencyTree.toList({
           filename: `${UNIT_TEST_DIR}/webpack/${name}.js`,
-          // @ts-ignore
+          // @ts-expect-error
           directory: this._root,
-          // @ts-ignore
+          // @ts-expect-error
           webpackConfig: this._webpackConfig,
           filter: (filename) => filename.indexOf('filing-cabinet') !== -1,
         });
@@ -579,9 +578,8 @@ describe('dependencyTree', function () {
     });
 
     it('resolves unaliased modules', () => {
-      // @ts-ignore
       this.timeout(5000);
-      // @ts-ignore
+      // @ts-expect-error
       this._testResolution('unaliased');
     });
   });
@@ -791,18 +789,18 @@ describe('dependencyTree', function () {
         visited: {},
       };
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       config.filename = fooFile;
       dependencyTree(config);
       expect(nonExistent[fooFile]).to.deep.equal(['non-exist-foo-pkg']);
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       config.filename = barFile;
       dependencyTree(config);
       expect(nonExistent[fooFile]).to.deep.equal(['non-exist-foo-pkg']);
       expect(nonExistent[barFile]).to.deep.equal(['non-exist-bar-pkg']);
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       config.filename = bazFile;
       dependencyTree(config);
       expect(nonExistent[fooFile]).to.deep.equal(['non-exist-foo-pkg']);
@@ -827,11 +825,11 @@ describe('dependencyTree', function () {
         directory,
       };
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       config.filename = baseFile;
       dependencyTree(config);
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       config.filename = indexFile;
       const dependencies = dependencyTree(config);
       expect(dependencies).to.be.ok;

--- a/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/index.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/index.ts
@@ -64,7 +64,7 @@ module.exports._getDependencies = function (config) {
   const precinctOptions = config.detectiveConfig;
   precinctOptions.includeCore = false;
   precinctOptions.envDetectors = config.envDetectors;
-  // @ts-ignore
+  // @ts-expect-error
   delete precinct.ast;
 
   try {
@@ -88,7 +88,7 @@ module.exports._getDependencies = function (config) {
   const pathMapFile = { file: config.filename };
 
   dependencies.forEach((dependency) => processDependency(dependency));
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   pathMapFile.dependencies = pathMapDependencies;
   config.pathMap.push(pathMapFile);
   return resolvedDependencies;
@@ -102,7 +102,7 @@ module.exports._getDependencies = function (config) {
       dependency,
       filename: config.filename,
       directory: config.directory,
-      // @ts-ignore
+      // @ts-expect-error
       ast: precinct.ast,
       config: config.requireConfig,
       webpackConfig: config.webpackConfig,
@@ -111,7 +111,7 @@ module.exports._getDependencies = function (config) {
     };
     if (!isDependenciesArray && dependenciesRaw[dependency].isScript !== undefined) {
       // used for vue
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       cabinetParams.isScript = dependenciesRaw[dependency].isScript;
     }
     let result;
@@ -139,14 +139,14 @@ module.exports._getDependencies = function (config) {
     }
     const pathMap = { importSource: dependency, resolvedDep: result };
     if (!isDependenciesArray && dependenciesRaw[dependency].importSpecifiers) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       pathMap.importSpecifiers = dependenciesRaw[dependency].importSpecifiers;
     }
 
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     pathMapDependencies.push(pathMap);
 
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     resolvedDependencies.push(result);
   }
   function addToNonExistent(dependency) {
@@ -193,7 +193,7 @@ function traverse(config) {
       debug(`number of dependencies after filtering: ${dependencies.length}`);
     }
     debug('cabinet-resolved all dependencies: ', dependencies);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     tree[dependency] = dependencies;
     const filePathMap = config.pathMap.find((pathMapEntry) => pathMapEntry.file === dependency);
     if (!filePathMap) throw new Error(`file ${dependency} is missing from PathMap`);
@@ -221,7 +221,7 @@ function traverse(config) {
     }
     debug(`found ${dependency} in the cache`);
     const dependencies = config.visited[dependency].pathMap.dependencies.map((d) => d.resolvedDep);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     tree[dependency] = dependencies;
     config.pathMap.push(config.visited[dependency].pathMap);
     if (config.visited[dependency].missing) {

--- a/scopes/dependencies/dependencies/files-dependency-builder/filing-cabinet/index.spec.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/filing-cabinet/index.spec.ts
@@ -211,7 +211,7 @@ describe('filing-cabinet', () => {
         });
 
         assert.ok(
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           require.main.paths.some(function (p) {
             return p.indexOf(path.normalize(directory)) !== -1;
           })

--- a/scopes/dependencies/dependencies/files-dependency-builder/index.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/index.ts
@@ -1,5 +1,4 @@
 import { getDependencyTree } from './build-tree';
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import getDependenciesFromSource from './precinct';
 
 export { getDependencyTree, getDependenciesFromSource };

--- a/scopes/dependencies/dependencies/files-dependency-builder/precinct/index.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/precinct/index.ts
@@ -4,7 +4,6 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-// @ts-ignore we currently have @types/node as v12, and this is available > 16. once updated, remove the ts-ignore
 import { isBuiltin } from 'module';
 
 import getModuleType from 'module-definition';

--- a/scopes/dependencies/dependencies/resolve-pkg-data.ts
+++ b/scopes/dependencies/dependencies/resolve-pkg-data.ts
@@ -98,7 +98,6 @@ function enrichDataFromDependency(packageData: ResolvedPackageData) {
   if (packageInfo.componentId) {
     const scope = packageInfo.componentId.scope as string;
     if (packageInfo.exported === false) {
-      // @ts-ignore
       delete packageInfo.componentId.scope;
     }
     const componentId = ComponentID.fromObject(packageInfo.componentId, scope);

--- a/scopes/dependencies/dependency-resolver/apply-updates.spec.ts
+++ b/scopes/dependencies/dependency-resolver/apply-updates.spec.ts
@@ -24,7 +24,6 @@ describe('applyUpdates()', function () {
         variantPoliciesByPatterns: {},
       }
     );
-    // @ts-ignore
     expect(updatedWorkspacePolicyEntries).to.deep.equal(
       [
         {
@@ -42,7 +41,7 @@ describe('applyUpdates()', function () {
           lifecycleType: 'peer',
         },
       ],
-      // @ts-ignore
+      // @ts-expect-error
       { updateExisting: true }
     );
   });
@@ -119,7 +118,6 @@ describe('applyUpdates()', function () {
         variantPoliciesByPatterns,
       }
     );
-    // @ts-ignore
     expect(variantPoliciesByPatterns.variant1).to.deep.equal({
       dependencies: {
         'variant1-runtime-dep1': { version: '2.0.0', resolveFromEnv: true },
@@ -134,7 +132,6 @@ describe('applyUpdates()', function () {
         'variant1-peer-dep2': '1.0.0',
       },
     });
-    // @ts-ignore
     expect(variantPoliciesByPatterns.variant2).to.deep.equal({
       dependencies: {
         'variant2-runtime-dep1': '1.0.0',
@@ -149,7 +146,6 @@ describe('applyUpdates()', function () {
         'variant2-peer-dep2': '1.0.0',
       },
     });
-    // @ts-ignore
     expect(variantPoliciesByPatterns.variant3).to.deep.equal({
       dependencies: {
         'variant3-runtime-dep1': '1.0.0',
@@ -194,7 +190,6 @@ describe('applyUpdates()', function () {
         variantPoliciesByPatterns: {},
       }
     );
-    // @ts-ignore
     expect(updatedComponents).to.deep.equal([
       {
         componentId: ComponentID.fromString('scope/component1'),

--- a/scopes/dependencies/dependency-resolver/dependencies/component-dependency/component-dependency-factory.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/component-dependency/component-dependency-factory.ts
@@ -23,7 +23,7 @@ export class ComponentDependencyFactory implements DependencyFactory {
   }
 
   // TODO: solve this generics issue and remove the ts-ignore
-  // @ts-ignore
+  // @ts-expect-error
   parse<ComponentDependency, S extends SerializedComponentDependency>(serialized: S): ComponentDependency {
     let id;
 

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.graphql.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.graphql.ts
@@ -73,9 +73,9 @@ export function dependencyResolverSchema(dependencyResolver: DependencyResolverM
           return serialized
             .map((serialize) => {
               const type = DependencyTypes[serialize.__type];
-              // @ts-ignore
+              // @ts-expect-error
               serialize.type = serialize.__type;
-              // @ts-ignore
+              // @ts-expect-error
               delete serialize.__type;
               return {
                 __typename: type,

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -237,7 +237,7 @@ export class DependencyResolverMain {
 
   isolatedCapsules(): boolean {
     const globalConfig = this.configStore.getConfig(CFG_ISOLATED_SCOPE_CAPSULES);
-    // @ts-ignore
+    // @ts-expect-error
     const defaultVal = globalConfig !== undefined ? globalConfig === true || globalConfig === 'true' : true;
     const res = this.config.isolatedCapsules ?? defaultVal;
     return res;
@@ -1348,9 +1348,9 @@ export class DependencyResolverMain {
       manifest.dependencies = manifest.dependencies.map((dep) => this.aspectLoader.cloneManifest(dep));
       await updateDirectDepsVersions(manifest.dependencies);
     }
-    // @ts-ignore
+    // @ts-expect-error
     if (manifest?._runtimes) {
-      // @ts-ignore
+      // @ts-expect-error
       await mapSeries(manifest?._runtimes, async (runtime: RuntimeManifest) => {
         if (runtime.dependencies) {
           runtime.dependencies = runtime.dependencies.map((dep) => this.aspectLoader.cloneManifest(dep));
@@ -1718,7 +1718,7 @@ as an alternative, you can use "+" to keep the same version installed in the wor
     ]);
     componentAspect.dependencyResolver = dependencyResolver;
     // TODO: solve this generics issue and remove the ts-ignore
-    // @ts-ignore
+    // @ts-expect-error
     dependencyResolver.registerDependencyFactories([new ComponentDependencyFactory(componentAspect)]);
 
     LegacyComponent.registerOnComponentOverridesLoading(

--- a/scopes/dependencies/dependency-resolver/get-all-policy-pkgs.spec.ts
+++ b/scopes/dependencies/dependency-resolver/get-all-policy-pkgs.spec.ts
@@ -60,7 +60,6 @@ describe('getAllPolicyPkgs()', () => {
         },
       ],
     });
-    // @ts-ignore
     expect(outdatedPkgs).to.deep.equal([
       {
         currentRange: '1',

--- a/scopes/dependencies/dependency-resolver/manifest/deduping/merge-with-root.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/merge-with-root.ts
@@ -32,7 +32,6 @@ function mergeRootDepToDedupedDependencies(
     if (isDepExistInAnyOfTheRootDedupedDependencies(depId, dedupedDependencies)) return;
     const existingRootDeps = dedupedDependencies.rootDependencies;
     if (existingRootDeps[depKeyName]) {
-      // @ts-ignore - for some reason ts thinks it might be undefined
       existingRootDeps[depKeyName][depId] = range.toString();
     } else {
       existingRootDeps[depKeyName] = {

--- a/scopes/dependencies/dependency-resolver/policy/env-policy/env-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/env-policy/env-policy.ts
@@ -61,12 +61,12 @@ export class EnvPolicy extends VariantPolicy {
      * Always force it for the env itself
      */
     let selfPeersEntries: VariantPolicyEntry[];
-    // @ts-ignore TODO: need to fix this, the | confusing the compiler
+    // @ts-expect-error TODO: need to fix this, the | confusing the compiler
     if (includeLegacyPeersInSelfPolicy && !configObject.peers && configObject.peerDependencies) {
-      // @ts-ignore TODO: need to fix this, the | confusing the compiler
+      // @ts-expect-error TODO: need to fix this, the | confusing the compiler
       selfPeersEntries = handleLegacyPeers(configObject);
     } else {
-      // @ts-ignore TODO: need to fix this, the | confusing the compiler
+      // @ts-expect-error TODO: need to fix this, the | confusing the compiler
       selfPeersEntries = entriesFromKey(configObject, 'peers', 'version', 'runtime', {
         source: 'env-own',
         force: true,
@@ -80,12 +80,12 @@ export class EnvPolicy extends VariantPolicy {
      * Those were always forced on the components as visible dependencies.
      */
     const legacyPolicy = VariantPolicy.fromConfigObject(configObject, { source: 'env', force: true, hidden: false });
-    // @ts-ignore TODO: need to fix this, the | confusing the compiler
+    // @ts-expect-error TODO: need to fix this, the | confusing the compiler
     const componentPeersEntries = entriesFromKey(configObject, 'peers', 'supportedRange', 'peer', { source: 'env' });
     const otherKeyNames: EnvJsoncPolicyConfigKey[] = ['dev', 'runtime'];
     const otherEntries: VariantPolicyEntry[] = otherKeyNames.reduce(
       (acc: VariantPolicyEntry[], keyName: EnvJsoncPolicyConfigKey) => {
-        // @ts-ignore TODO: need to fix this, the | confusing the compiler
+        // @ts-expect-error TODO: need to fix this, the | confusing the compiler
         const currEntries = entriesFromKey(configObject, keyName, 'version', keyName as DependencyLifecycleType, {
           source: 'env',
         });

--- a/scopes/dependencies/yarn/yarn.package-manager.ts
+++ b/scopes/dependencies/yarn/yarn.package-manager.ts
@@ -78,7 +78,7 @@ export class YarnPackageManager implements PackageManager {
 
     const project = new Project(rootDirPath, { configuration: config });
 
-    // @ts-ignore
+    // @ts-expect-error
     project.setupResolutions();
     if (installOptions.rootComponentsForCapsules && !installOptions.useNesting) {
       installOptions.overrides = {
@@ -454,7 +454,7 @@ export class YarnPackageManager implements PackageManager {
     }
     const descriptor = structUtils.makeDescriptor(ident, range);
 
-    // @ts-ignore
+    // @ts-expect-error
     project.setupResolutions();
     const resolveOptions: ResolveOptions = {
       project,

--- a/scopes/envs/envs/env-service-list.ts
+++ b/scopes/envs/envs/env-service-list.ts
@@ -22,7 +22,7 @@ export class EnvServiceList {
           id,
           name: service.name,
           description: service.description,
-          // @ts-ignore
+          // @ts-expect-error
           data: service.getDescriptor(this.env),
         };
       }),

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -302,7 +302,7 @@ export class EnvsMain {
    */
   hasEnvManifest(envComponent?: Component, legacyFiles?: SourceFile[]): boolean | undefined {
     if (!envComponent && !legacyFiles) return undefined;
-    // @ts-ignore
+    // @ts-expect-error
     const files = legacyFiles || envComponent.filesystem.files;
     const envJson = files.find((file) => {
       return file.relative === 'env.jsonc' || file.relative === 'env.json';
@@ -339,7 +339,7 @@ export class EnvsMain {
   ): Promise<EnvJsonc | undefined> {
     // TODO: maybe throw an error here?
     if (!envComponent && !legacyFiles) return undefined;
-    // @ts-ignore
+    // @ts-expect-error
     const files = legacyFiles || envComponent.filesystem.files;
     const envJson = files.find((file) => {
       return file.relative === 'env.jsonc' || file.relative === 'env.json';
@@ -525,11 +525,11 @@ export class EnvsMain {
     // const resolvedEnvJsonc = await this.calculateEnvManifest(component);
     const result = componentDescriptor;
     if (envComponentSelfDescriptor) {
-      // @ts-ignore
+      // @ts-expect-error
       result.self = envComponentSelfDescriptor;
     }
     // if (resolvedEnvJsonc) {
-    //   // @ts-ignore
+    //   // @ts-expect-error
     //   result.resolvedEnvJsonc = resolvedEnvJsonc;
     // }
     return result;

--- a/scopes/envs/envs/runtime/runtime.ts
+++ b/scopes/envs/envs/runtime/runtime.ts
@@ -77,7 +77,7 @@ export class Runtime {
     const errors: Error[] = [];
     const contexts: EnvResult<T>[] = await mapSeries(runtimes || this.runtimeEnvs, async (env) => {
       try {
-        // @ts-ignore
+        // @ts-expect-error
         const serviceResult = await service.run(new ExecutionContext(this, env), options);
 
         return {

--- a/scopes/envs/envs/services/service-handler.ts
+++ b/scopes/envs/envs/services/service-handler.ts
@@ -29,7 +29,7 @@ export function reduceServiceHandlersFactories<T>(
 ): ServiceHandlerFactory<T> {
   if (!factories.length) throw new Error('no factories were provided');
   const result: ServiceHandlerFactory<T> = (context: ServiceHandlerContext) => {
-    // @ts-ignore
+    // @ts-expect-error
     const initialVal = factories.shift()(context);
     const reduced: ServiceHandler & T = factories.reduce((acc, currFactory) => {
       const curr = currFactory(context);

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -215,7 +215,7 @@ export class GeneratorMain {
     name: string,
     templates: Array<T>
   ): T | undefined {
-    // @ts-ignore (should set T to be extends ComponentTemplateWithId or WorkspaceTemplateWithId)
+    // @ts-expect-error (should set T to be extends ComponentTemplateWithId or WorkspaceTemplateWithId)
     const found = templates.find(({ id, template }) => {
       // When doing something like:
       // bit create react-env my-env --aspect teambit.react/react-env

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -657,5 +657,4 @@ export class CiMain {
   }
 }
 
-// @ts-ignore
 CiAspect.addRuntime(CiMain);

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -129,7 +129,6 @@ export class ApiServerMain {
     const app = this.express.createApp();
 
     app.use(
-      // @ts-ignore todo: it's not clear what's the issue.
       cors({
         origin(origin, callback) {
           callback(null, true);
@@ -153,7 +152,7 @@ export class ApiServerMain {
         on: {
           error: (err, req, res) => {
             this.logger.error('graphql cloud proxy error', err);
-            // @ts-ignore
+            // @ts-expect-error
             res.writeHead(500, {
               'Content-Type': 'text/plain',
             });
@@ -177,7 +176,7 @@ export class ApiServerMain {
           },
           error: (err, req, res) => {
             this.logger.error('rest cloud proxy error', err);
-            // @ts-ignore
+            // @ts-expect-error
             res.writeHead(500, {
               'Content-Type': 'text/plain',
             });

--- a/scopes/harmony/api-server/cli-raw.route.ts
+++ b/scopes/harmony/api-server/cli-raw.route.ts
@@ -44,12 +44,12 @@ export class CLIRawRoute implements Route {
 
       if (ttyPath) {
         const fileHandle = await fs.open(ttyPath, 'w');
-        // @ts-ignore monkey patch the process stdout write method
+        // @ts-expect-error monkey patch the process stdout write method
         process.stdout.write = (chunk, encoding, callback) => {
           fs.writeSync(fileHandle, chunk.toString());
           return originalStdoutWrite.call(process.stdout, chunk, encoding, callback);
         };
-        // @ts-ignore monkey patch the process stderr write method
+        // @ts-expect-error monkey patch the process stderr write method
         process.stderr.write = (chunk, encoding, callback) => {
           fs.writeSync(fileHandle, chunk.toString());
           return originalStderrWrite.call(process.stdout, chunk, encoding, callback);

--- a/scopes/harmony/application/build-application.task.ts
+++ b/scopes/harmony/application/build-application.task.ts
@@ -129,7 +129,7 @@ export class AppsBuildTask implements BuildTask {
          * TODO: we need to think how to pass private metadata between build pipes, maybe create shared context
          * or create new deploy context on builder
          */
-        // @ts-ignore
+        // @ts-expect-error
         _metadata: { deployContext, name: app.name, appType: app.applicationType },
       },
     };

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -486,7 +486,7 @@ export class AspectLoaderMain {
     const errorMsg = error.message.split('\n')[0]; // show only the first line if the error is long (e.g. happens with MODULE_NOT_FOUND errors)
     const msg = UNABLE_TO_LOAD_EXTENSION(idStr, errorMsg);
     if (throwOnError) {
-      // @ts-ignore
+      // @ts-expect-error
       this.logger.console(error);
       throw new CannotLoadExtension(idStr, error);
     }
@@ -739,7 +739,7 @@ export class AspectLoaderMain {
         return nodesUniq.map((n) => n.attr);
       };
       const relevantManifests = getOnlyDeclaredDependenciesManifests();
-      // @ts-ignore TODO: fix this
+      // @ts-expect-error TODO: fix this
       await this.harmony.load(relevantManifests);
     } catch (e: any) {
       const ids = extensionsManifests.map((manifest) => manifest.id || 'unknown');

--- a/scopes/harmony/aspect/aspect.env.ts
+++ b/scopes/harmony/aspect/aspect.env.ts
@@ -112,7 +112,7 @@ export class AspectEnv implements DependenciesEnv, PackageEnv, PreviewEnv {
         .setShouldCopyNonSupportedFiles(false);
       return tsConfigMutator;
     };
-    // @ts-ignore
+    // @ts-expect-error
     const externalTransformer: TsConfigTransformer[] = modifiers?.tsModifier?.transformers || [];
     const tsCompilerTask = this.reactEnv.getCjsCompilerTask([transformer, ...externalTransformer]);
     const babelCompiler = this.getBabelCompiler();

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -143,7 +143,7 @@ function attachVersionsFromBitmap(rawConfig: Record<string, any>, consumerInfo: 
   try {
     parsedBitMap = rawBitmap ? (json.parse(rawBitmap?.toString('utf8'), undefined, true) as Record<string, any>) : {};
     // @todo: remove this if statement once we don't need the migration of the bitmap file for lanes
-    // @ts-ignore
+    // @ts-expect-error
     if (parsedBitMap?._bit_lane?.name) {
       // backward compatibility. if "_bit_land" has the old format, then, later, when the bitmap is loaded again,
       // it'll take care of the migration.

--- a/scopes/harmony/bit/run-bit.ts
+++ b/scopes/harmony/bit/run-bit.ts
@@ -62,18 +62,18 @@ function consoleFileReadUsages() {
   };
   const originalReadFile = fs.readFile;
   const originalReadFileSync = fs.readFileSync;
-  // @ts-ignore
+  // @ts-expect-error
   fs.readFile = (...args) => {
     numR++;
     print(args[0]);
-    // @ts-ignore
+    // @ts-expect-error
     return originalReadFile(...args);
   };
 
   fs.readFileSync = (...args) => {
     numR++;
     print(args[0]);
-    // @ts-ignore
+    // @ts-expect-error
     return originalReadFileSync(...args);
   };
 }

--- a/scopes/harmony/bit/server-forever.ts
+++ b/scopes/harmony/bit/server-forever.ts
@@ -35,7 +35,7 @@ export function spawnPTY() {
   let didGetClient = false;
   let outputNotForClients = '';
 
-  // @ts-ignore
+  // @ts-expect-error
   ptyProcess.on('data', (data) => {
     if (!clients.length) outputNotForClients += data.toString();
     // Forward data from the ptyProcess to connected clients
@@ -112,7 +112,7 @@ This means another instance may already be running in this workspace.
     console.log(`Socket listening on port ${PORT}`);
   });
 
-  // @ts-ignore
+  // @ts-expect-error
   ptyProcess.on('exit', (code, signal) => {
     server.close();
     if (didGetClient) {

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -130,7 +130,7 @@ export class CLIParser {
       'dependents',
       'dependencies',
     ];
-    // @ts-ignore
+    // @ts-expect-error
     yargs.completion('completion', async function (current, argv, completionFilter, done) {
       if (!current.startsWith('-') && commandsToShowComponentIdsForCompletion.includes(argv._[1])) {
         const consumer = await loadConsumerIfExist();

--- a/scopes/harmony/cli/default-error-handler.ts
+++ b/scopes/harmony/cli/default-error-handler.ts
@@ -13,7 +13,7 @@ import { hashErrorIfNeeded } from '@teambit/legacy.cli.error';
  */
 export function sendToAnalyticsAndSentry(err: Error) {
   const possiblyHashedError = hashErrorIfNeeded(err);
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const shouldNotReportToSentry = Boolean(err.isUserError || err.code === 'EACCES');
   // only level FATAL are reported to Sentry.
   const level = shouldNotReportToSentry ? LEVEL.INFO : LEVEL.FATAL;
@@ -21,15 +21,14 @@ export function sendToAnalyticsAndSentry(err: Error) {
 }
 
 function handleNonBitCustomErrors(err: Error): string {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   if (err.code === 'EACCES' && err.path) {
     // see #1774
     return chalk.red(
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       `error: you do not have permissions to access '${err.path}', were you running bit, npm or git as root?`
     );
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return chalk.red(err.message || err);
 }
 

--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -403,7 +403,6 @@ export class WorkspaceConfig implements HostConfig {
       componentsDefaultDirectory,
       _manageWorkspaces: this.extension('teambit.dependencies/dependency-resolver', true)?.manageWorkspaces,
       extensions: this.extensions.toConfigObject(),
-      // @ts-ignore
       path: this.path,
       isLegacy: false,
       write: ({ workspaceDir }) => this.write.call(this, { dir: workspaceDir }),

--- a/scopes/harmony/doctor/core-diagnoses/broken-symlink-files.ts
+++ b/scopes/harmony/doctor/core-diagnoses/broken-symlink-files.ts
@@ -17,7 +17,6 @@ export default class BrokenSymlinkFiles extends Diagnosis {
 
   _formatSymptoms(bareResult: ExamineBareResult): string {
     if (!bareResult.data) throw new Error('BrokenSymlinkFiles, bareResult.data is missing');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const toString = bareResult.data.brokenSymlinks
       .map(
         (brokenSymlink) => `symlink path: "${brokenSymlink.symlinkPath}", broken link: "${brokenSymlink.brokenPath}"`

--- a/scopes/harmony/doctor/core-diagnoses/orphan-symlink-objects.ts
+++ b/scopes/harmony/doctor/core-diagnoses/orphan-symlink-objects.ts
@@ -12,13 +12,11 @@ export default class OrphanSymlinkObjects extends Diagnosis {
 
   _formatSymptoms(bareResult: ExamineBareResult): string {
     if (!bareResult.data) throw new Error('OrphanSymlinkObjects, bareResult.data is missing');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return `the following refs points to non-existing components "${bareResult.data.orphanSymlinks.toString()}"`;
   }
 
   _formatManualTreat(bareResult: ExamineBareResult) {
     if (!bareResult.data) throw new Error('OrphanSymlinkObjects, bareResult.data is missing');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return `please delete the following paths:\n${bareResult.data.objectsToDelete.join('\n')}`;
   }
 
@@ -29,13 +27,13 @@ export default class OrphanSymlinkObjects extends Diagnosis {
     const objectsToDelete = [];
     await Promise.all(
       symlinks.map(async (symlink) => {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const realComponentId: ComponentID = symlink.getRealComponentId();
         const realModelComponent = ModelComponent.fromBitId(realComponentId);
         const foundComponent = await consumer.scope.objects.load(realModelComponent.hash());
         if (!foundComponent) {
           orphanSymlinks.push(realComponentId);
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           objectsToDelete.push(consumer.scope.objects.objectPath(symlink.hash()));
         }
       })

--- a/scopes/harmony/doctor/core-diagnoses/validate-bit-version.ts
+++ b/scopes/harmony/doctor/core-diagnoses/validate-bit-version.ts
@@ -11,7 +11,6 @@ export default class ValidateBitVersion extends Diagnosis {
 
   _formatSymptoms(bareResult: ExamineBareResult): string {
     if (!bareResult.data) throw new Error('ValidateBitVersion, bareResult.data is missing');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!bareResult.data.latestVersion) {
       return 'could not fetch bit latest version';
     }
@@ -22,7 +21,6 @@ export default class ValidateBitVersion extends Diagnosis {
 
   _formatManualTreat(bareResult: ExamineBareResult) {
     if (!bareResult.data) throw new Error('ValidateBitVersion, bareResult.data is missing');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!bareResult.data.latestVersion) {
       return 'please make sure you have an internet connection';
     }

--- a/scopes/harmony/doctor/diagnosis-list-template.ts
+++ b/scopes/harmony/doctor/diagnosis-list-template.ts
@@ -22,7 +22,7 @@ function createRow(diagnosis: Diagnosis): DiagnosisRow {
 export default function formatDiagnosesList(diagnosesList: Diagnosis[]): string {
   const header = [chalk.bold('category'), chalk.bold('name'), chalk.bold('description')];
   const rows = diagnosesList.map(createRow);
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   rows.unshift(header);
   const output = table(rows, tableColumnConfig);
   return output;

--- a/scopes/harmony/doctor/diagnosis.ts
+++ b/scopes/harmony/doctor/diagnosis.ts
@@ -17,13 +17,9 @@ export type ExamineResult = {
 };
 
 export default class Diagnosis {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   name: string;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   description: string;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   category: string;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   result: Record<string, any>;
 
   /**

--- a/scopes/harmony/doctor/doctor-cmd.ts
+++ b/scopes/harmony/doctor/doctor-cmd.ts
@@ -79,7 +79,7 @@ export class DoctorCmd implements Command {
     }
     let filePath = save;
     // Happen when used --save without specify the location
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (save === true || archive === true) {
       filePath = '.';
     }

--- a/scopes/harmony/doctor/doctor-registrar.ts
+++ b/scopes/harmony/doctor/doctor-registrar.ts
@@ -11,7 +11,6 @@ const _checkName = (name) => (diagnosis: Diagnosis) => {
 };
 
 export default class DoctorRegistrar {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   diagnoses: Diagnosis[];
 
   constructor() {

--- a/scopes/harmony/doctor/doctor-results-template.ts
+++ b/scopes/harmony/doctor/doctor-results-template.ts
@@ -31,7 +31,7 @@ function _createSummeryRow(examineResult: ExamineResult): SummeryRow {
 function _createSummeryTable(examineResult: ExamineResult[]): string {
   const header = [chalk.bold('category'), chalk.bold('name'), chalk.bold('description'), chalk.bold('status')];
   const rows = examineResult.map(_createSummeryRow);
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   rows.unshift(header);
   const output = table(rows, summeryTableColumnConfig);
   return output;

--- a/scopes/harmony/doctor/doctor.main.runtime.ts
+++ b/scopes/harmony/doctor/doctor.main.runtime.ts
@@ -3,7 +3,6 @@ import { CLIAspect, MainRuntime } from '@teambit/cli';
 import path from 'path';
 import fs from 'fs-extra';
 import os from 'os';
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import type Stream from 'stream';
 import tar from 'tar-stream';
 import tarFS from 'tar-fs';
@@ -260,7 +259,7 @@ export class DoctorMain {
       userDetails: this._getUserDetails(),
     };
 
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return env;
   }
 

--- a/scopes/harmony/global-config/remote-cmd.ts
+++ b/scopes/harmony/global-config/remote-cmd.ts
@@ -64,7 +64,6 @@ export class RemoteCmd implements Command {
   alias = '';
   loadAspects = false;
   options = [['g', 'global', 'see globally configured remotes']] as CommandOptions;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   commands = [new RemoteAdd(), new RemoteRm(), new RemoteList()];
 
   async report(args: string[], { global }: { global: boolean }) {

--- a/scopes/harmony/global-config/remote.ts
+++ b/scopes/harmony/global-config/remote.ts
@@ -3,7 +3,6 @@ import { Remote, getScopeRemotes, GlobalRemotes } from '@teambit/scope.remotes';
 import { loadScope } from '@teambit/legacy.scope';
 
 function buildRemote(url: string): Remote {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return new Remote(url);
 }
 
@@ -21,7 +20,6 @@ export async function add(url: string, global: boolean) {
       });
     }
 
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return loadScope().then((scope) => {
       return scope.scopeJson
         .addRemote(remote)
@@ -44,7 +42,6 @@ export async function remove(name: string, global: boolean) {
     return name;
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const scope = await loadScope();
   const hasRemoved = scope.scopeJson.rmRemote(name);
   if (!hasRemoved) {
@@ -59,7 +56,6 @@ export async function list(global: boolean) {
     return GlobalRemotes.load().then((globalRemotes) => globalRemotes.toPlainObject());
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return loadScope().then((scope) => {
     return getScopeRemotes(scope).then((remotes) => remotes.toPlainObject());
   });

--- a/scopes/harmony/graphql/create-remote-schemas/create-remote-schemas.ts
+++ b/scopes/harmony/graphql/create-remote-schemas/create-remote-schemas.ts
@@ -19,7 +19,7 @@ async function getRemoteSchema({ uri, subscriptionsUri }) {
       return response;
     });
   });
-  // @ts-ignore
+  // @ts-expect-error
   const http = new HttpLink({ uri, fetch });
   const httpLink = setContext((request, previousContext) => {
     return {

--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -132,7 +132,6 @@ export class GraphqlMain {
     const app = options.app || express();
     if (!this.config.disableCors) {
       app.use(
-        // @ts-ignore todo: it's not clear what's the issue.
         cors({
           origin(origin, callback) {
             callback(null, true);
@@ -151,9 +150,9 @@ export class GraphqlMain {
           this.logger.error('graphql got an error during running the following query:', params);
           this.logger.error('graphql error ', err);
           return Object.assign(err, {
-            // @ts-ignore
+            // @ts-expect-error
             ERR_CODE: err?.originalError?.errors?.[0].ERR_CODE || err.originalError?.constructor?.name,
-            // @ts-ignore
+            // @ts-expect-error
             HTTP_CODE: err?.originalError?.errors?.[0].HTTP_CODE || err.originalError?.code,
           });
         },
@@ -309,7 +308,6 @@ export class GraphqlMain {
     const deps = this.context.getDependencies(extension);
     const ids = deps.map((dep) => dep.id);
 
-    // @ts-ignore check :TODO why types are breaking here.
     return Array.from(this.modules.entries())
       .map(([depId, module]) => {
         const dep = ids.includes(depId);

--- a/scopes/harmony/testing/load-aspect/load-aspect.ts
+++ b/scopes/harmony/testing/load-aspect/load-aspect.ts
@@ -156,9 +156,9 @@ function clearGlobalsIfNeeded() {
   ComponentOverrides.componentOverridesLoadingRegistry = {};
   ComponentConfig.componentConfigLoadingRegistry = {};
   PackageJsonTransformer.packageJsonTransformersRegistry = [];
-  // @ts-ignore
+  // @ts-expect-error
   ComponentLoader.loadDeps = undefined;
   ExtensionDataList.coreExtensionsNames = new Map();
-  // @ts-ignore
+  // @ts-expect-error
   LegacyWorkspaceConfig.workspaceConfigLoadingRegistry = undefined;
 }

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -564,7 +564,7 @@ export class LaneRemoveCmd implements Command {
   ): Promise<string> {
     if (!silent) {
       const removePromptResult = await approveOperation();
-      // @ts-ignore
+      // @ts-expect-error
       if (!yn(removePromptResult.shouldProceed)) {
         throw new BitError('the operation has been cancelled');
       }

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -195,7 +195,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     }
     const { mergeResults, deleteResults, configMergeResults } = await this.mergeLanes.mergeLaneByCLI(name, {
       build,
-      // @ts-ignore
+      // @ts-expect-error
       mergeStrategy,
       ours,
       theirs,

--- a/scopes/pipelines/builder/artifact/artifact-list.ts
+++ b/scopes/pipelines/builder/artifact/artifact-list.ts
@@ -121,7 +121,7 @@ export class ArtifactList<T extends Artifact> extends Array<T> {
       const defaultResolver = new DefaultResolver();
       await defaultResolver.store(component, artifact as FsArtifact);
     }
-    // @ts-ignore
+    // @ts-expect-error
     if (storageResolver.store && typeof storageResolver.store === 'function') {
       return this.storeWholeArtifactByResolver(storageResolver as WholeArtifactStorageResolver, artifact, component);
     }

--- a/scopes/pipelines/builder/builder.route.ts
+++ b/scopes/pipelines/builder/builder.route.ts
@@ -24,7 +24,7 @@ export class BuilderRoute implements Route {
 
   middlewares = [
     async (req: Request<BuilderUrlParams>, res: Response) => {
-      // @ts-ignore TODO: @guy please fix.
+      // @ts-expect-error TODO: @guy please fix.
       const component = req.component as Component;
       const { params } = req;
       const [aspectIdStr, filePath] = params[1].split('~');

--- a/scopes/pipelines/builder/pipeline.ts
+++ b/scopes/pipelines/builder/pipeline.ts
@@ -28,7 +28,7 @@ export class Pipeline {
     });
 
     const buildTasks: BuildTask[] = _tasks.map((task) => {
-      // @ts-ignore
+      // @ts-expect-error
       const aspectId = task.aspectId || envId;
       const buildTask: BuildTask = Object.assign(clone(task), { aspectId });
       return buildTask;

--- a/scopes/pkg/pkg/package.route.ts
+++ b/scopes/pkg/pkg/package.route.ts
@@ -17,7 +17,7 @@ export class PackageRoute implements Route {
 
   middlewares = [
     async (req: Request, res: Response) => {
-      // @ts-ignore TODO: @guy please fix.
+      // @ts-expect-error TODO: @guy please fix.
       const component: any = req.component as any;
       const file = await this.pkg.getPackageTarFile(component);
       // TODO: 404 again how to handle.

--- a/scopes/pkg/pkg/packer.ts
+++ b/scopes/pkg/pkg/packer.ts
@@ -14,7 +14,6 @@ import type { Logger } from '@teambit/logger';
 import pMap from 'p-map';
 import isRelative from 'is-relative-path';
 
-// @ts-ignore (for some reason the tsc -w not found this)
 import { ScopeNotFound } from './exceptions/scope-not-found';
 
 export type PackResult = Omit<ComponentResult, 'component'>;

--- a/scopes/preview/preview/artifact-file-middleware.ts
+++ b/scopes/preview/preview/artifact-file-middleware.ts
@@ -18,9 +18,9 @@ export type GetCacheControlFunc = (filePath: string, contents: string, mimeType?
 export function getArtifactFileMiddleware(logger: Logger, getCacheControlFunc?: GetCacheControlFunc): Middleware {
   return async (req: Request<PreviewUrlParams>, res: Response) => {
     try {
-      // @ts-ignore
+      // @ts-expect-error
       const artifact: PreviewArtifact = req.artifact;
-      // @ts-ignore
+      // @ts-expect-error
       const isLegacyPath = req.isLegacyPath;
       let file;
       if (!isLegacyPath) {

--- a/scopes/preview/preview/component-preview.route.ts
+++ b/scopes/preview/preview/component-preview.route.ts
@@ -24,7 +24,7 @@ export class ComponentPreviewRoute implements Route {
     async (req: Request<PreviewUrlParams>, res: Response, next: NextFunction) => {
       try {
         let isLegacyPath = false;
-        // @ts-ignore TODO: @guy please fix.
+        // @ts-expect-error TODO: @guy please fix.
         const component = req.component as Component | undefined;
         if (!component) return res.status(404).send(noPreview());
 
@@ -37,9 +37,9 @@ export class ComponentPreviewRoute implements Route {
           this.logger.error(`preview.getPreview has failed`, e);
           return res.status(404).send(noPreview());
         }
-        // @ts-ignore
+        // @ts-expect-error
         req.artifact = artifact;
-        // @ts-ignore
+        // @ts-expect-error
         req.isLegacyPath = isLegacyPath;
         return next();
       } catch (e: any) {

--- a/scopes/preview/preview/env-template.route.ts
+++ b/scopes/preview/preview/env-template.route.ts
@@ -39,11 +39,10 @@ export class EnvTemplateRoute implements RegisteredComponentRoute {
   // Then in the component route when we do host.get(id) it will fail, as we don't have the core envs in the scope/workspace
   resolveComponent = false;
 
-  // @ts-ignore
+  // @ts-expect-error
   middlewares = [
     async (req: Request<UrlParams>, res: Response, next: NextFunction) => {
       try {
-        // @ts-ignore TODO: @guy please fix.
         // const component = req.component as Component | undefined;
         // if (!component) return res.status(404).send(noPreview());
 
@@ -57,9 +56,9 @@ export class EnvTemplateRoute implements RegisteredComponentRoute {
           return res.status(404).send(noPreview());
         }
 
-        // @ts-ignore
+        // @ts-expect-error
         req.artifact = artifact;
-        // @ts-ignore
+        // @ts-expect-error
         req.isLegacyPath = false;
 
         return next();

--- a/scopes/preview/preview/preview-assets.route.ts
+++ b/scopes/preview/preview/preview-assets.route.ts
@@ -20,7 +20,7 @@ export class PreviewAssetsRoute implements Route {
   middlewares = [
     async (req: Request, res: Response) => {
       try {
-        // @ts-ignore TODO: @guy please fix.
+        // @ts-expect-error TODO: @guy please fix.
         const component = req.component as Component | undefined;
         // if (!component) return res.status(404).send(noPreview());
         if (!component) return res.status(404).jsonp({ error: 'not found' });

--- a/scopes/preview/preview/preview.main.runtime.ts
+++ b/scopes/preview/preview/preview.main.runtime.ts
@@ -860,7 +860,7 @@ export class PreviewMain {
       const defaultTemplatePath = await previewDef.renderTemplatePathByEnv?.(context.env);
       const visitedEnvs = new Set();
       const mainModulesMap: MainModulesMap = {
-        // @ts-ignore
+        // @ts-expect-error
         default: defaultTemplatePath,
         [context.envDefinition.id]: defaultTemplatePath,
       };
@@ -1138,7 +1138,7 @@ export class PreviewMain {
     componentExtension.registerRoute([
       new PreviewRoute(preview, logger),
       new ComponentPreviewRoute(preview, logger),
-      // @ts-ignore
+      // @ts-expect-error
       new EnvTemplateRoute(preview, logger),
       new PreviewAssetsRoute(preview, logger),
     ]);

--- a/scopes/preview/preview/preview.route.ts
+++ b/scopes/preview/preview/preview.route.ts
@@ -23,7 +23,7 @@ export class PreviewRoute implements Route {
   middlewares = [
     async (req: Request<PreviewUrlParams>, res: Response, next: NextFunction) => {
       try {
-        // @ts-ignore TODO: @guy please fix.
+        // @ts-expect-error TODO: @guy please fix.
         const component = req.component as Component | undefined;
         if (!component) return res.status(404).send(noPreview());
         const isLegacyPath = await this.preview.isBundledWithEnv(component);
@@ -43,9 +43,9 @@ export class PreviewRoute implements Route {
           this.logger.error(`getEnvTemplateFromComponentEnv or getPreview has failed`, e);
           return res.status(404).send(noPreview());
         }
-        // @ts-ignore
+        // @ts-expect-error
         req.artifact = artifact;
-        // @ts-ignore
+        // @ts-expect-error
         req.isLegacyPath = isLegacyPath;
         return next();
       } catch (e: any) {

--- a/scopes/preview/preview/webpack/webpack.config.ts
+++ b/scopes/preview/preview/webpack/webpack.config.ts
@@ -10,10 +10,8 @@ export function createWebpackConfig(outputDir: string, entryFile: string): Confi
   const baseConfig = configBaseFactory(true);
   const preBundleConfig = createPreBundleConfig(outputDir, entryFile);
 
-  // @ts-ignore that's an issue because of different types/webpack version
   const combined = merge(baseConfig, preBundleConfig);
 
-  // @ts-ignore that's an issue because of different types/webpack version
   return combined;
 }
 
@@ -74,7 +72,7 @@ function createPreBundleConfig(outputDir: string, entryFile: string) {
           }, seed);
           const entrypointFiles = entrypoints.main.filter((fileName) => !fileName.endsWith('.map'));
 
-          // @ts-ignore - https://github.com/shellscape/webpack-manifest-plugin/issues/276
+          // @ts-expect-error - https://github.com/shellscape/webpack-manifest-plugin/issues/276
           return {
             files: manifestFiles,
             entrypoints: entrypointFiles,

--- a/scopes/react/react/apps/web/react.application.ts
+++ b/scopes/react/react/apps/web/react.application.ts
@@ -126,7 +126,6 @@ export class ReactApp implements Application {
         },
       ],
 
-      // @ts-ignore
       capsuleNetwork: undefined,
       previousTasksResults: [],
     });
@@ -155,7 +154,6 @@ export class ReactApp implements Application {
         },
       ],
 
-      // @ts-ignore
       capsuleNetwork: undefined,
       previousTasksResults: [],
     });

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -275,7 +275,7 @@ export class ReactEnv
 
   private getEslintOptions(options: ESLintLib.Options, pluginPath: string, context: LinterContext): ESLintOptions {
     const mergedConfig: ESLintLib.Options = {
-      // @ts-ignore - this is a bug in the @types/eslint types
+      // @ts-expect-error - this is a bug in the @types/eslint types
       overrideConfig: options,
       extensions: context.extensionFormats,
       useEslintrc: false,

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -467,7 +467,6 @@ export class ReactMain {
     );
     const appType = new ReactAppType('react-app', reactEnv, logger, dependencyResolver);
     const react = new ReactMain(reactEnv, envs, application, appType, dependencyResolver, logger);
-    // @ts-ignore
     graphql.register(() => reactSchema(react));
     envs.registerEnv(reactEnv);
     if (generator) {

--- a/scopes/react/react/react.preview.runtime.ts
+++ b/scopes/react/react/react.preview.runtime.ts
@@ -46,7 +46,7 @@ export class ReactPreview {
   static async provider([preview]: [PreviewPreview], config, [providerSlot]: [ProviderSlot]) {
     const reactPreview = new ReactPreview(preview, providerSlot);
 
-    // @ts-ignore
+    // @ts-expect-error
     reactPreview.registerProvider([HighlighterProvider]);
 
     preview.registerRenderContext(reactPreview.getRenderingContext);

--- a/scopes/react/react/webpack/webpack.config.base.prod.ts
+++ b/scopes/react/react/webpack/webpack.config.base.prod.ts
@@ -110,7 +110,7 @@ export default function (dev?: boolean): Configuration {
       //       return manifest;
       //     }, seed);
       //     const entrypointFiles = entrypoints.main.filter((fileName) => !fileName.endsWith('.map'));
-      //     // @ts-ignore - https://github.com/shellscape/webpack-manifest-plugin/issues/276
+      //     // @ts-expect-error - https://github.com/shellscape/webpack-manifest-plugin/issues/276
       //     return {
       //       files: manifestFiles,
       //       entrypoints: entrypointFiles,

--- a/scopes/react/react/webpack/webpack.config.base.ts
+++ b/scopes/react/react/webpack/webpack.config.base.ts
@@ -326,7 +326,6 @@ export default function (isEnvProduction = false): Configuration {
         },
       ],
     },
-    // @ts-ignore
     plugins: [
       isEnvProduction &&
         new MiniCssExtractPlugin({

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -670,7 +670,6 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     ids: ComponentIdList,
     shouldFork = false // not in used currently, but might be needed soon
   ): Promise<boolean> {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const shouldChangeScope = shouldFork
       ? remoteScope !== componentsObjects.component.scope
       : !componentsObjects.component.scope;

--- a/scopes/scope/importer/dependents-getter.ts
+++ b/scopes/scope/importer/dependents-getter.ts
@@ -1,5 +1,5 @@
 import yesno from 'yesno';
-// @ts-ignore AutoComplete is actually there, the d.ts is probably outdated
+// @ts-expect-error AutoComplete is actually there, the d.ts is probably outdated
 import { prompt, AutoComplete } from 'enquirer';
 import { compact, uniq } from 'lodash';
 import chalk from 'chalk';

--- a/scopes/scope/importer/fetch-cmd.ts
+++ b/scopes/scope/importer/fetch-cmd.ts
@@ -83,7 +83,7 @@ function formatPlainComponentItemWithVersions(bitId: ComponentID, importDetails:
   const getConflictMessage = () => {
     if (!importDetails.filesStatus) return '';
     const conflictedFiles = Object.keys(importDetails.filesStatus) // $FlowFixMe file is set
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       .filter((file) => importDetails.filesStatus[file] === FileStatus.manual);
     if (!conflictedFiles.length) return '';
     return `(the following files were saved with conflicts ${conflictedFiles

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -665,13 +665,8 @@ otherwise, if tagged/snapped, "bit reset" it, then bit rename it.`);
     const existingBitMapBitId = this.consumer.bitMap.getComponentId(component.id, { ignoreVersion: true });
     const fsComponent = await this.consumer.loadComponent(existingBitMapBitId);
     const currentlyUsedVersion = existingBitMapBitId.version;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const baseComponent: Version = await componentModel.loadVersion(currentlyUsedVersion, this.consumer.scope.objects);
-    const otherComponent: Version = await componentModel.loadVersion(
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      component.id.version,
-      this.consumer.scope.objects
-    );
+    const otherComponent: Version = await componentModel.loadVersion(component.id.version, this.consumer.scope.objects);
     const mergeResults = await threeWayMerge({
       scope: this.consumer.scope,
       otherComponent,
@@ -704,7 +699,6 @@ otherwise, if tagged/snapped, "bit reset" it, then bit rename it.`);
       const filesStatus = {};
       // don't write the files to the filesystem, only bump the bitmap version.
       files.forEach((file) => {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         filesStatus[pathNormalizeToLinux(file.relative)] = FileStatus.unchanged;
       });
       this.consumer.bitMap.updateComponentId(component.id);
@@ -715,7 +709,6 @@ otherwise, if tagged/snapped, "bit reset" it, then bit rename it.`);
       const filesStatus = {};
       // the local changes will be overridden (as if the user entered --override flag for this component)
       files.forEach((file) => {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         filesStatus[pathNormalizeToLinux(file.relative)] = FileStatus.updated;
       });
       return filesStatus;

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -338,7 +338,7 @@ function formatPlainComponentItemWithVersions(bitId: ComponentID, importDetails:
   const getConflictMessage = () => {
     if (!importDetails.filesStatus) return '';
     const conflictedFiles = Object.keys(importDetails.filesStatus)
-      // @ts-ignore file is set
+      // @ts-expect-error file is set
       .filter((file) => importDetails.filesStatus[file] === FileStatus.manual);
     if (!conflictedFiles.length) return '';
     return `(the following files were saved with conflicts ${conflictedFiles

--- a/scopes/scope/network/fs/fs.ts
+++ b/scopes/scope/network/fs/fs.ts
@@ -34,7 +34,6 @@ export default class Fs implements Network {
   }
 
   pushMany(objectList: ObjectList, pushOptions: PushOptions): Promise<string[]> {
-    // @ts-ignore for some reason, it finds two different ObjectList. try to remove it once all legacy are gone
     return put({ path: this.scopePath, objectList }, pushOptions);
   }
 

--- a/scopes/scope/network/http/http.ts
+++ b/scopes/scope/network/http/http.ts
@@ -281,7 +281,7 @@ export class Http implements Network {
           `Http.pushToCentralHub, completed. url: ${this.url}/${route}, status ${_response.status} statusText ${_response.statusText}`
         );
 
-        // @ts-ignore TODO: need to fix this
+        // @ts-expect-error TODO: need to fix this
         const _results = await this.readPutCentralStream(_response.body);
         return { results: _results, response: _response };
       },
@@ -332,7 +332,7 @@ export class Http implements Network {
       `Http.deleteViaCentralHub, completed. url: ${this.url}/${route}, status ${res.status} statusText ${res.statusText}`
     );
 
-    // @ts-ignore TODO: need to fix this
+    // @ts-expect-error TODO: need to fix this
     const results = await this.readPutCentralStream(res.body);
     if (!results.data) throw new Error(`HTTP results are missing "data" property`);
     if (results.data.isError) {
@@ -408,7 +408,6 @@ export class Http implements Network {
     // const res = await fetch(urlToFetch, opts);
     logger.debug(`Http.fetch got a response, ${scopeData}, status ${res.status}, statusText ${res.statusText}`);
     await this.throwForNonOkStatus(res);
-    // @ts-ignore TODO: need to fix this
     const objectListReadable = ObjectList.fromTarToObjectStream(res.body);
 
     return objectListReadable;

--- a/scopes/scope/network/network-lib.ts
+++ b/scopes/scope/network/network-lib.ts
@@ -9,7 +9,6 @@ export default function connect(host: string, name: string, localScopeName?: str
   }
 
   if (host.startsWith('file://')) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new Fs(host.replace('file://', '')).connect();
   }
 

--- a/scopes/scope/objects/models/export-metadata.ts
+++ b/scopes/scope/objects/models/export-metadata.ts
@@ -29,7 +29,6 @@ export default class ExportMetadata extends BitObject {
     };
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   toString(pretty: boolean): string {
     const args = getStringifyArgs(pretty);
     return JSON.stringify(this.toObject(), ...args);

--- a/scopes/scope/objects/models/model-component.ts
+++ b/scopes/scope/objects/models/model-component.ts
@@ -52,7 +52,6 @@ import { DetachedHeads } from './detach-heads';
 
 type State = {
   versions?: {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     [version: string]: {
       local?: boolean; // whether a component was changed locally
     };
@@ -101,7 +100,6 @@ export const VERSION_ZERO = '0.0.0';
  * with 'Component' in their headers. see object-registrar.types()
  */
 // TODO: FIX me .parser
-// @ts-ignore
 export default class Component extends BitObject {
   scope: string;
   name: string;
@@ -527,9 +525,9 @@ export default class Component extends BitObject {
     let version = null;
     let versionStr = null;
     while (!version && versions && versions.length) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       versionStr = versions.pop();
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       version = this.loadVersionSync(versionStr, repository, false);
     }
     return versionStr || VERSION_ZERO;
@@ -579,9 +577,9 @@ export default class Component extends BitObject {
     const results = versionsInfo.map((versionInfo) => {
       const log = versionInfo.version ? versionInfo.version.log : { message: '<no-data-available>' };
       return {
-        ...log, // @ts-ignore
+        ...log, // @ts-expect-error
         username: log?.username || 'unknown',
-        // @ts-ignore
+        // @ts-expect-error
         email: log?.email || 'unknown',
         tag: versionInfo.tag,
         hash: getRef(versionInfo.ref),
@@ -596,7 +594,7 @@ export default class Component extends BitObject {
     });
     // sort from earliest to latest
     const sorted = results.sort((a: ComponentLog, b: ComponentLog) => {
-      // @ts-ignore
+      // @ts-expect-error
       if (a.date && b.date) return a.date - b.date;
       return 0;
     });
@@ -606,7 +604,6 @@ export default class Component extends BitObject {
   collectVersions(repo: Repository): Promise<ConsumerComponent[]> {
     return Promise.all(
       this.listVersions().map((versionNum) => {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         return this.toConsumerComponent(versionNum, this.scope, repo);
       })
     );
@@ -839,14 +836,14 @@ Error from "semver": ${err.message}`);
       schema: this.schema,
       detachedHeads: this.detachedHeads.toObject(),
     };
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (this.local) componentObject.local = this.local;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!isEmpty(this.state)) componentObject.state = this.state;
-    // @ts-ignore
+    // @ts-expect-error
     if (!isEmpty(this.orphanedVersions)) componentObject.orphanedVersions = versions(this.orphanedVersions);
     const headStr = this.getHeadStr();
-    // @ts-ignore
+    // @ts-expect-error
     if (headStr) componentObject.head = headStr;
 
     return componentObject;
@@ -863,7 +860,7 @@ Error from "semver": ${err.message}`);
   loadVersionSync(version: string, repository: Repository, throws = true): Version {
     const versionRef = this.getRef(version);
     if (!versionRef) throw new VersionNotFound(version, this.id());
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return versionRef.loadSync(repository, throws);
   }
 
@@ -1089,7 +1086,6 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
     // @todo: this is weird. why the scopeMeta would be taken from the current scope and not he component scope?
     const scopeMetaP = scopeName ? ScopeMeta.fromScopeName(scopeName).load(repository) : Promise.resolve();
     const log = version.log || null;
-    // @ts-ignore
     const [files, scopeMeta] = await Promise.all([filesP, scopeMetaP]);
 
     const extensions = version.extensions.clone();
@@ -1112,10 +1108,10 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
       packageDependencies: clone(version.packageDependencies),
       devPackageDependencies: clone(version.devPackageDependencies),
       peerPackageDependencies: clone(version.peerPackageDependencies),
-      // @ts-ignore
+      // @ts-expect-error
       files,
       docs: version.docs,
-      // @ts-ignore
+      // @ts-expect-error
       license: scopeMeta ? License.deserialize(scopeMeta.license) : undefined, // todo: make sure we have license in case of local scope
       log,
       overrides: ComponentOverrides.loadFromScope(version.overrides),
@@ -1178,9 +1174,9 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
 
   markVersionAsLocal(version: string) {
     if (!this.state.versions) this.state = { versions: {} };
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!this.state.versions[version]) this.state.versions[version] = {};
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.state.versions[version].local = true;
   }
 
@@ -1190,7 +1186,7 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
    */
   getLocalVersions(): string[] {
     if (isEmpty(this.state) || isEmpty(this.state.versions)) return [];
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return Object.keys(this.state.versions).filter((version) => this.state.versions[version].local);
   }
 
@@ -1349,7 +1345,7 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
   }
 
   static fromBitId(bitId: ComponentID): Component {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new Component({
       name: bitId.fullName,
       scope: bitId.scope,

--- a/scopes/scope/objects/models/scopeMeta.ts
+++ b/scopes/scope/objects/models/scopeMeta.ts
@@ -8,7 +8,6 @@ type ScopeMetaProps = {
 };
 
 // TODO: fix parse
-// @ts-ignore
 export default class ScopeMeta extends BitObject {
   license: string | null | undefined;
   name: string;
@@ -26,7 +25,6 @@ export default class ScopeMeta extends BitObject {
     };
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   toString(pretty: boolean): string {
     const args = getStringifyArgs(pretty);
     return JSON.stringify(this.toObject(), ...args);
@@ -41,12 +39,12 @@ export default class ScopeMeta extends BitObject {
   }
 
   static fromScopeName(name: string): Ref {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return ScopeMeta.fromObject({ name }).hash();
   }
 
   static parse(propsStr: string | Buffer): ScopeMeta {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.fromObject(JSON.parse(propsStr));
   }
 

--- a/scopes/scope/objects/models/source.ts
+++ b/scopes/scope/objects/models/source.ts
@@ -1,7 +1,6 @@
 import { BitObject } from '../objects';
 
 // TODO: fix .parse
-// @ts-ignore
 export default class Source extends BitObject {
   contents: Buffer;
 

--- a/scopes/scope/objects/models/version.spec.ts
+++ b/scopes/scope/objects/models/version.spec.ts
@@ -17,7 +17,7 @@ describe('Version', () => {
       let idRaw;
       let idParsed;
       before(() => {
-        // @ts-ignore
+        // @ts-expect-error
         version = new Version(versionFixture);
         idRaw = version.id();
         idParsed = JSON.parse(idRaw);
@@ -89,7 +89,7 @@ describe('Version', () => {
     let hash;
     const versionFixtureHash = '4f67925a80b5e1f52dd1177196bf4c003d2f8798';
     before(() => {
-      // @ts-ignore
+      // @ts-expect-error
       version = new Version(versionFixture);
       hash = version.calculateHash();
     });

--- a/scopes/scope/objects/models/version.ts
+++ b/scopes/scope/objects/models/version.ts
@@ -70,11 +70,8 @@ export type VersionProps = {
   flattenedEdges?: DepEdge[];
   flattenedEdgesRef?: Ref;
   dependenciesGraphRef?: Ref;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   packageDependencies?: { [key: string]: string };
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   devPackageDependencies?: { [key: string]: string };
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   peerPackageDependencies?: { [key: string]: string };
   bindingPrefix: string;
   schema?: string;
@@ -123,7 +120,6 @@ export default class Version extends BitObject {
    * (around August 2023 should be safe)
    */
   private flattenedEdges: DepEdge[];
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   packageDependencies: { [key: string]: string };
   devPackageDependencies: { [key: string]: string };
   peerPackageDependencies: { [key: string]: string };
@@ -163,7 +159,7 @@ export default class Version extends BitObject {
     this.schema = props.schema;
     this.overrides = props.overrides || {};
     this.packageJsonChangedProps = props.packageJsonChangedProps || {};
-    // @ts-ignore yes, props.hash can be undefined here, but it gets populated as soon as Version is created
+    // @ts-expect-error yes, props.hash can be undefined here, but it gets populated as soon as Version is created
     this._hash = props.hash;
     this.parents = props.parents || [];
     this.squashed = props.squashed;
@@ -238,7 +234,7 @@ export default class Version extends BitObject {
     // @todo: remove the entire dependencies.relativePaths from the ID (it's going to be a breaking change)
     const getDependencies = (deps: Dependencies) => {
       const clonedDependencies = deps.cloneAsString();
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       return clonedDependencies.map((dependency: Dependency) => {
         return {
           id: dependency.id,
@@ -700,7 +696,6 @@ export default class Version extends BitObject {
       files: files.map(parseFile),
       bindingPrefix: component.bindingPrefix,
       log: component.log as Log,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       docs: component.docs,
       dependencies: component.dependencies.get(),
       devDependencies: component.devDependencies.get(),
@@ -714,7 +709,6 @@ export default class Version extends BitObject {
       flattenedEdgesRef: flattenedEdges?.hash(),
       schema: component.schema,
       overrides: component.overrides.componentOverridesData,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       packageJsonChangedProps: component.packageJsonChangedProps,
       extensions: component.extensions,
       buildStatus: component.buildStatus,
@@ -752,7 +746,7 @@ export default class Version extends BitObject {
   }
 
   setDist(dist: Source | undefined) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.dist = dist
       ? {
           file: dist.hash(),

--- a/scopes/scope/objects/objects/object.ts
+++ b/scopes/scope/objects/objects/object.ts
@@ -63,7 +63,7 @@ path: ${err.path}`);
         throw err;
       }
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       refsCollection.push(...refs);
       await Promise.all(objs.map((obj) => addRefs(obj)));
     }
@@ -141,13 +141,11 @@ path: ${err.path}`);
    * prefer using `this.parseObject()`, unless it must be sync.
    */
   static parseSync(fileContents: Buffer): BitObject {
-    // @ts-ignore todo: fix after merging #9359
     const buffer = inflateSync(fileContents);
     return parse(buffer);
   }
 
   static makeHash(str: string | Buffer): string {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return sha1(str);
   }
 }

--- a/scopes/scope/objects/objects/raw-object.ts
+++ b/scopes/scope/objects/objects/raw-object.ts
@@ -8,7 +8,6 @@ export default class BitRawObject {
   headers: string[];
   type: string;
   content: Buffer;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   parsedContent: any;
   _ref: string;
 
@@ -17,7 +16,6 @@ export default class BitRawObject {
     ref: string | null | undefined,
     type: string | null | undefined,
     content: Buffer | null | undefined,
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     parsedContent: any | null | undefined
   ) {
     let headers;
@@ -30,9 +28,9 @@ export default class BitRawObject {
     this.content = content || contentFromBuffer;
     this.headers = headers ? headers.split(SPACE_DELIMITER) : undefined;
     const typeFromHeader = this.headers ? this.headers[0] : undefined;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.type = type || typeFromHeader;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this._ref = ref;
     this.parsedContent = parsedContent || this.getParsedContent();
   }
@@ -72,17 +70,14 @@ export default class BitRawObject {
     }
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   set ref(ref: string) {
     this._ref = ref;
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   get ref(): string {
     return this._ref;
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   get id(): string {
     switch (this.type) {
       case 'Version':
@@ -114,12 +109,8 @@ export default class BitRawObject {
     return [];
   }
 
-  static async fromDeflatedBuffer(
-    fileContents: Buffer,
-    ref: string | null | undefined
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  ): Promise<BitObject> {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  static async fromDeflatedBuffer(fileContents: Buffer, ref: string | null | undefined): Promise<BitObject> {
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return inflate(fileContents).then((buffer) => new BitRawObject(buffer, ref));
   }
 
@@ -129,14 +120,13 @@ export default class BitRawObject {
    * @param {Any} parsedContent
    */
   toRealObject() {
-    // @ts-ignore
     return types[this.type].from(this.parsedContent || this.getParsedContent(), this.headers[1]);
   }
 
   clone() {
     const parsedContent = this.parsedContent ? clone(this.parsedContent) : undefined;
     // TODO: Should also clone the buffers (content)
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new BitRawObject(undefined, this._ref, this.type, this.content, parsedContent);
   }
 }

--- a/scopes/scope/objects/objects/repository.ts
+++ b/scopes/scope/objects/objects/repository.ts
@@ -32,7 +32,6 @@ const OBJECTS_BACKUP_DIR = `${OBJECTS_DIR}.bak`;
 const TRASH_DIR = 'trash';
 
 export default class Repository {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   objects: { [key: string]: BitObject } = {};
   objectsToRemove: Ref[] = [];
   scopeJson: ScopeJson;
@@ -137,7 +136,7 @@ export default class Repository {
   }
 
   getLicense(): Promise<string> {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.scopeJson.getPopulatedLicense();
   }
 
@@ -198,7 +197,7 @@ export default class Repository {
         const msg = `fatal: failed finding an object file ${objectPath} in the filesystem at ${err.path}`;
         throw Object.assign(err, { stack: new Error(msg).stack });
       }
-      // @ts-ignore @todo: fix! it should return BitObject | null.
+      // @ts-expect-error @todo: fix! it should return BitObject | null.
       return null;
     }
     const size = fileContentsRaw.byteLength;
@@ -435,7 +434,7 @@ export default class Repository {
       if (throws) {
         throw new HashNotFound(ref.toString());
       }
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       return null;
     }
   }
@@ -559,9 +558,9 @@ export default class Repository {
    */
   validateObjects(validate: boolean, objects: BitObject[]) {
     objects.forEach((bitObject) => {
-      // @ts-ignore some BitObject classes have validate() method
+      // @ts-expect-error some BitObject classes have validate() method
       if (validate && bitObject.validate) {
-        // @ts-ignore
+        // @ts-expect-error
         bitObject.validate();
       }
       if (!validate) {
@@ -687,7 +686,7 @@ export default class Repository {
     logger.trace(`repository._writeOne: ${objectPath}`);
     // Run hook to transform content pre persisting
     const transformedContent = this.onPersist(contents);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return writeFile(objectPath, transformedContent, options);
   }
 

--- a/scopes/scope/objects/objects/scope-index.spec.ts
+++ b/scopes/scope/objects/objects/scope-index.spec.ts
@@ -11,15 +11,15 @@ describe('ComponentsIndex', () => {
       scopeIndex = new ScopeIndex('scope-path');
     });
     it('should add to the index array', () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const modelComponent = new ModelComponent({ scope: 'my-scope', name: 'is-string' });
       scopeIndex.addOne(modelComponent);
       const allItems = scopeIndex.getAll();
-      // @ts-ignore
+      // @ts-expect-error
       expect(allItems[0].id).to.deep.equal({ scope: 'my-scope', name: 'is-string' });
     });
     it('should not add the same component multiple times', () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const modelComponent = new ModelComponent({ scope: 'my-scope', name: 'is-string' });
       scopeIndex.addOne(modelComponent);
       scopeIndex.addOne(modelComponent);
@@ -27,7 +27,7 @@ describe('ComponentsIndex', () => {
       expect(scopeIndex.getAll()).to.have.lengthOf(1);
     });
     it('should not add BitObjects that are not Symlink nor ModelComponent', () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const bitObject = new BitObject({ scope: 'my-scope', name: 'is-string' });
       const result = scopeIndex.addOne(bitObject);
       expect(scopeIndex.getAll()).to.have.lengthOf(0);
@@ -40,7 +40,7 @@ describe('ComponentsIndex', () => {
       scopeIndex = new ScopeIndex('scope-path');
     });
     it('should remove from the index array', () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const modelComponent = new ModelComponent({ scope: 'my-scope', name: 'is-string' });
       scopeIndex.addOne(modelComponent);
       expect(scopeIndex.getAll()).to.have.lengthOf(1);
@@ -48,9 +48,9 @@ describe('ComponentsIndex', () => {
       expect(scopeIndex.getAll()).to.have.lengthOf(0);
     });
     it('should remove the correct one when there are multiple', () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const isStringComponent = new ModelComponent({ scope: 'my-scope', name: 'is-string' });
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const isTypeComponent = new ModelComponent({ scope: 'my-scope', name: 'is-type' });
       scopeIndex.addOne(isStringComponent);
       scopeIndex.addOne(isTypeComponent);
@@ -58,7 +58,7 @@ describe('ComponentsIndex', () => {
       scopeIndex.removeOne(isStringComponent.hash().toString());
       const allIds = scopeIndex.getAll();
       expect(allIds).to.have.lengthOf(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(allIds[0].id).to.deep.equal({ scope: 'my-scope', name: 'is-type' });
     });
   });
@@ -68,9 +68,9 @@ describe('ComponentsIndex', () => {
     let isTypeComponent;
     beforeEach(() => {
       scopeIndex = new ScopeIndex('scope-path');
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       isStringComponent = new ModelComponent({ scope: 'my-scope', name: 'is-string' });
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       isTypeComponent = new ModelComponent({ scope: 'my-scope', name: 'is-type' });
       scopeIndex.addMany([isStringComponent, isTypeComponent]);
       expect(scopeIndex.getAll()).to.have.lengthOf(2);

--- a/scopes/scope/objects/objects/scope-index.ts
+++ b/scopes/scope/objects/objects/scope-index.ts
@@ -111,11 +111,10 @@ export class ScopeIndex {
   }
 
   getHashes(indexType: IndexType): string[] {
-    // @ts-ignore how to tell TS that all this.index.prop are array?
     return this.index[indexType].map((indexItem: IndexItem) => indexItem.hash);
   }
   getHashesByQuery(indexType: IndexType, filter: Function): string[] {
-    // @ts-ignore how to tell TS that all this.index.prop are array?
+    // @ts-expect-error how to tell TS that all this.index.prop are array?
     return this.index[indexType].filter(filter).map((indexItem: IndexItem) => indexItem.hash);
   }
   getHashesIncludeSymlinks(): string[] {

--- a/scopes/scope/scope/debug-commands/cat-component.ts
+++ b/scopes/scope/scope/debug-commands/cat-component.ts
@@ -4,13 +4,11 @@ import { loadScope } from '@teambit/legacy.scope';
 import type { Version } from '@teambit/objects';
 
 export async function catComponent(id: string): Promise<Record<string, any>> {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const scope: Scope = await loadScope();
   const bitId = await scope.getParsedId(id);
   // $FlowFixMe unclear what's the issue here
   const component = await scope.getModelComponent(bitId);
   if (bitId.hasVersion()) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const version: Version = await component.loadVersion(bitId.version, scope.objects);
     return version.toObject();
   }

--- a/scopes/scope/scope/debug-commands/cat-scope-cmd.ts
+++ b/scopes/scope/scope/debug-commands/cat-scope-cmd.ts
@@ -35,9 +35,9 @@ export class CatScopeCmd implements Command {
     const payload = await catScope(scopePath || process.cwd(), full);
     if (jsonExtra) {
       payload.forEach((obj) => {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         obj.hash = obj.hash().toString();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         obj.type = obj.constructor.name;
       });
     }

--- a/scopes/scope/scope/routes/fetch.route.ts
+++ b/scopes/scope/scope/routes/fetch.route.ts
@@ -3,7 +3,6 @@ import { Verb } from '@teambit/express';
 import { fetch } from '@teambit/legacy.scope-api';
 import { ObjectList } from '@teambit/objects';
 import type { Logger } from '@teambit/logger';
-// @ts-ignore
 import { pipeline } from 'stream/promises';
 import type { ScopeMain } from '../scope.main.runtime';
 

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -157,7 +157,7 @@ needed-for: ${neededFor || '<unknown>'}`);
     const depsToLoad: Array<ExtensionManifest | Aspect> = [];
     await mapSeries(manifests, async (manifest) => {
       depsToLoad.push(...(manifest.dependencies || []));
-      // @ts-ignore
+      // @ts-expect-error
       (manifest._runtimes || []).forEach((runtime) => {
         depsToLoad.push(...(runtime.dependencies || []));
       });
@@ -257,7 +257,6 @@ needed-for: ${neededFor || '<unknown>'}`);
     const compiledCode = (
       await Promise.all(
         component.filesystem.files.flatMap(async (file) => {
-          // @ts-ignore - we know it's not null, we have throw error above if yes
           if (!compiler.isFileSupported(file.path)) {
             return [
               {
@@ -266,9 +265,7 @@ needed-for: ${neededFor || '<unknown>'}`);
               },
             ] as TranspileFileOutputOneFile[];
           }
-          // @ts-ignore - we know it's not null, we have throw error above if yes
           if (compiler.transpileFile) {
-            // @ts-ignore - we know it's not null, we have throw error above if yes
             return compiler.transpileFile(file.contents.toString('utf8'), {
               filePath: file.path,
               componentDir: capsule.path,
@@ -282,7 +279,6 @@ needed-for: ${neededFor || '<unknown>'}`);
 
     await Promise.all(
       compact(compiledCode).map((compiledFile) => {
-        // @ts-ignore - we know it's not null, we have throw error above if yes
         const path = compiler.getDistPathBySrcPath(compiledFile.outputPath);
         return capsule?.outputFile(path, compiledFile.outputText);
       })
@@ -355,13 +351,13 @@ needed-for: ${neededFor || '<unknown>'}`);
 
   shouldUseDatedCapsules(): boolean {
     const globalConfig = this.configStore.getConfig(CFG_USE_DATED_CAPSULES);
-    // @ts-ignore
+    // @ts-expect-error
     return globalConfig === true || globalConfig === 'true';
   }
 
   shouldCacheLockFileOnly(): boolean {
     const globalConfig = this.configStore.getConfig(CFG_CACHE_LOCK_ONLY_CAPSULES);
-    // @ts-ignore
+    // @ts-expect-error
     return globalConfig === true || globalConfig === 'true';
   }
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -323,7 +323,7 @@ export class ScopeMain implements ComponentFactory {
       component.state._consumer.dependencies.dependencies
     );
     if (resolvedEnvJsonc) {
-      // @ts-ignore
+      // @ts-expect-error
       envsData.resolvedEnvJsonc = resolvedEnvJsonc;
     }
     // Make sure we are adding the envs / deps data first because other on load events might depend on it
@@ -1364,7 +1364,6 @@ export class ScopeMain implements ComponentFactory {
       new ActionRoute(scope),
       new DeleteRoute(scope),
     ]);
-    // @ts-ignore - @ran to implement the missing functions and remove it
     ui.registerUiRoot(new ScopeUIRoot(scope));
     graphql.register(() => scopeSchema(scope));
     componentExt.registerHost(scope);

--- a/scopes/semantics/schema/schema.spec.ts
+++ b/scopes/semantics/schema/schema.spec.ts
@@ -54,7 +54,6 @@ describe('SchemaAspect', function () {
       // uncomment the next line temporarily to sync the expected json with new schema changes
       // fs.outputFileSync(expectedJsonPath, JSON.stringify(results, undefined, 2));
       const expectedJson = fs.readJsonSync(expectedJsonPath);
-      // @ts-ignore it exists on Jest. for some reason ts assumes this is Jasmine.
       expect(results).to.to.containSubset(expectedJson);
     });
   });
@@ -65,7 +64,6 @@ describe('SchemaAspect', function () {
       const apiSchema = schema.getSchemaFromObject(json);
       expect(apiSchema instanceof APISchema).to.be.true;
       expect(apiSchema.componentId.constructor.name).to.equal(ComponentID.name);
-      // @ts-ignore it exists on Jest. for some reason ts assumes this is Jasmine.
       expect(apiSchema.toObject()).to.containSubset(json);
     });
     it('should not throw when it does not recognize the schema', () => {
@@ -74,7 +72,6 @@ describe('SchemaAspect', function () {
       const apiSchema = schema.getSchemaFromObject(json);
       expect(apiSchema instanceof APISchema).to.be.true;
       expect(apiSchema.module.exports[0] instanceof UnknownSchema).to.be.true;
-      // @ts-ignore
       expect(apiSchema.module.exports[0].location).to.deep.equal({ file: 'index.ts', line: 21, character: 14 });
     });
   });

--- a/scopes/toolbox/network/get-port/get-port.ts
+++ b/scopes/toolbox/network/get-port/get-port.ts
@@ -73,7 +73,7 @@ export class Port {
       server.listen(options, () => {
         const serverInfo = server.address();
         server.close(() => {
-          // @ts-ignore
+          // @ts-expect-error
           resolve(serverInfo?.port);
         });
       });

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -3,7 +3,7 @@ import { getTokenAtPosition, canHaveJsDoc, getJsDoc } from 'tsutils';
 import type { ExportAssignment, ExportDeclaration, Node, TypeNode } from 'typescript';
 import ts, { getTextOfJSDocComment, SyntaxKind } from 'typescript';
 import { head, uniqBy } from 'lodash';
-// @ts-ignore david we should figure fix this.
+// @ts-expect-error david we should figure fix this.
 // eslint-disable-next-line import/no-unresolved
 import type protocol from 'typescript/lib/protocol';
 import { pathNormalizeToLinux, isRelativeImport } from '@teambit/legacy.utils';

--- a/scopes/typescript/typescript/typescript.parser.ts
+++ b/scopes/typescript/typescript/typescript.parser.ts
@@ -69,7 +69,6 @@ export class TypeScriptParser implements Parser {
     });
 
     const withoutEmpty = exportModels.filter((exportModel) => exportModel !== undefined);
-    // @ts-ignore
     return withoutEmpty;
   }
 

--- a/scopes/ui-foundation/less/less.compiler.ts
+++ b/scopes/ui-foundation/less/less.compiler.ts
@@ -56,7 +56,7 @@ export class LessCompiler implements Compiler {
     );
 
     return {
-      // @ts-ignore TODO: fix this.
+      // @ts-expect-error TODO: fix this.
       componentsResults: results,
     };
   }

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -290,7 +290,6 @@ export class UIServer {
     const config = await this.getDevConfig();
     const compiler = webpack(config as any);
     const devServerConfig = await this.getDevServerConfig(devServerPort, expressAppPort, config.devServer);
-    // @ts-ignore in the capsules it throws an error about compatibilities issues between webpack.compiler and webpackDevServer/webpack/compiler
     const devServer = new WebpackDevServer(devServerConfig, compiler);
 
     await devServer.start();

--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -340,7 +340,7 @@ export default function createWebpackConfig(
           }, seed);
           const entrypointFiles = entrypoints.main.filter((fileName) => !fileName.endsWith('.map'));
 
-          // @ts-ignore - https://github.com/shellscape/webpack-manifest-plugin/issues/276
+          // @ts-expect-error - https://github.com/shellscape/webpack-manifest-plugin/issues/276
           return {
             files: manifestFiles,
             entrypoints: entrypointFiles,

--- a/scopes/ui-foundation/ui/webpack/webpack.browser.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.browser.config.ts
@@ -17,9 +17,7 @@ export default function createWebpackConfig(
 ): Configuration {
   const baseConfig = createBaseConfig(outputDir, entryFiles);
   const browserConfig = createBrowserConfig(outputDir, title, publicDir);
-  // @ts-ignore that's an issue because of different types/webpack version
   const combined = merge(baseConfig, browserConfig);
-  // @ts-ignore that's an issue because of different types/webpack version
   return combined;
 }
 

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -143,7 +143,7 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
         // middlewares before `redirectServedPath` otherwise will not have any effect
         // This lets us fetch source contents from webpack for the error overlay
         middlewares.push(
-          // @ts-ignore @types/wds mismatch
+          // @ts-expect-error @types/wds mismatch
           evalSourceMapMiddleware(devServer),
           // This lets us open files from the runtime error overlay.
           errorOverlayMiddleware(),

--- a/scopes/ui-foundation/ui/webpack/webpack.ssr.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.ssr.config.ts
@@ -10,9 +10,7 @@ export default function createWebpackConfig(
 ): Configuration {
   const baseConfig = createBaseConfig(workspaceDir, entryFiles);
   const ssrConfig = createSsrConfig(workspaceDir, publicDir);
-  // @ts-ignore that's an issue because of different types/webpack version
   const combined = merge(baseConfig, ssrConfig);
-  // @ts-ignore that's an issue because of different types/webpack version
   return combined;
 }
 

--- a/scopes/webpack/config-mutator/config-mutator.spec.ts
+++ b/scopes/webpack/config-mutator/config-mutator.spec.ts
@@ -38,7 +38,6 @@ describe('add aliases', () => {
   it('add simple alias', () => {
     const config = new WebpackConfigMutator({});
     config.addAliases({ react: 'custom-react-path' });
-    // @ts-ignore - error since there is mix between mocha and jest types
     expect(config.raw.resolve?.alias).toHaveProperty('react', 'custom-react-path');
   });
 });
@@ -47,9 +46,7 @@ describe('add top level', () => {
   it('add simple alias', () => {
     const config = new WebpackConfigMutator({});
     config.addTopLevel('output', { publicPath: 'my-public-path' });
-    // @ts-ignore - error since there is mix between mocha and jest types
     expect(config.raw).toHaveProperty('output');
-    // @ts-ignore - error since there is mix between mocha and jest types
     expect(config.raw.output).toHaveProperty('publicPath', 'my-public-path');
   });
 });
@@ -59,11 +56,8 @@ describe('add module rule', () => {
     const config = new WebpackConfigMutator({});
     config.addModuleRule(cssRule);
     expect(config.raw.module?.rules?.length).toEqual(1);
-    // @ts-ignore - error since there is mix between mocha and jest types
     expect(config.raw.module?.rules?.[0]).toHaveProperty('test', /\.css$/);
-    // @ts-ignore - error since there is mix between mocha and jest types
     expect(config.raw.module?.rules?.[0]).toHaveProperty('exclude', /\.module\.css$/);
-    // @ts-ignore - error since there is mix between mocha and jest types
     expect(config.raw.module?.rules?.[0]).toHaveProperty('use', ['style-loader', 'css-loader']);
   });
 });

--- a/scopes/webpack/config-mutator/config-mutator.ts
+++ b/scopes/webpack/config-mutator/config-mutator.ts
@@ -136,7 +136,6 @@ export class WebpackConfigMutator {
     if (!this.raw.module.rules) {
       this.raw.module.rules = [];
     }
-    // @ts-ignore
     const moduleWithOneOf = this.raw.module.rules.find((r) => !!(r as RuleSetRule).oneOf);
     if (!moduleWithOneOf) {
       this.raw.module.rules.unshift({ oneOf: [] });
@@ -203,7 +202,6 @@ export class WebpackConfigMutator {
       return this;
     }
     if (isObject(this.raw?.resolve?.alias)) {
-      // @ts-ignore
       this.raw.resolve.alias = omit(this.raw.resolve.alias, aliases);
     }
     return this;
@@ -242,7 +240,6 @@ export class WebpackConfigMutator {
     ) {
       externals = [externalDeps].concat(externals);
     } else if (externalDeps instanceof Object && externals instanceof Object) {
-      // @ts-ignore
       externals = {
         ...externals,
         ...externalDeps,

--- a/scopes/webpack/plugins/inject-head-webpack-plugin/inject-head-webpack-plugin.ts
+++ b/scopes/webpack/plugins/inject-head-webpack-plugin/inject-head-webpack-plugin.ts
@@ -35,10 +35,10 @@ export default class InjectHeadPlugin {
     compiler.hooks.compilation.tap('InjectHeadPluginOptions', (compilation) => {
       HtmlWebpackPlugin.getHooks(compilation).beforeEmit.tap('InjectHeadPluginOptions', (data) => {
         if (this.options.position === 'end') {
-          // @ts-ignore
+          // @ts-expect-error
           data.html = insertStringBefore(data.html, '</head>', this.options.content);
         } else {
-          // @ts-ignore
+          // @ts-expect-error
           data.html = insertStringAfter(data.html, '<head>', this.options.content);
         }
         return data;

--- a/scopes/webpack/webpack/config/webpack.config.ts
+++ b/scopes/webpack/webpack/config/webpack.config.ts
@@ -30,7 +30,7 @@ export function configFactory(target: Target, context: BundlerContext): Configur
     bail: true,
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
-    // @ts-ignore
+    // @ts-expect-error
     entry: truthyEntries,
 
     infrastructureLogging: {

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -118,7 +118,7 @@ export function configFactory(
         // middlewares before `redirectServedPath` otherwise will not have any effect
         // This lets us fetch source contents from webpack for the error overlay
         middlewares.push(
-          // @ts-ignore @types/wds mismatch
+          // @ts-expect-error @types/wds mismatch
           evalSourceMapMiddleware(devServer),
           // This lets us open files from the runtime error overlay.
           errorOverlayMiddleware(),

--- a/scopes/webpack/webpack/run-transformer.ts
+++ b/scopes/webpack/webpack/run-transformer.ts
@@ -9,7 +9,6 @@ export function runTransformersWithContext(
 ): WebpackConfigMutator {
   if (!Array.isArray(transformers)) return config;
   const newConfig = transformers.reduce((acc, transformer) => {
-    // @ts-ignore
     return transformer(acc, context);
   }, config);
   return newConfig;

--- a/scopes/webpack/webpack/transformers/inject-body.ts
+++ b/scopes/webpack/webpack/transformers/inject-body.ts
@@ -16,7 +16,7 @@ export type BodyInjectionOptions = {
  */
 export function GenerateBodyInjectionTransformer(options: BodyInjectionOptions): WebpackConfigTransformer {
   return (config) => {
-    // @ts-ignore - https://github.com/Jaid/inject-body-webpack-plugin/issues/12
+    // @ts-expect-error - https://github.com/Jaid/inject-body-webpack-plugin/issues/12
     const plugin = new InjectBodyPlugin(options);
 
     return config.addPlugin(plugin);

--- a/scopes/webpack/webpack/webpack.bundler.ts
+++ b/scopes/webpack/webpack/webpack.bundler.ts
@@ -150,7 +150,7 @@ export class WebpackBundler implements Bundler {
       entryVal.assets?.forEach((asset) => {
         const compressedSize = assetsMap[asset.name]?.compressedSize;
         if (compressedSize) {
-          // @ts-ignore
+          // @ts-expect-error
           asset.compressedSize = compressedSize;
           compressedAssetsSize += compressedSize;
         }
@@ -158,7 +158,7 @@ export class WebpackBundler implements Bundler {
       entryVal.auxiliaryAssets?.forEach((asset) => {
         const compressedSize = assetsMap[asset.name]?.compressedSize;
         if (compressedSize) {
-          // @ts-ignore
+          // @ts-expect-error
           asset.compressedSize = compressedSize;
           compressedAuxiliaryAssetsSize += compressedSize;
         }

--- a/scopes/webpack/webpack/webpack.dev-server.ts
+++ b/scopes/webpack/webpack/webpack.dev-server.ts
@@ -73,16 +73,15 @@ export class WebpackDevServer implements DevServer {
 
     // Compatibility check for Webpack dev server v3 (e.g. for Angular v8)
     if (typeof (this.WsDevServer as any).addDevServerEntrypoints !== 'undefined') {
-      // @ts-ignore in the capsules it throws an error about compatibilities issues between webpack.compiler and webpackDevServer/webpack/compiler
       const webpackDs = new (this.WsDevServer as any)(this.getCompiler(), this.config.devServer);
       return webpackDs.listen(port);
     }
 
-    // @ts-ignore in the capsules it throws an error about compatibilities issues between webpack.compiler and webpackDevServer/webpack/compiler
+    // @ts-expect-error in the capsules it throws an error about compatibilities issues between webpack.compiler and webpackDevServer/webpack/compiler
     const webpackDs: WDS = new this.WsDevServer(this.config.devServer, this.getCompiler());
     await webpackDs.start();
 
-    // @ts-ignore
+    // @ts-expect-error
     return webpackDs.server;
   }
 

--- a/scopes/webpack/webpack/webpack.main.runtime.ts
+++ b/scopes/webpack/webpack/webpack.main.runtime.ts
@@ -106,7 +106,6 @@ export class WebpackMain {
       [...internalTransformers, ...transformers],
       transformerContext
     );
-    // @ts-ignore - fix this
     return new WebpackDevServer(afterMutation.raw, this.getWebpackInstance(webpackModulePath, webpack), wdsPath);
   }
 

--- a/scopes/workspace/config-merger/component-config-merger.ts
+++ b/scopes/workspace/config-merger/component-config-merger.ts
@@ -450,7 +450,6 @@ export class ComponentConfigMerger {
       if (dep.__type !== 'component') {
         return dep.id;
       }
-      // @ts-ignore
       return dep.packageName;
     };
 

--- a/scopes/workspace/eject/components-ejector.ts
+++ b/scopes/workspace/eject/components-ejector.ts
@@ -42,7 +42,6 @@ export class ComponentsEjector {
   consumer: Consumer;
   idsToEject: ComponentIdList;
   componentsToEject: Component[] = [];
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   notEjectedDependents: Array<{ dependent: Component; ejectedDependencies: Component[] }>;
   failedComponents: FailedComponents;
   constructor(

--- a/scopes/workspace/install/pick-outdated-pkgs.spec.ts
+++ b/scopes/workspace/install/pick-outdated-pkgs.spec.ts
@@ -37,7 +37,6 @@ describe('makeOutdatedPkgChoices', () => {
     ]);
     // Removing the ansi chars for better work on bit build on ci
     const stripped = stripAnsiFromChoices(choices);
-    // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     expect(stripped).to.deep.equal(orderedChoices);
   });
@@ -62,7 +61,6 @@ describe('makeOutdatedPkgChoices', () => {
     ]);
     // Removing the ansi chars for better work on bit build on ci
     const stripped = stripAnsiFromChoices(choices);
-    // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     expect(stripped).to.deep.equal(contextOrders);
   });

--- a/scopes/workspace/modules/node-modules-linker/codemod-components.ts
+++ b/scopes/workspace/modules/node-modules-linker/codemod-components.ts
@@ -74,7 +74,6 @@ async function codemodComponent(
         pathNormalizeToLinux(file.relative)
       ];
       if (!relativeInstances) return;
-      // @ts-ignore
       const fileBefore = file.contents.toString() as string;
       let newFileString = fileBefore;
       await Promise.all(
@@ -93,7 +92,6 @@ async function codemodComponent(
         })
       );
       if (fileBefore !== newFileString) {
-        // @ts-ignore
         file.contents = Buffer.from(newFileString);
         files.push(file);
       }

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -142,7 +142,7 @@ https://facebook.github.io/watchman/docs/troubleshooting#fseventstreamstart-regi
 
     return new Promise((resolve, reject) => {
       if (this.verbose) {
-        // @ts-ignore
+        // @ts-expect-error
         if (msgs?.onAll) watcher.on('all', msgs.onAll);
       }
       watcher.on('ready', () => {

--- a/scopes/workspace/workspace-config-files/dedup-paths.spec.ts
+++ b/scopes/workspace/workspace-config-files/dedup-paths.spec.ts
@@ -302,7 +302,7 @@ describe('Workspace Config files - dedupe paths', function () {
     describe('ts example', () => {
       let result: DedupedPaths;
       before(async () => {
-        // @ts-ignore (we don't really care about the env itself here)
+        // @ts-expect-error (we don't really care about the env itself here)
         result = dedupePaths(tsExtendingConfigFilesMap, envCompsDirsMap);
       });
 
@@ -318,7 +318,7 @@ describe('Workspace Config files - dedupe paths', function () {
     describe('eslint example', () => {
       let result: DedupedPaths;
       before(async () => {
-        // @ts-ignore (we don't really care about the env itself here)
+        // @ts-expect-error (we don't really care about the env itself here)
         result = dedupePaths(eslintExtendingConfigFilesMap, envCompsDirsMap);
       });
 
@@ -334,7 +334,7 @@ describe('Workspace Config files - dedupe paths', function () {
     describe('prettier example', () => {
       let result: DedupedPaths;
       before(async () => {
-        // @ts-ignore (we don't really care about the env itself here)
+        // @ts-expect-error (we don't really care about the env itself here)
         result = dedupePaths(prettierExtendingConfigFilesMap, envCompsDirsMap);
       });
 

--- a/scopes/workspace/workspace/auto-tag.ts
+++ b/scopes/workspace/workspace/auto-tag.ts
@@ -26,7 +26,7 @@ export async function getAutoTagInfo(consumer: Consumer, changedComponents: Comp
     if (!graph.hasNode(idStr)) return;
     // preorder gets all dependencies and dependencies of dependencies and so on.
     // we loop over the dependencies of a component
-    // @ts-ignore
+    // @ts-expect-error
     const dependenciesStr = graphlib.alg.preorder(graph, idStr);
     const dependenciesBitIds = dependenciesStr.map((depStr) => graph.node(depStr));
     const triggeredDependencies = dependenciesBitIds.filter((dependencyId) => {

--- a/scopes/workspace/workspace/capsule.cmd.ts
+++ b/scopes/workspace/workspace/capsule.cmd.ts
@@ -89,7 +89,7 @@ export class CapsuleCreateCmd implements Command {
   }
 
   async report([componentIds]: [string[]], opts: CreateOpts) {
-    // @ts-ignore
+    // @ts-expect-error
     const capsules = await this.create(componentIds, opts);
     const capsuleOutput = capsules
       .map((capsule) => `${chalk.bold(capsule.component.id.toString())} - ${capsule.path}`)
@@ -99,7 +99,7 @@ export class CapsuleCreateCmd implements Command {
   }
 
   async json([componentIds]: [string[]], opts: CreateOpts) {
-    // @ts-ignore
+    // @ts-expect-error
     const capsules = await this.create(componentIds, opts);
     return capsules.map((c) => ({
       id: c.component.id.toString(),

--- a/scopes/workspace/workspace/component-config-file/component-config-file.ts
+++ b/scopes/workspace/workspace/component-config-file/component-config-file.ts
@@ -116,7 +116,7 @@ export class ComponentConfigFile {
         if (!shouldMergeConfig) return config;
         if (!config || config === '-') return config;
         if (!existing.config) return config;
-        // @ts-ignore
+        // @ts-expect-error
         if (existing.config === '-') return config;
         return merge(existing.config, config);
       };

--- a/scopes/workspace/workspace/workspace-component/component-status-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/component-status-loader.ts
@@ -64,7 +64,7 @@ export class ComponentStatusLoader {
   }
 
   private async getStatus(id: ComponentID) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const status: ComponentStatusLegacy = {};
     const componentFromModel: ModelComponent | undefined = await this.consumer.scope.getModelComponentIfExist(id);
     let componentFromFileSystem: ConsumerComponent | undefined;
@@ -124,7 +124,7 @@ export class ComponentStatusLoader {
     if (!versionFromModel) {
       throw new BitError(`failed loading version ${versionFromFs} of ${idStr} from the scope`);
     }
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-expect-error AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     status.modified = await this.consumer.isComponentModified(versionFromModel, componentFromFileSystem);
     return status;
   }

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -313,7 +313,7 @@ export class WorkspaceComponentLoader {
     layeredEnvsGroups.forEach((group) => {
       const filteredIds = group.ids.filter((id) => envsOfCoreAspectEnv.includes(id.toStringWithoutVersion()));
       if (filteredIds.length) {
-        // @ts-ignore
+        // @ts-expect-error
         coreAspectEnvGroup.ids.push(...filteredIds);
       }
     });
@@ -931,7 +931,7 @@ export class WorkspaceComponentLoader {
       envExtendsDeps
     );
     if (resolvedEnvJsonc) {
-      // @ts-ignore
+      // @ts-expect-error
       envsData.resolvedEnvJsonc = resolvedEnvJsonc;
     }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1809,7 +1809,7 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
     if (resolveEnvsFromRoots === undefined) {
       const resolveEnvsFromRootsConfig = this.configStore.getConfig(CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS);
       const defaultResolveEnvsFromRoots: boolean =
-        // @ts-ignore
+        // @ts-expect-error
         resolveEnvsFromRootsConfig === 'true' || resolveEnvsFromRootsConfig === true;
       resolveEnvsFromRoots = defaultResolveEnvsFromRoots;
     }


### PR DESCRIPTION
Remove 186 unused `@ts-expect-error` directives across 83 files in the scopes directory. These were identified by TypeScript compiler after a migration from `@ts-ignore` to `@ts-expect-error` directives.

Also adds an automation script at `scripts/remove-unused-ts-expect-errors.js` for future cleanup tasks.