### PR TITLE
fix: disable windows-nightly workflow triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1143,13 +1143,13 @@ workflows:
 
   # Windows nightly workflow
   windows-nightly:
-    triggers:
-      - schedule: # every day at 5AM UTC (= 1AM EST = 8AM IST)
-          cron: '0 5 * * *'
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+    #   - schedule: # every day at 5AM UTC (= 1AM EST = 8AM IST)
+    #       cron: '0 5 * * *'
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master
     jobs:
       - windows_checkout_code
       - windows_set_ssh_key


### PR DESCRIPTION
Disables the windows-nightly workflow by commenting out its triggers section, as this workflow hasn't been working for a while now.

The workflow definition remains intact and can be easily re-enabled by uncommenting the triggers when needed.