### PR TITLE
fix(deps): prevent duplicate dependencies when overriding dep types in env.jsonc

### DIFF
--- a/e2e/harmony/update-cmd.e2e.ts
+++ b/e2e/harmony/update-cmd.e2e.ts
@@ -202,7 +202,7 @@ const isPositive = require("is-positive");`
       it('should add an updated version of the dependency from the model to the bitmap', function () {
         const bitMap = helper.bitMap.read();
         expect(
-          bitMap.comp1.config['teambit.dependencies/dependency-resolver'].policy.dependencies['is-negative']
+          bitMap.comp1.config['teambit.dependencies/dependency-resolver'].policy.devDependencies['is-negative']
         ).to.equal('^2.1.0');
       });
       it('should not update extensions from the model', function () {
@@ -232,7 +232,7 @@ const isPositive = require("is-positive");`
       it('should add an updated version of the dependency from the model to the bitmap', function () {
         const bitMap = helper.bitMap.read();
         expect(
-          bitMap.comp1.config['teambit.dependencies/dependency-resolver'].policy.dependencies['is-negative']
+          bitMap.comp1.config['teambit.dependencies/dependency-resolver'].policy.devDependencies['is-negative']
         ).to.equal('~2.1.0');
       });
       it('should not update extensions from the model', function () {

--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -348,15 +348,39 @@ export class ApplyOverrides {
     if (!dependencies) return;
     const { components, packages } = dependencies;
     DEPENDENCIES_FIELDS.forEach((depField) => {
+      const otherFields = DEPENDENCIES_FIELDS.filter((f) => f !== depField);
       if (components[depField] && components[depField].length) {
+        const depsSet = new Set();
         components[depField].forEach((depData) => {
+          depsSet.add(depData.packageName);
           this.allDependencies[depField].push(
             new Dependency(depData.componentId, [], depData.packageName, depData.versionRange)
+          );
+        });
+        otherFields.forEach((otherField) => {
+          this.allDependencies[otherField] = this.allDependencies[otherField].filter(
+            (dep) => !depsSet.has(dep.packageName)
           );
         });
       }
       if (packages[depField] && !isEmpty(packages[depField])) {
         Object.assign(this.allPackagesDependencies[this._pkgFieldMapping(depField)], packages[depField]);
+        // remove the dependency from the other fields to prevent duplications
+        otherFields.forEach((otherField) => {
+          Object.keys(packages[depField]).forEach((pkgName) => {
+            if (this.component.id.toString().includes('screen-title')) {
+              if (this.allPackagesDependencies[this._pkgFieldMapping(otherField)][pkgName]) {
+                console.log(
+                  'deleting',
+                  otherField,
+                  pkgName,
+                  this.allPackagesDependencies[this._pkgFieldMapping(otherField)][pkgName]
+                );
+              }
+            }
+            delete this.allPackagesDependencies[this._pkgFieldMapping(otherField)][pkgName];
+          });
+        });
       }
     });
     // The automatic dependency detector considers all found dependencies to be runtime dependencies.

--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -368,16 +368,6 @@ export class ApplyOverrides {
         // remove the dependency from the other fields to prevent duplications
         otherFields.forEach((otherField) => {
           Object.keys(packages[depField]).forEach((pkgName) => {
-            if (this.component.id.toString().includes('screen-title')) {
-              if (this.allPackagesDependencies[this._pkgFieldMapping(otherField)][pkgName]) {
-                console.log(
-                  'deleting',
-                  otherField,
-                  pkgName,
-                  this.allPackagesDependencies[this._pkgFieldMapping(otherField)][pkgName]
-                );
-              }
-            }
             delete this.allPackagesDependencies[this._pkgFieldMapping(otherField)][pkgName];
           });
         });


### PR DESCRIPTION
Fixes an issue where dependencies would appear in multiple dependency fields (e.g., both peer and dev) when moving a dependency from one type to another in env.jsonc overrides.

This ensures that when a dependency is explicitly set in one field, it's properly removed from other dependency fields to prevent duplications in package.json.

Related to #9720