### PR TITLE
fix(ci): sanitize dots in branch names for Bit lane creation

### DIFF
--- a/scopes/git/ci/commands/pr.cmd.ts
+++ b/scopes/git/ci/commands/pr.cmd.ts
@@ -45,8 +45,8 @@ export class CiPrCmd implements Command {
       if (!currentBranch) {
         throw new Error('Failed to get branch name');
       }
-      // Sanitize branch name to make it valid for Bit lane IDs by replacing slashes with dashes
-      const sanitizedBranch = currentBranch.replace(/\//g, '-');
+      // Sanitize branch name to make it valid for Bit lane IDs by replacing slashes and dots with dashes
+      const sanitizedBranch = currentBranch.replace(/[/.]/g, '-');
       laneIdStr = `${this.workspace.defaultScope}/${sanitizedBranch}`;
     }
 


### PR DESCRIPTION
Fixes an issue where `bit ci pr` fails when branch names contain dots (e.g., `fix-typescript-5.9.2-upgrade-compatibility`).

The error occurred because Bit lane names can only contain alphanumeric, lowercase characters, and specific symbols: `["-", "_", "$", "!"]`.

Updated the branch name sanitization logic to replace both slashes and dots with hyphens to ensure valid Bit lane names.