### PR TITLE
chore(deps): bump oxlint to 1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint-staged": "lint-staged"
   },
   "dependencies": {
-    "oxlint": "1.10.0",
+    "oxlint": "1.11.2",
     "husky": "9.1.7"
   },
   "devDependencies": {},


### PR DESCRIPTION
Update dependencies in package.json and pnpm-lock.yaml to keep them up to date.