### PR TITLE
fix: properly disable windows-nightly workflow execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1142,7 +1142,7 @@ workflows:
             - harmony_publish_to_gcloud
 
   # Windows nightly workflow
-  windows-nightly:
+  # windows-nightly:
     # triggers:
     #   - schedule: # every day at 5AM UTC (= 1AM EST = 8AM IST)
     #       cron: '0 5 * * *'
@@ -1150,24 +1150,24 @@ workflows:
     #         branches:
     #           only:
     #             - master
-    jobs:
-      - windows_checkout_code
-      - windows_set_ssh_key
-      - windows_bvm_install:
-          <<: *master_only_filter
-          requires:
-            - windows_checkout_code
-      - windows_build_bvm:
-          <<: *master_only_filter
-          requires:
-            - windows_bvm_install
-      - windows_e2e_test_bvm:
-          <<: *master_only_filter
-          requires:
-            - windows_checkout_code
-            - windows_set_ssh_key
-            - windows_bvm_install
-            - windows_build_bvm
+    # jobs:
+    #   - windows_checkout_code
+    #   - windows_set_ssh_key
+    #   - windows_bvm_install:
+    #       <<: *master_only_filter
+    #       requires:
+    #         - windows_checkout_code
+    #   - windows_build_bvm:
+    #       <<: *master_only_filter
+    #       requires:
+    #         - windows_bvm_install
+    #   - windows_e2e_test_bvm:
+    #       <<: *master_only_filter
+    #       requires:
+    #         - windows_checkout_code
+    #         - windows_set_ssh_key
+    #         - windows_bvm_install
+    #         - windows_build_bvm
 
   # TODO: check if we can combine it with the regular nightly somehow
   harmony_deploy:


### PR DESCRIPTION
Fixes the issue where the previous PR (#9912) didn't properly disable the windows-nightly workflow. The workflow was still being executed on every PR despite being intended to be disabled.