### PR TITLE
feat: add --auto-merge-resolve and --force-theirs flags to bit ci merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,7 +627,7 @@ jobs:
       - run: cd bit && npm run generate-core-aspects-ids
       - run:
           name: 'bit ci merge'
-          command: 'cd bit && bit ci merge --build ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual ${BIT_CI_MERGE_EXTRA_FLAGS}'
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=32000


### PR DESCRIPTION
## Summary

Add support for `--auto-merge-resolve` and `--force-theirs` flags to the `bit ci merge` command, providing more flexible merge conflict resolution strategies during CI operations.

## Changes

- **Added `--auto-merge-resolve` flag** with support for `ours`, `theirs`, and `manual` strategies
- **Added `--force-theirs` flag** to overwrite with incoming files without merging
- **Implemented conflict detection** for manual merge strategy with clear user guidance
- **Updated default behavior** to preserve backward compatibility while enabling new options
- **Updated CircleCI config** to use `--auto-merge-resolve manual` for safer merge operations