### PR TITLE
fix: add retry logic for npm 409 publish conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,6 +611,9 @@ jobs:
     environment:
       BIT_FEATURES: cloud-importer-v2
       NODE_OPTIONS: --max-old-space-size=30000
+      # NPM 409 conflict retry settings
+      BIT_PUBLISH_RETRY_ATTEMPTS: "5"       # 5 retry attempts for 409 npm registry conflicts
+      BIT_PUBLISH_RETRY_DELAY: "8000"       # 8 seconds initial retry delay with exponential backoff
     steps:
       - attach_workspace:
           at: ./
@@ -627,7 +630,8 @@ jobs:
       - run: cd bit && npm run generate-core-aspects-ids
       - run:
           name: 'bit ci merge'
-          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          # command: 'cd bit && bit ci merge --build --auto-merge-resolve manual ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual --increment-by 3 ${BIT_CI_MERGE_EXTRA_FLAGS}'
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=32000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,9 +611,6 @@ jobs:
     environment:
       BIT_FEATURES: cloud-importer-v2
       NODE_OPTIONS: --max-old-space-size=30000
-      # NPM 409 conflict retry settings
-      BIT_PUBLISH_RETRY_ATTEMPTS: "5"       # 5 retry attempts for 409 npm registry conflicts
-      BIT_PUBLISH_RETRY_DELAY: "8000"       # 8 seconds initial retry delay with exponential backoff
     steps:
       - attach_workspace:
           at: ./

--- a/scopes/pkg/pkg/publisher.ts
+++ b/scopes/pkg/pkg/publisher.ts
@@ -62,55 +62,41 @@ export class Publisher {
     let lastError: ComponentResult | null = null;
 
     for (let attempt = 1; attempt <= PUBLISH_RETRY_ATTEMPTS; attempt++) {
-      try {
-        const result = await this.publishOneCapsule(capsule);
+      const result = await this.publishOneCapsule(capsule);
 
-        // If publish succeeded (no errors), return the result
-        if (!result.errors || result.errors.length === 0) {
-          if (attempt > 1) {
-            this.logger.info(`Successfully published ${capsule.component.id.toString()} on attempt ${attempt}`);
-          }
-          return result;
+      // If publish succeeded (no errors), return the result
+      if (!result.errors || result.errors.length === 0) {
+        if (attempt > 1) {
+          this.logger.info(`Successfully published ${capsule.component.id.toString()} on attempt ${attempt}`);
         }
+        return result;
+      }
 
-        // Check if error is specifically related to npm registry conflicts (409, packument)
-        const errorMessage = result.errors ? result.errors.join(', ') : 'Unknown error';
-        const is409Error =
-          errorMessage.includes('409') ||
-          errorMessage.includes('packument') ||
-          errorMessage.includes('Failed to save packument');
+      // Check if error is specifically related to npm registry conflicts (409, packument)
+      const errorMessage = result.errors ? result.errors.join(', ') : 'Unknown error';
+      const is409Error =
+        errorMessage.includes('409') ||
+        errorMessage.includes('packument') ||
+        errorMessage.includes('Failed to save packument');
 
-        if (!is409Error) {
-          // Not a 409 error, return immediately without retry
-          return result;
-        }
+      if (!is409Error) {
+        // Not a 409 error, return immediately without retry
+        return result;
+      }
 
-        // Store the error result for potential return
-        lastError = result;
+      // Store the error result for potential return
+      lastError = result;
 
-        if (attempt < PUBLISH_RETRY_ATTEMPTS) {
-          const delay = PUBLISH_RETRY_DELAY * Math.pow(2, attempt - 1); // Exponential backoff
-          this.logger.warn(
-            `npm 409 conflict for ${capsule.component.id.toString()}, retrying in ${delay}ms (attempt ${attempt}/${PUBLISH_RETRY_ATTEMPTS}). Error: ${errorMessage}`
-          );
-          await this.sleep(delay);
-        } else {
-          this.logger.error(
-            `Failed to publish ${capsule.component.id.toString()} after ${PUBLISH_RETRY_ATTEMPTS} attempts due to npm registry conflicts`
-          );
-        }
-      } catch (error) {
-        this.logger.error(
-          `Unexpected error during publish attempt ${attempt} for ${capsule.component.id.toString()}: ${error}`
+      if (attempt < PUBLISH_RETRY_ATTEMPTS) {
+        const delay = PUBLISH_RETRY_DELAY * Math.pow(2, attempt - 1); // Exponential backoff
+        this.logger.warn(
+          `npm 409 conflict for ${capsule.component.id.toString()}, retrying in ${delay}ms (attempt ${attempt}/${PUBLISH_RETRY_ATTEMPTS}). Error: ${errorMessage}`
         );
-        // For unexpected errors, don't retry
-        return {
-          component: capsule.component,
-          metadata: {},
-          errors: [`Unexpected error: ${error}`],
-          startTime: Date.now(),
-          endTime: Date.now(),
-        };
+        await this.sleep(delay);
+      } else {
+        this.logger.error(
+          `Failed to publish ${capsule.component.id.toString()} after ${PUBLISH_RETRY_ATTEMPTS} attempts due to npm registry conflicts`
+        );
       }
     }
 


### PR DESCRIPTION
## Problem
During `bit ci merge`, npm publishing fails with 409 Conflict errors when multiple `@teambit` components are published in parallel:
```
npm error 409 Conflict - PUT https://registry.npmjs.org/@teambit%2fgraph - Failed to save packument. A common cause is if you try to publish a new package before the previous package has been fully processed.
```

## Solution
- **Maintain parallel publishing performance** (10 concurrent publishes)
- **Add smart retry logic** specifically for npm 409 registry conflicts  
- **Use exponential backoff** to avoid overwhelming npm registry
- **Configurable retry settings** via environment variables
