### PR TITLE
feat: add conditional execution for CLI reference generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -620,6 +620,13 @@ jobs:
       - run:
           name: setting npmjs registry with publishing permission
           command: echo "//registry.npmjs.org/:_authToken=${npmjsRegistryToken}" >> ~/.npmrc
+      - run:
+          name: If no component has changed, exit the job
+          command: |
+            if cd bit && bit diff | grep -q "there are no modified components to diff"; then
+              echo "No changes detected, halting job to prevent further workflow execution."
+              circleci-agent step halt
+            fi
       - run: cd bit && npm run generate-cli-reference
       - run: cd bit && npm run generate-cli-reference-json
       - run: cd bit && npm run generate-cli-reference-docs


### PR DESCRIPTION
This PR prevents unnecessary version bumps to `teambit.harmony/bit` by conditionally skipping CLI reference generation when no components have been modified.

## Problem
Previously, the `npm run generate-cli-reference-docs` step would always modify the `teambit.harmony/content/cli-reference` component, even when no actual component changes existed. This caused the subsequent `bit ci merge` to create unnecessary new tags for `teambit.harmony/bit` (which depends on the cli-reference component), resulting in version bumps on every CI run regardless of actual changes.

## Solution
- Added conditional check using `bit diff` to detect when no components have changed
- Skip CLI reference generation and halt the job gracefully using `circleci-agent step halt` when no changes are detected
- Prevents the expensive `bit ci merge` operation from running unnecessarily

## Benefits
- Eliminates spurious version bumps to `teambit.harmony/bit`
- Prevents unnecessary tags when no actual component changes exist
- Reduces the frequency of expensive `bit ci merge` operations
- Maintains proper semantic versioning by only bumping versions when components actually change