### PR TITLE
fix(linter): support async version for linter

### DIFF
--- a/scopes/defender/linter/linter.service.ts
+++ b/scopes/defender/linter/linter.service.ts
@@ -82,8 +82,8 @@ export class LinterService implements EnvService<LintResults> {
     );
   }
 
-  render(env: EnvDefinition) {
-    const descriptor = this.getDescriptor(env);
+  async render(env: EnvDefinition) {
+    const descriptor = await this.getDescriptor(env);
     const name = `${chalk.green('configured linter:')} ${descriptor?.id} (${descriptor?.displayName} @ ${
       descriptor?.version
     })`;
@@ -102,7 +102,7 @@ export class LinterService implements EnvService<LintResults> {
     };
   }
 
-  getDescriptor(env: EnvDefinition) {
+  async getDescriptor(env: EnvDefinition) {
     if (!env.env.getLinter) return undefined;
     const mergedOpts = this.optionsWithDefaults({});
     const linterContext = this.mergeContext(mergedOpts);
@@ -112,7 +112,7 @@ export class LinterService implements EnvService<LintResults> {
       id: linter.id,
       icon: linter.icon,
       config: linter.displayConfig ? linter.displayConfig() : undefined,
-      version: linter.version ? linter.version() : '?',
+      version: linter.version ? await linter.version() : '?',
       displayName: linter.displayName ? linter.displayName : '?',
     };
   }

--- a/scopes/defender/linter/linter.ts
+++ b/scopes/defender/linter/linter.ts
@@ -170,7 +170,7 @@ export interface Linter {
   /**
    * returns the version of the current linter instance (e.g. '4.0.1').
    */
-  version?(): string;
+  version?(): string | Promise<string>;
 
   /**
    * returns the display name of the current linter instance (e.g. 'ESlint')

--- a/scopes/envs/envs/env-service-list.ts
+++ b/scopes/envs/envs/env-service-list.ts
@@ -14,18 +14,20 @@ export class EnvServiceList {
     readonly services: [string, EnvService<any>][]
   ) {}
 
-  toObject() {
+  async toObject() {
     return {
       env: this.env.toObject(),
-      services: this.services.map(([id, service]) => {
-        return {
-          id,
-          name: service.name,
-          description: service.description,
-          // @ts-ignore
-          data: service.getDescriptor(this.env),
-        };
-      }),
+      services: await Promise.all(
+        this.services.map(async ([id, service]) => {
+          return {
+            id,
+            name: service.name,
+            description: service.description,
+            // @ts-ignore
+            data: await service.getDescriptor(this.env),
+          };
+        })
+      ),
     };
   }
 }

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -549,7 +549,7 @@ export class EnvsMain {
     if (!envDef) return undefined;
 
     const rawServices = await this.getServices(envDef);
-    const services = rawServices.toObject();
+    const services = await rawServices.toObject();
     // const selfDescriptor = (await this.getEnvDescriptorFromEnvDef(envDef)) || {};
     const selfDescriptor = await this.getEnvDescriptorFromEnvDef(envDef);
 

--- a/scopes/envs/envs/envs.cmd.ts
+++ b/scopes/envs/envs/envs.cmd.ts
@@ -59,7 +59,7 @@ export class GetEnvCmd implements Command {
     const env = this.envs.getEnv(component);
     const envRuntime = await this.envs.createEnvironment([component]);
     const envExecutionContext = envRuntime.getEnvExecutionContext();
-    const services = this.envs.getServices(env);
+    const services = await this.envs.getServices(env);
     const allP = services.services.map(async ([serviceId, service]) => {
       if (servicesArr && !servicesArr.includes(serviceId)) return null;
       const serviceTitle = chalk.cyan.bold.underline(serviceId);


### PR DESCRIPTION
This change updates the linter to support an asynchronous `version()` method. This allows linters to fetch their version information dynamically.