### PR TITLE
fix: prevent build from including dependents through non-workspace components

### DIFF
--- a/components/legacy/e2e-helper/e2e-npm-helper.ts
+++ b/components/legacy/e2e-helper/e2e-npm-helper.ts
@@ -33,9 +33,18 @@ export default class NpmHelper {
    * Add a fake package, don't really install it. if you need the real package
    * use installNpmPackage below
    */
-  addFakeNpmPackage(name = 'lodash.get', version = '4.4.2') {
-    const packageJsonFixture = JSON.stringify({ name, version });
-    this.fs.createFile(`node_modules/${name}`, 'index.js');
-    this.fs.createFile(`node_modules/${name}`, 'package.json', packageJsonFixture);
+  addFakeNpmPackage(name = 'lodash.get', version = '4.4.2', isComp = false) {
+    const obj: any = { name, version };
+    if (isComp) {
+      const [, ...rest] = name.split('/');
+      obj.componentId = {
+        scope: this.scopes.remote,
+        name: rest.join('/'),
+        version,
+      };
+    }
+    const packageJsonFixture = JSON.stringify(obj, null, 2);
+    this.fs.outputFile(`node_modules/${name}/index.js`, '');
+    this.fs.outputFile(`node_modules/${name}/package.json`, packageJsonFixture);
   }
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -673,13 +673,14 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
   async getDependentsIds(ids: ComponentID[], filterOutNowWorkspaceIds = true): Promise<ComponentID[]> {
     const graph = await this.getGraphIds();
     const dependents = ids
-      .map((id) => graph.predecessors(id.toString()))
+      .map((id) =>
+        graph.predecessors(id.toString(), {
+          nodeFilter: (node) => (filterOutNowWorkspaceIds ? this.hasId(node.attr) : true),
+        })
+      )
       .flat()
       .map((node) => node.attr);
-    const uniqIds = ComponentIdList.uniqFromArray(dependents);
-    if (!filterOutNowWorkspaceIds) return uniqIds;
-    const workspaceIds = this.listIds();
-    return uniqIds.filter((id) => workspaceIds.has(id));
+    return ComponentIdList.uniqFromArray(dependents);
   }
 
   public async createAspectList(extensionDataList: ExtensionDataList) {


### PR DESCRIPTION
This fix addresses a bug where the build command was incorrectly including dependents through non-workspace components.

**Problem:** When a component was modified, the build would include not only direct dependents in the workspace but also dependents that were connected through components not present in the workspace.

**Solution:** Modified the `getDependentsIds` method in the workspace to use a `nodeFilter` that ensures only workspace components are considered when traversing the dependency graph.

**Test:** Added comprehensive E2E test that validates the fix by creating a scenario where comp1 depends on comp2, comp2 depends on comp3, but only comp1 and comp3 are imported to the workspace. When comp3 is modified, only comp3 should be built (not comp1).