### PR TITLE
fix(isolator): disable getExistingAsIs when capsule directory missing

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -649,7 +649,7 @@ export class IsolatorMain {
     }
 
     const config = { installPackages: true, ...opts };
-    if (!(await fs.pathExists(capsulesDir)) && opts.getExistingAsIs) {
+    if (opts.getExistingAsIs && !(await fs.pathExists(capsulesDir))) {
       this.logger.console(
         `💡 Capsules directory not found: ${capsulesDir}. Automatically setting getExistingAsIs to false.`
       );

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -649,6 +649,12 @@ export class IsolatorMain {
     }
 
     const config = { installPackages: true, ...opts };
+    if (!(await fs.pathExists(capsulesDir)) && opts.getExistingAsIs) {
+      this.logger.console(
+        `💡 Capsules directory not found: ${capsulesDir}. Automatically setting getExistingAsIs to false.`
+      );
+      opts.getExistingAsIs = false;
+    }
     if (opts.emptyRootDir) {
       await fs.emptyDir(capsulesDir);
     }


### PR DESCRIPTION
Previously when running commands with `--reuse-capsules` (which sets `getExistingAsIs` to true), if the capsule directory didn't exist yet, the process would only create the capsules and return them without completing the full capsule preparation process (e.g., package installation wouldn't run).

This fix checks if the directory exists and automatically sets `getExistingAsIs` to false when the directory is missing, ensuring the complete capsule setup process runs correctly.