### PR TITLE
feat: upgrade open package from 7.x to 8.x and replace react-dev-utils/openBrowser

### DIFF
--- a/scopes/harmony/application/run.cmd.ts
+++ b/scopes/harmony/application/run.cmd.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import type { Command, CommandOptions } from '@teambit/cli';
 import type { Logger } from '@teambit/logger';
-import openBrowser from 'react-dev-utils/openBrowser';
+import open from 'open';
 import type { ApplicationMain } from './application.main.runtime';
 
 type RunOptions = {
@@ -85,7 +85,7 @@ export class RunCmd implements Command {
       this.logger.console(`${appName} app is running on ${url}`);
 
       if (!noBrowser && port) {
-        openBrowser(url);
+        await open(url);
       }
     } else if (port) {
       // New API - also open browser when port is available
@@ -93,7 +93,7 @@ export class RunCmd implements Command {
       // this.logger.console(`${appName} app is running on ${url}`);
 
       if (!noBrowser) {
-        openBrowser(url);
+        await open(url);
       }
     }
 

--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -159,7 +159,7 @@ export class ExportCmd implements Command {
       const prefix = shouldOpenBrowser ? 'Your browser has been opened to the following link' : 'Visit the link below';
       const msg = `\n\n${prefix} to track the progress of building the components in the cloud\n`;
       if (shouldOpenBrowser) {
-        open(rippleJobUrls[0], { url: true }).catch(() => {
+        open(rippleJobUrls[0]).catch(() => {
           /** it's ok, the user is instructed to open the browser manually */
         });
       }

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -2,7 +2,7 @@ import { BitError } from '@teambit/bit-error';
 import type { Command, CommandOptions } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { Logger } from '@teambit/logger';
-import openBrowser from 'react-dev-utils/openBrowser';
+import open from 'open';
 import chalk from 'chalk';
 import type { UiMain } from './ui.main.runtime';
 
@@ -108,7 +108,7 @@ export class StartCmd implements Command {
 Bit server is running on ${chalk.cyan(url)}`);
         spinnies.add('summary', { text: message, status: 'non-spinnable' });
         if (!noBrowser) {
-          openBrowser(url);
+          await open(url);
         }
         return undefined;
       })

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -506,7 +506,7 @@
         "npm": "6.14.17",
         "object-diff": "0.0.4",
         "object-hash": "2.1.1",
-        "open": "7.4.2",
+        "open": "8.4.2",
         "open-editor": "3.0.0",
         "ora": "5.4.1",
         "p-filter": "2.1.0",


### PR DESCRIPTION
This PR includes two main changes:

1. **Upgraded open package**: Updated from version 7.4.2 to 8.4.2 in workspace.jsonc
2. **Replaced openBrowser dependency**: Replaced all instances of 'react-dev-utils/openBrowser' with the 'open' package across multiple files

**Files modified:**
- `workspace.jsonc` - Updated open package version
- `scopes/harmony/application/run.cmd.ts` - Replaced openBrowser import and usage
- `scopes/scope/export/export-cmd.ts` - Updated open usage (removed url option)
- `scopes/ui-foundation/ui/start.cmd.tsx` - Replaced openBrowser import and usage