### PR TITLE
feat(mcp): add batch support to bit_component_details tool

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -211,7 +211,7 @@ In default mode, the server exposes a minimal set of essential tools focused on 
 
   - `bit_remote_search`: Search for components in remote scopes
   - `bit_workspace_info`: Get comprehensive workspace information including status, components list, apps, templates, and dependency graph
-  - `bit_component_details`: Get detailed information about a specific component including basic info and optionally its public API schema
+  - `bit_component_details`: Get detailed information about multiple components in parallel (up to 5 max) including basic info and optionally their public API schemas
   - `bit_create`: Create a new component (source files and config) using a template with proper argument validation and documentation
   - `bit_query`: Execute read-only Bit commands that safely inspect workspace and component state without making modifications
   - `bit_execute`: Execute any Bit command, including those that modify workspace or repository state (use with caution)
@@ -263,6 +263,44 @@ Search for multiple components in parallel for efficient discovery:
 - Layout components: `["header", "navigation", "footer"]`
 - Data display: `["table", "pagination", "filter", "sort"]`
 - Button variations: `["button", "btn", "click"]`
+
+### bit_component_details
+
+Get detailed information about multiple components in parallel (limited to 5 components max to prevent context overload):
+
+```json
+{
+  "componentIds": ["acme.design/ui/button", "acme.design/forms/input"],
+  "includeSchema": true,
+  "cwd": "/path/to/workspace"
+}
+```
+
+**Parameters:**
+
+- `componentIds` (required): Array of component IDs to get details for. Limited to 5 components max. Use full component IDs (e.g., `acme.design/ui/button`)
+- `cwd` (required): Path to workspace directory
+- `includeSchema` (optional): Include component public API schema (default: false)
+
+**Examples:**
+
+- Multiple UI components: `{"componentIds": ["acme.design/ui/button", "acme.design/ui/input", "acme.design/ui/dropdown"], "cwd": "/path/to/workspace"}`
+- With schema information: `{"componentIds": ["teambit.base-ui/navigation/link"], "includeSchema": true, "cwd": "/path/to/workspace"}`
+- Form components batch: `{"componentIds": ["acme.forms/input", "acme.forms/validation", "acme.forms/submit-button"], "cwd": "/path/to/workspace"}`
+
+**Response Format:**
+
+The tool returns a structured response with:
+
+- `summary`: Statistics about the request (requested, successful, failed counts)
+- `components`: Object containing successful component details keyed by component ID
+- `failures`: Object containing error messages for failed components (if any)
+
+**Error Handling:**
+
+- Returns error if more than 5 components are requested
+- Individual component failures don't block the entire request
+- Clear error messages indicate which specific components failed and why
 
 ### bit_create
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -941,26 +941,119 @@ export class CliMcpServerMain {
   private registerComponentDetailsTool(server: McpServer) {
     const toolName = 'bit_component_details';
     const description =
-      'Get detailed information about a specific component including basic info and optionally its public API schema';
+      'Get detailed information about multiple components in parallel. Supports batch requests for efficient component discovery. Limited to 5 components max to prevent context overload.';
     const schema: Record<string, any> = {
       cwd: z.string().describe('Path to workspace directory'),
-      componentName: z.string().describe('Component name or component ID to get details for'),
+      componentIds: z
+        .array(z.string())
+        .describe(
+          'Array of component IDs to get details for. Limited to 5 components max. Examples: ["acme.design/ui/button", "acme.design/forms/input", "teambit.base-ui/navigation/link"]'
+        ),
       includeSchema: z.boolean().optional().describe('Include component public API schema (default: false)'),
     };
 
     server.tool(toolName, description, schema, async (params: any) => {
       try {
-        const includeSchema = params.includeSchema === true;
-        const componentName = params.componentName;
+        // Validate that componentIds parameter is provided and valid
+        if (!params.componentIds || !Array.isArray(params.componentIds) || params.componentIds.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: componentIds parameter must be provided as a non-empty array of component IDs. Example: ["acme.design/ui/button", "acme.design/forms/input"]',
+              },
+            ],
+          };
+        }
 
-        // Get component details using IDE API with includeSchema parameter
-        const ideApiResult = await this.callBitServerIDEAPI(
-          'getCompDetails',
-          [componentName, includeSchema],
-          params.cwd
+        const includeSchema = params.includeSchema === true;
+        const componentIds = params.componentIds;
+
+        // Check limit of 5 components to prevent context overload
+        const maxComponents = 5;
+
+        if (componentIds.length > maxComponents) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: Too many components requested. Maximum allowed is ${maxComponents} components, but ${componentIds.length} were requested. Please reduce the number of components in your request.`,
+              },
+            ],
+          };
+        }
+
+        // Execute component detail requests in parallel
+        this.logger.debug(
+          `[MCP-DEBUG] Fetching details for ${componentIds.length} component(s) in parallel: ${componentIds.join(', ')}`
         );
 
-        return this.formatAsCallToolResult(ideApiResult);
+        const detailPromises = componentIds.map(async (componentId: string) => {
+          try {
+            const result = await this.callBitServerIDEAPI('getCompDetails', [componentId, includeSchema], params.cwd);
+            return {
+              componentId,
+              success: true,
+              details: result,
+            };
+          } catch (error) {
+            this.logger.warn(
+              `[MCP-DEBUG] Failed to get details for component "${componentId}": ${(error as Error).message}`
+            );
+            return {
+              componentId,
+              success: false,
+              error: (error as Error).message,
+            };
+          }
+        });
+
+        const detailResults = await Promise.all(detailPromises);
+
+        // Process and consolidate results
+        const successfulResults = detailResults.filter((r) => r.success);
+        const failedResults = detailResults.filter((r) => !r.success);
+
+        if (successfulResults.length === 0) {
+          let message = 'Failed to get details for any components';
+          if (failedResults.length > 0) {
+            message += '\n\nErrors:';
+            failedResults.forEach((r) => {
+              message += `\n- "${r.componentId}": ${r.error}`;
+            });
+          }
+          return { content: [{ type: 'text', text: message }] };
+        }
+
+        // Build the response
+        const response: any = {
+          summary: {
+            requested: componentIds.length,
+            successful: successfulResults.length,
+            failed: failedResults.length,
+            includeSchema,
+          },
+          components: {},
+        };
+
+        // Add successful component details
+        successfulResults.forEach((result) => {
+          response.components[result.componentId] = result.details;
+        });
+
+        // Add failed components info if any
+        if (failedResults.length > 0) {
+          response.failures = {};
+          failedResults.forEach((result) => {
+            response.failures[result.componentId] = result.error;
+          });
+        }
+
+        this.logger.debug(
+          `[MCP-DEBUG] Component details fetched: ${successfulResults.length} successful, ${failedResults.length} failed`
+        );
+
+        return this.formatAsCallToolResult(response);
       } catch (error) {
         this.logger.error(`[MCP-DEBUG] Error in bit_component_details tool: ${(error as Error).message}`);
         return this.formatErrorAsCallToolResult(error as Error, 'getting component details');

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
@@ -188,14 +188,14 @@ describe('CliMcpServer Integration Tests', function () {
   });
 
   describe('bit_component_details tool', () => {
-    it('should get component details for an existing component', async () => {
-      const firstComponentId = 'comp1';
+    it('should get component details for multiple components', async () => {
+      const componentIds = ['comp1', 'comp2'];
 
       const result = (await mcpClient.callTool({
         name: 'bit_component_details',
         arguments: {
           cwd: workspacePath,
-          componentName: firstComponentId,
+          componentIds,
           includeSchema: false,
         },
       })) as CallToolResult;
@@ -205,18 +205,21 @@ describe('CliMcpServer Integration Tests', function () {
       expect(result.content[0]).to.have.property('type', 'text');
 
       const content = JSON.parse((result.content[0] as any).text);
-      expect(content).to.have.property('id');
-      expect(content).to.have.property('env');
+      expect(content).to.have.property('summary');
+      expect(content).to.have.property('components');
+      expect(content.summary).to.have.property('requested', 2);
+      expect(content.summary).to.have.property('successful');
+      expect(content.components).to.be.an('object');
     });
 
     it('should get component details with schema', async () => {
-      const firstComponentId = 'comp1';
+      const componentIds = ['comp1'];
 
       const result = (await mcpClient.callTool({
         name: 'bit_component_details',
         arguments: {
           cwd: workspacePath,
-          componentName: firstComponentId,
+          componentIds,
           includeSchema: true,
         },
       })) as CallToolResult;
@@ -226,8 +229,13 @@ describe('CliMcpServer Integration Tests', function () {
       expect(result.content[0]).to.have.property('type', 'text');
 
       const content = JSON.parse((result.content[0] as any).text);
-      expect(content).to.have.property('id');
-      expect(content).to.have.property('publicAPI');
+      expect(content).to.have.property('summary');
+      expect(content).to.have.property('components');
+      expect(content.summary.includeSchema).to.be.true;
+      if (content.summary.successful > 0) {
+        const firstComponent = Object.values(content.components)[0] as any;
+        expect(firstComponent).to.have.property('publicAPI');
+      }
     });
 
     it('should handle non-existent component gracefully', async () => {
@@ -235,7 +243,7 @@ describe('CliMcpServer Integration Tests', function () {
         name: 'bit_component_details',
         arguments: {
           cwd: workspacePath,
-          componentName: 'non-existent/component',
+          componentIds: ['non-existent/component'],
         },
       })) as CallToolResult;
 
@@ -243,9 +251,56 @@ describe('CliMcpServer Integration Tests', function () {
       expect(result.content).to.be.an('array');
       expect(result.content[0]).to.have.property('type', 'text');
 
-      // Should return error information or component details
+      const responseText = (result.content[0] as any).text;
+
+      // Try to parse as JSON first
+      try {
+        const content = JSON.parse(responseText);
+        // Should have summary with failed components
+        expect(content).to.have.property('summary');
+        expect(content.summary).to.have.property('failed');
+        expect(content.summary.failed).to.be.greaterThan(0);
+      } catch {
+        // If not JSON, should be an error message string
+        expect(responseText).to.be.a('string');
+        expect(responseText).to.include('Failed to get details for any components');
+      }
+    });
+
+    it('should reject requests with more than 5 components', async () => {
+      const tooManyComponents = ['comp1', 'comp2', 'comp3', 'comp4', 'comp5', 'comp6'];
+
+      const result = (await mcpClient.callTool({
+        name: 'bit_component_details',
+        arguments: {
+          cwd: workspacePath,
+          componentIds: tooManyComponents,
+        },
+      })) as CallToolResult;
+
+      expect(result).to.have.property('content');
+      expect(result.content).to.be.an('array');
+      expect(result.content[0]).to.have.property('type', 'text');
+
       const content = (result.content[0] as any).text;
-      expect(content).to.be.a('string');
+      expect(content).to.include('Too many components requested');
+      expect(content).to.include('Maximum allowed is 5');
+    });
+
+    it('should require componentIds parameter', async () => {
+      try {
+        await mcpClient.callTool({
+          name: 'bit_component_details',
+          arguments: {
+            cwd: workspacePath,
+            // Missing componentIds parameter
+          },
+        });
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).to.include('componentIds');
+        expect(error.message).to.include('Required');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Enhance bit_component_details tool to support multiple component IDs in parallel
- Limit to 5 components max to prevent context overload  
- Strict validation with clear error messages when limits exceeded
- Individual component failures don't block entire requests

## Changes
- Change parameter from `componentName` (string) to `componentIds` (array)
- Add parallel processing using Promise.all() similar to remote search
- Enhanced error handling with per-component failure tracking
- Updated examples to use full component IDs (e.g., acme.design/ui/button)