### PR TITLE
feat(mcp): add external package manager support to MCP rules

### DIFF
--- a/components/mcp/mcp-config-writer/bit-git-rules-template.md
+++ b/components/mcp/mcp-config-writer/bit-git-rules-template.md
@@ -45,6 +45,11 @@ This is the decision-making process for executing any Bit operation.
   - **For Read-Only Operations, use `bit_query`**: Use this for operations that inspect state but do not change the workspace.
   - **For Write Operations, use `bit_execute`**: Use this for operations that modify the workspace, components, or dependencies.
 
+## Installation Commands
+
+- Use `bit install` to install dependencies
+- **Exception**: If the workspace configuration has `externalPackageManager: true` in the dependency-resolver extension, DO NOT use `bit install`. Instead use your configured package manager (npm, yarn, or pnpm) and run it directly in the terminal.
+
 ### Step 2: Check for Terminal Exceptions
 
 - The following commands have rich, interactive, or streaming output and should be run directly in the user's terminal. You should construct the command and advise the user to run it.


### PR DESCRIPTION
## Summary

Add conditional installation instructions to MCP rule templates to support external package manager mode.

When `externalPackageManager: true` is set in workspace config, AI assistants will use npm/yarn/pnpm instead of `bit install`.

## Changes

- Added "Installation Commands" section with conditional logic to rule templates
- Simple approach that AI can interpret dynamically without complex processing