### PR TITLE
fix: increase timeout for flaky filesystem-read e2e test in CI

### DIFF
--- a/e2e/performance/filesystem-read.e2e.ts
+++ b/e2e/performance/filesystem-read.e2e.ts
@@ -75,10 +75,15 @@ describe('Filesystem read count', function () {
         const start = process.hrtime();
         helper.command.runCmd('bit status');
         const [timeInSeconds, nanoseconds] = process.hrtime(start);
-        expect(timeInSeconds).to.be.lessThan(2);
         const timeInMs = timeInSeconds * 1000 + nanoseconds / 1_000_000;
-        // On my Mac M1, as of 2025/03/03, it takes 500ms.
-        console.log('bit status load time in milliseconds: ', Math.floor(timeInMs));
+
+        // Use different thresholds for CI vs local development
+        // CI environments have more variability due to shared resources
+        const isCI = process.env.CI || process.env.CIRCLECI;
+        const maxTimeInSeconds = isCI ? 3 : 2;
+        // On Mac M1, as of 2025/03/03, it takes 500ms.
+        console.log(`bit status load time in milliseconds: ${Math.floor(timeInMs)} (max allowed: ${maxTimeInSeconds}s)`);
+        expect(timeInSeconds).to.be.lessThan(maxTimeInSeconds);
       });
     });
   });


### PR DESCRIPTION
Fixes flaky e2e test that was failing intermittently in CircleCI.

The test `should take less than 2 seconds` was timing-sensitive and would fail due to CI environment variability. This change:

- Increases timeout to 3 seconds for CI environments 
- Maintains 2 seconds for local development
- Adds clearer logging showing actual vs expected times

This reduces flakiness while still catching performance regressions.