### PR TITLE
Fix shared object references in package.json properties across components

### DIFF
--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -335,8 +335,12 @@ export class PkgMain {
   async mergePackageJsonProps(component: Component): Promise<PackageJsonProps> {
     let newProps: PackageJsonProps = {};
     const mergeToNewProps = (otherProps: PackageJsonProps) => {
+      // Deep clone otherProps to prevent shared object references between components.
+      // Without this, nested objects (like exports) can be unintentionally shared across different components,
+      // causing modifications to one component's package.json to leak into others.
+      const otherPropsCloned = JSON.parse(JSON.stringify(otherProps));
       const files = [...(newProps.files || []), ...(otherProps.files || [])];
-      const merged = { ...newProps, ...otherProps };
+      const merged = { ...newProps, ...otherPropsCloned };
       if (files.length) merged.files = files;
       return merged;
     };


### PR DESCRIPTION
## Description:
This PR fixes a critical bug where package.json properties were being unintentionally shared between components that use the same environment during the build process.

##  Problem
When an environment defines package.json properties (like `exports["."].require: './dist/{main}.js'`) with placeholders, these properties were being shared across all components
  using that environment. This caused the placeholder replacement for the first component to
  permanently modify the template, affecting all subsequent components.

##  For example:
  - Environment defines: `exports["."].require: './dist/{main}.js'`
  - First component (main file: index.ts) processes and replaces `{main}` → `./dist/index.js`
  - Second component teambit.legacy/constants (main file: constants.ts) incorrectly gets
  `./dist/index.js` instead of `./dist/constants.js`

##  Root Cause
The mergeToNewProps function was using shallow object spread (`...otherProps`) which preserved references to nested objects. When placeholder replacement modified these nested objects, it was modifying the shared reference used by all components.

##  Solution
Added deep cloning via `JSON.parse(JSON.stringify())` when merging package.json properties to ensure each component gets its own independent copy of the configuration objects.