### PR TITLE
fix: use workspace root for doctor archive when run from nested directory

### DIFF
--- a/scopes/harmony/doctor/doctor.main.runtime.ts
+++ b/scopes/harmony/doctor/doctor.main.runtime.ts
@@ -239,7 +239,8 @@ export class DoctorMain {
       return false;
     };
 
-    const myPack = tarFS.pack('.', {
+    const workspaceRoot = consumerInfo?.path || '.';
+    const myPack = tarFS.pack(workspaceRoot, {
       ignore,
       finalize: false,
       finish: packExamineResults,


### PR DESCRIPTION
## Summary

Fixes an issue where `bit doctor --archive` creates a tar file with only the contents of the current directory when run from a nested folder instead of archiving the entire workspace.

The problem was that the code used `tarFS.pack('.')` which packs from the current working directory. Now it uses the workspace root path obtained from `getWorkspaceInfo()`.