### PR TITLE
fix: use port range [user_port, user_port + 100] when single port is busy

### DIFF
--- a/scopes/toolbox/network/get-port/get-port.ts
+++ b/scopes/toolbox/network/get-port/get-port.ts
@@ -114,7 +114,7 @@ export class Port {
 
   static getPortFromRange(range: number[] | number, usedPort?: number[]) {
     const port = new Port();
-    const portsRange = typeof range === 'number' ? [range] : port.makeRange(range[0], range[1]);
+    const portsRange = typeof range === 'number' ? port.makeRange(range, range + 100) : port.makeRange(range[0], range[1]);
     return port.get({ port: portsRange, usedPort });
   }
 }


### PR DESCRIPTION
## Summary
Fix port selection logic in `bit start --port` command to use a reasonable range [user_port, user_port + 100] when the specified port is busy, instead of falling back to random high-numbered ports.

## Problem
When running `bit start --port 3000` and port 3000 is busy, the system would select a random high port number (e.g., 62683) instead of trying nearby ports.

## Solution  
Modified `Port.getPortFromRange()` in `scopes/toolbox/network/get-port/get-port.ts` to create a 100-port range starting from the user-specified port when a single port number is provided.

## Test Plan
- [x] Verified `bit start --port 3000` with port 3000 busy now selects port 3001
- [x] Verified `bit start --port 3050` with port 3050 available selects port 3050
- [x] Confirmed range stays within [user_port, user_port + 100] bounds