### PR TITLE
fix: display file path when running 'bit mcp-server rules' command

### DIFF
--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1536,6 +1536,27 @@ export class CliMcpServerMain {
     return McpConfigWriter.getDefaultRulesContent(consumerProject, process.cwd(), forceStandard);
   }
 
+  /**
+   * Get the path to the rules file based on editor type and scope
+   */
+  getRulesFilePath(editor: string, isGlobal: boolean, workspaceDir?: string): string {
+    const editorLower = editor.toLowerCase();
+
+    if (editorLower === 'vscode') {
+      return McpConfigWriter.getVSCodePromptsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'cursor') {
+      return McpConfigWriter.getCursorPromptsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'roo') {
+      return McpConfigWriter.getRooCodePromptsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'cline') {
+      return McpConfigWriter.getClinePromptsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'claude-code') {
+      return McpConfigWriter.getClaudeCodePromptsPath(isGlobal, workspaceDir);
+    }
+
+    throw new Error(`Editor "${editor}" is not supported yet for rules files.`);
+  }
+
   static slots = [];
   static dependencies = [CLIAspect, LoggerAspect];
   static runtime = MainRuntime;

--- a/scopes/mcp/cli-mcp-server/rules-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/rules-cmd.ts
@@ -83,7 +83,13 @@ export class McpRulesCmd implements Command {
         );
       }
 
-      return chalk.green(`✓ Successfully wrote ${editorName} Bit MCP rules file (${scope})`);
+      // Get the file path for the rules file to show user where it was written
+      const rulesPath = this.mcpServerMain.getRulesFilePath(editor, isGlobal);
+
+      return chalk.green(
+        `✓ Successfully wrote ${editorName} Bit MCP rules file (${scope})\n` +
+        `  File written to: ${chalk.cyan(rulesPath)}`
+      );
     } catch (error) {
       const editorName = this.mcpServerMain.getEditorDisplayName(editor);
       return chalk.red(`Error writing ${editorName} rules file: ${(error as Error).message}`);


### PR DESCRIPTION
## Summary
- Enhanced the `bit mcp-server rules` command to display the file path where rules are written
- Now all editors (Cursor, VS Code, Roo, Cline, etc.) show the path consistently, similar to how the `setup` command works