### PR TITLE
fix: add IDE-specific frontmatter to MCP rules files

### DIFF
--- a/components/mcp/mcp-config-writer/bit-git-rules-template.md
+++ b/components/mcp/mcp-config-writer/bit-git-rules-template.md
@@ -1,7 +1,3 @@
----
-applyTo: '**'
----
-
 # Bit MCP Agent Instructions (Git-Integrated Workflow)
 
 ## Core Objectives

--- a/components/mcp/mcp-config-writer/bit-rules-consumer-template.md
+++ b/components/mcp/mcp-config-writer/bit-rules-consumer-template.md
@@ -1,7 +1,3 @@
----
-applyTo: '**'
----
-
 ## How to Install and Use Bit Components
 
 - Bit Components are reusable pieces of code in the form of node packages.

--- a/components/mcp/mcp-config-writer/bit-rules-template.md
+++ b/components/mcp/mcp-config-writer/bit-rules-template.md
@@ -1,7 +1,3 @@
----
-applyTo: '**'
----
-
 # Bit MCP Agent Instructions
 
 ## Core Objectives

--- a/components/mcp/mcp-config-writer/mcp-config-writer.ts
+++ b/components/mcp/mcp-config-writer/mcp-config-writer.ts
@@ -524,9 +524,17 @@ export class McpConfigWriter {
     // Ensure directory exists
     await fs.ensureDir(path.dirname(promptsPath));
 
-    // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
-    await fs.writeFile(promptsPath, rulesContent);
+    // Get base rules content
+    const baseRulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
+    
+    // Add VS Code frontmatter
+    const vscodeRulesContent = `---
+applyTo: '**'
+---
+
+${baseRulesContent}`;
+
+    await fs.writeFile(promptsPath, vscodeRulesContent);
   }
 
   /**
@@ -541,9 +549,18 @@ export class McpConfigWriter {
     // Ensure directory exists
     await fs.ensureDir(path.dirname(promptsPath));
 
-    // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
-    await fs.writeFile(promptsPath, rulesContent);
+    // Get base rules content
+    const baseRulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
+    
+    // Add Cursor frontmatter
+    const cursorRulesContent = `---
+description: Bit MCP Agent Instructions
+Always: true
+---
+
+${baseRulesContent}`;
+
+    await fs.writeFile(promptsPath, cursorRulesContent);
   }
 
   /**
@@ -558,7 +575,7 @@ export class McpConfigWriter {
     // Ensure directory exists
     await fs.ensureDir(path.dirname(promptsPath));
 
-    // Write rules content
+    // Get base rules content - Roo Code doesn't require frontmatter
     const rulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
     await fs.writeFile(promptsPath, rulesContent);
   }
@@ -575,9 +592,18 @@ export class McpConfigWriter {
     // Ensure directory exists
     await fs.ensureDir(path.dirname(promptsPath));
 
-    // Write rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
-    await fs.writeFile(promptsPath, rulesContent);
+    // Get base rules content
+    const baseRulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
+    
+    // Add Cline frontmatter
+    const clineRulesContent = `---
+description: Bit MCP Agent Instructions
+tags: ["bit", "mcp", "component-development"]
+---
+
+${baseRulesContent}`;
+
+    await fs.writeFile(promptsPath, clineRulesContent);
   }
 
   /**
@@ -593,9 +619,9 @@ export class McpConfigWriter {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Get base rules content
-    const rulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
+    const baseRulesContent = await this.getDefaultRulesContent(consumerProject, workspaceDir, forceStandard);
 
-    // Add integration instructions at the top
+    // Add integration instructions at the top (Claude Code doesn't use frontmatter)
     const integrationInstructions = `<!--
 To use these Bit instructions, add the following to your main CLAUDE.md file:
 
@@ -606,7 +632,7 @@ This will automatically include all Bit-specific instructions in your Claude Cod
 
 `;
 
-    const finalContent = integrationInstructions + rulesContent;
+    const finalContent = integrationInstructions + baseRulesContent;
 
     // Write rules content with integration instructions
     await fs.writeFile(promptsPath, finalContent);


### PR DESCRIPTION
## Summary
- Fixes Cursor MCP rules integration by adding proper IDE-specific frontmatter
- Removes hardcoded VS Code frontmatter from template files  
- Adds dynamic frontmatter generation per IDE in writer methods

## Changes
- **Template files**: Removed VS Code-specific `applyTo: '**'` frontmatter
- **VS Code**: Adds `applyTo: '**'` frontmatter dynamically
- **Cursor**: Adds `description` + `Always: true` frontmatter for proper rule activation
- **Cline**: Adds `description` + `tags` frontmatter with relevant categorization  
- **Roo Code**: Uses plain markdown (no frontmatter required)
- **Claude Code**: Uses plain markdown with integration instructions

## Test Plan
- [ ] Test VS Code rules generation with correct `applyTo` frontmatter
- [ ] Test Cursor rules generation with `Always: true` to ensure rule activation
- [ ] Test Cline rules generation with proper tags
- [ ] Verify Roo Code and Claude Code generate plain markdown correctly
- [ ] Test that existing functionality remains unchanged

Resolves the issue where Cursor displayed "This rule may never be used since it has no description or auto attachments" for bit.rules.mdc files.