### PR TITLE
fix(isolator): only skip deps with successful build status

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1436,7 +1436,9 @@ export class IsolatorMain {
       }
 
       const isPublished = component.get('teambit.pkg/pkg')?.config?.packageJson?.publishConfig;
-      const canBeInstalled = host.isExported(component.id) && (remotes.isHub(component.id.scope) || isPublished);
+      const canBeInstalled = host.isExported(component.id)
+        && (remotes.isHub(component.id.scope) || isPublished)
+        && component.buildStatus === 'succeed';
 
       if (canBeInstalled) {
         this.logger.debug(`[OPTIMIZATION] Excluding unmodified exported dependency: ${componentIdStr}`);


### PR DESCRIPTION
When working on a lane with snapped components that failed to build on Ripple, running `bit build <component-id>` locally would error about unable to install the package (since the package doesn't exist due to build failure).

This fix ensures that dependencies are only skipped and installed as packages when they have a successful build status, allowing for proper local debugging.