### PR TITLE
fix: prevent capsule list crash when no workspace or scope exists

### DIFF
--- a/scopes/workspace/workspace/capsule.cmd.ts
+++ b/scopes/workspace/workspace/capsule.cmd.ts
@@ -122,6 +122,11 @@ export class CapsuleListCmd implements Command {
   ) {}
 
   async report() {
+    if (!this.workspace && !this.scope) {
+      throw new Error(`This command requires a Bit workspace or scope.
+To initialize a workspace: bit init`);
+    }
+
     const { workspaceCapsulesRootDir, scopeAspectsCapsulesRootDir, scopeCapsulesRootDir } = this.getCapsulesRootDirs();
     const listWs = workspaceCapsulesRootDir ? await this.isolator.list(workspaceCapsulesRootDir) : undefined;
     const listScope = await this.isolator.list(scopeAspectsCapsulesRootDir);
@@ -148,6 +153,11 @@ export class CapsuleListCmd implements Command {
   }
 
   async json() {
+    if (!this.workspace && !this.scope) {
+      throw new Error(`This command requires a Bit workspace or scope.
+To initialize a workspace: bit init`);
+    }
+
     const rootDirs = this.getCapsulesRootDirs();
     const listWs = rootDirs.workspaceCapsulesRootDir
       ? await this.isolator.list(rootDirs.workspaceCapsulesRootDir)


### PR DESCRIPTION
## Summary
• Fixes crash when running `bit capsule list` outside of workspace/scope
• Adds helpful error message guiding users to run `bit init`
• Prevents `Cannot read properties of undefined (reading 'getAspectCapsulePath')` error

## Root Cause
The `CapsuleListCmd` was registered even when no workspace or scope existed, but tried to access `scope.getAspectCapsulePath()` on undefined scope object.

## Solution
Added early validation in both `report()` and `json()` methods to throw informative error when neither workspace nor scope are available.