### PR TITLE
ci: reduce CircleCI resource class from 2xlarge to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -584,7 +584,9 @@ jobs:
 
   # ========== Bit CI Jobs ==========
   bit_pr:
-    resource_class: 2xlarge
+    # uncomment in case this job fails with "Killed".
+    # resource_class: 2xlarge
+    resource_class: xlarge
     <<: *defaults
     environment:
       # BIT_FEATURES: cloud-importer-v2
@@ -606,7 +608,9 @@ jobs:
           path: ~/Library/Caches/Bit/logs
 
   bit_merge:
-    resource_class: 2xlarge
+    # uncomment in case this job fails with "Killed".
+    # resource_class: 2xlarge
+    resource_class: xlarge
     <<: *defaults
     environment:
       BIT_FEATURES: cloud-importer-v2


### PR DESCRIPTION
Reduces CircleCI resource class from 2xlarge to xlarge for bit_pr and bit_merge jobs to optimize resource usage while maintaining build performance.

The previous 2xlarge configuration is preserved in comments for easy rollback if needed.