### PR TITLE
fix: remove npm dependency that conflicts with Husky pre-commit hook

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -542,7 +542,6 @@
         "node-fetch": "2.6.7",
         "node-source-walk": "4.2.0",
         "normalize-path": "3.0.0",
-        "npm": "6.14.17",
         "object-diff": "0.0.4",
         "object-hash": "2.1.1",
         "open": "8.4.2",


### PR DESCRIPTION
## Problem

The Husky pre-commit hook was not running properly due to a conflicting npm dependency. The `npm@6.14.17` package was being installed in `node_modules/.bin/` and taking precedence over the system npm when Husky's hook helper script executes.

## Root Cause

When Husky runs hooks, its helper script (`h`) adds `node_modules/.bin` to the beginning of the PATH. This caused the local npm@6.14.17 wrapper to be used instead of the system npm from NVM, which failed silently in the Git hook environment.

## Solution

Removed the `npm: "6.14.17"` dependency from `workspace.jsonc`. This allows the pre-commit hook to use the correct system npm and execute lint-staged properly.

## Test Plan

- [x] Verified pre-commit hook now runs successfully
- [x] Confirmed lint-staged executes on staged files during commits
- [x] No regression in build or dependency management