### PR TITLE
feat: add Slack notifications for master branch failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ master_only_filter: &master_only_filter
 
 orbs:
   win: circleci/windows@5.0
+  slack: circleci/slack@5.2.3
 
 # ========================================
 # COMMANDS
@@ -1102,6 +1103,22 @@ workflows:
             branches:
               only: master
           serial-group: "bit-merge-operations"
+          post-steps:
+            - slack/notify:
+                event: fail
+                custom: |
+                  {
+                    "text": "🚨 MASTER BRANCH FAILURE 🚨",
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "⚠️ *bit_merge failed on master branch*\nThis needs immediate attention!\n<${CIRCLE_BUILD_URL}|View Failed Build>"
+                        }
+                      }
+                    ]
+                  }
 
   # Nightly workflow
   nightly:


### PR DESCRIPTION
## Summary
- Added Slack orb (v5.2.3) to CircleCI configuration
- Configured failure-only notifications for bit_merge job on master branch
- Added prominent alert with 🚨 emoji for master failures

## Context
The existing webhook that was sending all build notifications (success and failure) has been disabled. This PR replaces it with targeted failure-only notifications specifically when the bit_merge job fails on master branch, ensuring only critical failures are reported to the #bit-ci channel.