### PR TITLE
feat(cli-mcp-server): restrict lane switch and merge commands to terminal execution

### DIFF
--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1354,13 +1354,13 @@ export class CliMcpServerMain {
           args = [commandParts[1], ...args];
         }
 
-        // Check for risky lane commands that should not be executed without user awareness
+        // Check for lane commands that modify workspace state and require direct user interaction
         if (command === 'lane') {
           const subcommand = args[0];
           if (subcommand === 'switch' || subcommand === 'merge') {
             return this.formatAsCallToolResult(
-              `Error: The "lane ${subcommand}" command is not available through the MCP server for safety reasons. ` +
-                `This command must be run directly in the terminal where the user can review and confirm the operation.`
+              `Error: The "lane ${subcommand}" command is not available through the MCP server. ` +
+                `This workspace-modifying operation must be run directly in the terminal where the user has full visibility and control.`
             );
           }
         }
@@ -1368,8 +1368,8 @@ export class CliMcpServerMain {
         // Also check for the shorthand 'switch' command (which is an alias for 'lane switch')
         if (command === 'switch') {
           return this.formatAsCallToolResult(
-            `Error: The "switch" command (alias for "lane switch") is not available through the MCP server for safety reasons. ` +
-              `This command must be run directly in the terminal where the user can review and confirm the operation.`
+            `Error: The "switch" command (alias for "lane switch") is not available through the MCP server. ` +
+              `This workspace-modifying operation must be run directly in the terminal where the user has full visibility and control.`
           );
         }
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1354,6 +1354,25 @@ export class CliMcpServerMain {
           args = [commandParts[1], ...args];
         }
 
+        // Check for risky lane commands that should not be executed without user awareness
+        if (command === 'lane') {
+          const subcommand = args[0];
+          if (subcommand === 'switch' || subcommand === 'merge') {
+            return this.formatAsCallToolResult(
+              `Error: The "lane ${subcommand}" command is not available through the MCP server for safety reasons. ` +
+                `This command must be run directly in the terminal where the user can review and confirm the operation.`
+            );
+          }
+        }
+
+        // Also check for the shorthand 'switch' command (which is an alias for 'lane switch')
+        if (command === 'switch') {
+          return this.formatAsCallToolResult(
+            `Error: The "switch" command (alias for "lane switch") is not available through the MCP server for safety reasons. ` +
+              `This command must be run directly in the terminal where the user can review and confirm the operation.`
+          );
+        }
+
         this.logger.debug(
           `[MCP-DEBUG] Executing command: ${command} with args: ${JSON.stringify(args)} and flags: ${JSON.stringify(flags)}`
         );


### PR DESCRIPTION
## Summary
- Added validation in the MCP execute tool to prevent execution of lane switch and merge commands
- Commands `lane switch`, `lane merge`, and `switch` (alias) are now restricted from MCP execution
- These commands must be run directly in the terminal for better user visibility and control

## Changes
- Modified `registerExecuteTool` method in `cli-mcp-server.main.runtime.ts` to check for and restrict lane switch/merge commands
- Returns clear error messages indicating these workspace-modifying operations must be run in the terminal

## Rationale
The `lane switch` and `lane merge` commands are heavy operations that modify workspace state. By restricting them to terminal execution, we ensure users have full visibility and control when these commands are run, as they will need to execute them directly in the terminal where they can review the operation and its effects.