### PR TITLE
fix: correct pattern matching in scope list and import commands

### DIFF
--- a/scopes/component/lister/list.cmd.ts
+++ b/scopes/component/lister/list.cmd.ts
@@ -87,7 +87,7 @@ use --outdated to highlight components that have newer versions available.`;
     const getNamespaceWithWildcard = () => {
       if (!namespace) return undefined;
       if (hasWildcard(namespace)) return namespace;
-      return `${namespace}/*`;
+      return `${namespace}/**`;
     };
     const namespacesUsingWildcards = getNamespaceWithWildcard();
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -814,7 +814,7 @@ export class ScopeMain implements ComponentFactory {
     includeDeleted = false
   ): Promise<Component[]> {
     const patternsWithScope =
-      (filter?.namespaces && filter?.namespaces.map((pattern) => `**/${pattern || '**'}`)) || undefined;
+      (filter?.namespaces && filter?.namespaces.map((pattern) => `${this.name}/${pattern || '**'}`)) || undefined;
     const componentsIds = await this.listIds(includeCache, includeFromLanes, patternsWithScope);
 
     const comps = await this.getMany(


### PR DESCRIPTION
## Summary
- Fixed scope pattern matching in `scope.list()` to use specific scope name instead of wildcard
- Fixed namespace filtering in `bit list` command to use recursive pattern `/**` instead of single level `/*`

## Problem
When importing components with patterns like `teambit.vite/examples/**`, components with nested namespaces like `teambit.vite/beta/vitest-4/examples/hello-world` were incorrectly being included. Similarly, the `bit list` command with `--namespace` flag was only showing direct children instead of all nested components.

## Solution
1. **scope.main.runtime.ts**: Changed pattern from `**/{pattern}` to `{scopeName}/{pattern}` to ensure only components from the requested scope are matched
2. **list.cmd.ts**: Changed namespace wildcard from `/*` to `/**` to recursively match all components under a namespace

## Test plan
- Run `bit import "teambit.vite/examples/**" -x` and verify only components directly under `examples/` are imported
- Run `bit list teambit.vite --namespace examples` and verify all components under the examples namespace are shown