### PR TITLE
refactor: replace memoizee with lighter alternatives

### DIFF
--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -7,7 +7,6 @@ import { ComponentID } from '@teambit/component-id';
 // which is crucial in this context as preview operates from the frontend where proxy and CA cert handling are not required
 // Reverting to cross-fetch restores correct handling of relative URLs, ensuring that previews render correctly
 import crossFetch from 'cross-fetch';
-import memoize from 'memoizee';
 import { debounce, intersection, isObject } from 'lodash';
 
 import { PreviewNotFound } from './exceptions';
@@ -17,6 +16,7 @@ import { ClickInsideAnIframeEvent } from './events';
 import type { ModuleFile, PreviewModule } from './types/preview-module';
 import { RenderingContext } from './rendering-context';
 import { fetchComponentAspects } from './gql/fetch-component-aspects';
+import { createInMemoryCache } from '@teambit/harmony.modules.in-memory-cache';
 import { PREVIEW_MODULES } from './preview-modules';
 import { loadScript, loadLink } from './html-utils';
 import { SizeEvent } from './size-event';
@@ -308,10 +308,22 @@ export class PreviewPreview {
     return componentPreview as Record<string, ModuleFile[]>;
   }
 
-  private getComponentAspects = memoize(fetchComponentAspects, {
-    max: 100,
-    maxAge: 12 * 60 * 60 * 1000,
+  // Use existing LRU cache with TTL for component aspects
+  private componentAspectsCache = createInMemoryCache<any>({
+    maxSize: 100,
+    maxAge: 12 * 60 * 60 * 1000, // 12 hours
   });
+
+  private getComponentAspects = async (componentId: string) => {
+    const cached = this.componentAspectsCache.get(componentId);
+    if (cached) {
+      return cached;
+    }
+
+    const result = await fetchComponentAspects(componentId);
+    this.componentAspectsCache.set(componentId, result);
+    return result;
+  };
 
   /**
    * register a new preview.

--- a/scopes/react/bit-react-transformer/bit-react-transformer.ts
+++ b/scopes/react/bit-react-transformer/bit-react-transformer.ts
@@ -1,6 +1,6 @@
 import type { Visitor, PluginObj, PluginPass, NodePath } from '@babel/core';
 import { readFileSync } from 'fs-extra';
-import memoize from 'memoizee';
+import { memoize } from 'lodash';
 import type * as Types from '@babel/types'; // @babel/types, not @types/babel!
 import type { ComponentMeta } from '@teambit/react.ui.highlighter.component-metadata.bit-component-meta';
 import {
@@ -36,11 +36,7 @@ export function createBitReactTransformer(api: Api, opts: BitReactTransformerOpt
     }
   }
 
-  const extractMeta = memoize(
-    (filePath: string) => componentMap?.[filePath] || metaFromPackageJson(filePath),
-    // optimize for string input:
-    { primitive: true }
-  );
+  const extractMeta = memoize((filePath: string) => componentMap?.[filePath] || metaFromPackageJson(filePath));
 
   function addComponentId(path: NodePath<any>, filePath: string, identifier: string) {
     // add meta property, e.g. `Button.__bit_component = __bit_component;`
@@ -146,7 +142,7 @@ export function createBitReactTransformer(api: Api, opts: BitReactTransformerOpt
     },
     post() {
       // reset memoization, in case any file changes between runs
-      extractMeta.clear();
+      extractMeta.cache.clear?.();
     },
   };
 


### PR DESCRIPTION
Replaces the heavy memoizee dependency (which brings in 100+ files from es5-ext) with lighter alternatives using existing packages in the project:

- **bit-react-transformer**: Use lodash.memoize for simple memoization
- **traverse-versions**: Replace 1ms TTL cache with WeakMap-based deduplication (more appropriate for preventing duplicate work during same operation)  
- **preview.runtime**: Use existing createInMemoryCache factory with LRU + 12-hour TTL

This eliminates the memoizee dependency while maintaining identical functionality and using the project's existing infrastructure.