### PR TITLE
fix: initialize sourcePatterns in tester context to prevent undefined error

### DIFF
--- a/scopes/defender/tester/tester.service.ts
+++ b/scopes/defender/tester/tester.service.ts
@@ -155,6 +155,7 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
       release: false,
       specFiles,
       patterns,
+      sourcePatterns: patterns,
       rootPath: this.workspace.path,
       workspace: this.workspace,
       debug: options.debug,


### PR DESCRIPTION
Fixes the issue where Jest tester with `useSourceFiles: true` crashes with `Cannot read properties of undefined (reading 'toArray')` during `bit test`.

## Problem
When Jest tester is configured with `useSourceFiles: true`, it expects `context.sourcePatterns` to be available. However, during `bit test`, the tester context only included `patterns` but not `sourcePatterns`, causing an undefined error. The `sourcePatterns` was only being populated during `bit build` task by the tester-task component.

## Solution
Initialize `sourcePatterns` in the tester service to default to the same value as `patterns`. This ensures:
- During `bit test`: `sourcePatterns` equals `patterns`, allowing jest-tester to work correctly with source files
- During `bit build`: The jest-tester-task can still override `sourcePatterns` with capsule-specific paths