### PR TITLE
fix: correct component count when new component depends on modified component

### DIFF
--- a/e2e/commands/tag.e2e.1.ts
+++ b/e2e/commands/tag.e2e.1.ts
@@ -177,4 +177,34 @@ describe('bit tag command', function () {
       expect(() => helper.command.tagAllWithoutBuild('-m ""')).to.not.throw();
     });
   });
+  describe('component count display when new component depends on existing tagged component', () => {
+    let output;
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      // Create and tag an existing component
+      helper.fs.createFile('components/comp1', 'comp1.js', 'module.exports = { test: true };');
+      helper.command.addComponent('components/comp1', { i: 'components/comp1' });
+      helper.command.tagAllWithoutBuild();
+
+      // Modify comp1 so it will be tagged again
+      helper.fs.createFile('components/comp1', 'comp1.js', 'module.exports = { test: true, modified: true };');
+
+      // Create a new component that depends on comp1
+      helper.fs.createFile('components/comp2', 'comp2.js', "const comp1 = require('../comp1/comp1');");
+      helper.command.addComponent('components/comp2', { i: 'components/comp2' });
+      helper.command.linkAndRewire();
+
+      // Tag all components - this should tag both comp2 (new) and comp1 (modified)
+      // comp2 should be auto-tagged because its dependency (comp1) changed
+      output = helper.command.tagAllWithoutBuild();
+    });
+    it('should correctly display 2 components tagged, not 3', () => {
+      // The output should show:
+      // - 1 new component (comp2)
+      // - 1 changed component (comp1) with auto-tagged dependents (comp2 should be listed)
+      // Total: 2 component(s) tagged (not 3)
+      expect(output).to.have.string('2 component(s) tagged');
+      expect(output).to.not.have.string('3 component(s) tagged');
+    });
+  });
 });

--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -143,13 +143,21 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
 }
 
 export function snapResultOutput(results: SnapResults): string {
-  const { snappedComponents, autoSnappedResults, warnings, newComponents, laneName, removedComponents }: SnapResults =
-    results;
+  const {
+    snappedComponents,
+    autoSnappedResults,
+    warnings,
+    newComponents,
+    laneName,
+    removedComponents,
+    totalComponentsCount,
+  }: SnapResults = results;
   const changedComponents = snappedComponents.filter((component) => {
     return !newComponents.searchWithoutVersion(component.id) && !removedComponents?.searchWithoutVersion(component.id);
   });
   const addedComponents = snappedComponents.filter((component) => newComponents.searchWithoutVersion(component.id));
   const autoTaggedCount = autoSnappedResults ? autoSnappedResults.length : 0;
+  const totalCount = totalComponentsCount ?? snappedComponents.length + autoTaggedCount;
 
   const warningsOutput = warnings && warnings.length ? `${chalk.yellow(warnings.join('\n'))}\n\n` : '';
   const snapExplanation = `\n(use "bit export" to push these components to a remote")
@@ -186,7 +194,7 @@ export function snapResultOutput(results: SnapResults): string {
     outputIfExists('changed components', 'components that got a version bump', changedComponents) +
     outputIdsIfExists('removed components', removedComponents) +
     warningsOutput +
-    chalk.green(`\n${snappedComponents.length + autoTaggedCount} component(s) snapped${laneStr}`) +
+    chalk.green(`\n${totalCount} component(s) snapped${laneStr}`) +
     snapExplanation
   );
 }

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -134,6 +134,7 @@ export type BasicTagResults = {
   warnings: string[];
   newComponents: ComponentIdList;
   removedComponents?: ComponentIdList;
+  totalComponentsCount?: number; // total count of all components tagged/snapped (including auto-tagged)
 };
 
 export type FileData = { path: string; content: string; delete?: boolean };
@@ -284,8 +285,14 @@ export class SnappingMain {
       overrideHead,
       loose,
     };
-    const { taggedComponents, autoTaggedResults, publishedPackages, stagedConfig, removedComponents } =
-      await this.makeVersion(compIds, components, params);
+    const {
+      taggedComponents,
+      autoTaggedResults,
+      publishedPackages,
+      stagedConfig,
+      removedComponents,
+      totalComponentsCount,
+    } = await this.makeVersion(compIds, components, params);
 
     const tagResults = {
       taggedComponents,
@@ -295,6 +302,7 @@ export class SnappingMain {
       warnings,
       newComponents,
       removedComponents,
+      totalComponentsCount,
     };
 
     await consumer.onDestroy(`tag (message: ${message || 'N/A'})`);
@@ -580,17 +588,15 @@ export class SnappingMain {
       detachHead,
       loose,
     };
-    const { taggedComponents, autoTaggedResults, stagedConfig, removedComponents } = await this.makeVersion(
-      ids,
-      components,
-      makeVersionParams
-    );
+    const { taggedComponents, autoTaggedResults, stagedConfig, removedComponents, totalComponentsCount } =
+      await this.makeVersion(ids, components, makeVersionParams);
 
     const snapResults: Partial<SnapResults> = {
       snappedComponents: taggedComponents,
       autoSnappedResults: autoTaggedResults,
       newComponents,
       removedComponents,
+      totalComponentsCount,
     };
 
     const currentLane = consumer.getCurrentLaneId();

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -253,11 +253,19 @@ semver allows the following options only: ${RELEASE_TYPES.join(', ')}`);
 }
 
 export function tagResultOutput(results: TagResults): string {
-  const { taggedComponents, autoTaggedResults, warnings, newComponents, removedComponents, exportedIds }: TagResults =
-    results;
+  const {
+    taggedComponents,
+    autoTaggedResults,
+    warnings,
+    newComponents,
+    removedComponents,
+    exportedIds,
+    totalComponentsCount,
+  }: TagResults = results;
   const changedComponents = taggedComponents.filter((component) => !newComponents.searchWithoutVersion(component.id));
   const addedComponents = taggedComponents.filter((component) => newComponents.searchWithoutVersion(component.id));
   const autoTaggedCount = autoTaggedResults ? autoTaggedResults.length : 0;
+  const totalCount = totalComponentsCount ?? taggedComponents.length + autoTaggedCount;
 
   const warningsOutput = warnings && warnings.length ? `${chalk.yellow(warnings.join('\n'))}\n\n` : '';
   const tagExplanationPersist = exportedIds
@@ -333,9 +341,7 @@ export function tagResultOutput(results: TagResults): string {
     exportedOutput() +
     warningsOutput +
     chalk.green(
-      `\n${taggedComponents.length + autoTaggedCount} component(s) ${results.isSoftTag ? 'soft-' : ''}tagged${
-        exportedIds ? ' and exported' : ''
-      }`
+      `\n${totalCount} component(s) ${results.isSoftTag ? 'soft-' : ''}tagged${exportedIds ? ' and exported' : ''}`
     ) +
     tagExplanation +
     softTagClarification

--- a/scopes/component/snapping/version-maker.ts
+++ b/scopes/component/snapping/version-maker.ts
@@ -104,6 +104,7 @@ export class VersionMaker {
     publishedPackages: string[];
     stagedConfig?: StagedConfig;
     removedComponents?: ComponentIdList;
+    totalComponentsCount?: number;
   }> {
     this.allWorkspaceComps = this.workspace ? await this.workspace.list() : undefined;
     const componentsToTag = this.getUniqCompsToTag();
@@ -136,6 +137,7 @@ export class VersionMaker {
         autoTaggedResults: autoTagData,
         publishedPackages: [],
         stagedConfig,
+        totalComponentsCount: this.allComponentsToTag.length,
       };
     }
 
@@ -202,6 +204,7 @@ export class VersionMaker {
       publishedPackages,
       stagedConfig,
       removedComponents,
+      totalComponentsCount: this.allComponentsToTag.length,
     };
   }
 


### PR DESCRIPTION
## Summary
Fixes incorrect component count display in `bit tag` and `bit snap` when a new component depends on a modified component.

## Problem
When tagging components, if a new component depends on a modified component, the new component appears in both:
- The "new components" section
- The "auto-tagged dependents" section under the modified component

This caused the total count to be inflated (e.g., showing "3 component(s) tagged" when only 2 components were actually tagged).

## Solution
Added a `totalComponentsCount` property to track the actual number of components tagged/snapped:
- Calculated from `allComponentsToTag.length` in version-maker, which already excludes duplicates
- Passed through the tag/snap pipeline
- Used in the output display with a fallback to the old calculation for backward compatibility