### PR TITLE
feat: add validate command

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -2032,6 +2032,20 @@
         "mainFile": "index.ts",
         "rootDir": "components/legacy/utils"
     },
+    "validator": {
+        "name": "validator",
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.defender",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.79": {},
+            "teambit.envs/envs": {
+                "env": "teambit.harmony/envs/core-aspect-env"
+            }
+        }
+    },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",

--- a/e2e/harmony/validate.e2e.ts
+++ b/e2e/harmony/validate.e2e.ts
@@ -1,0 +1,100 @@
+import chai, { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+import chaiFs from 'chai-fs';
+
+chai.use(chaiFs);
+
+describe('validate command', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('validating components without errors', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(1);
+    });
+    it('should pass all validation checks', () => {
+      const output = helper.command.runCmd('bit validate');
+      expect(output).to.include('1/3 Type Checking');
+      expect(output).to.include('2/3 Linting');
+      expect(output).to.include('3/3 Testing');
+      expect(output).to.include('All validation checks passed');
+    });
+  });
+
+  describe('validating components with type errors', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/comp1.ts', 'const x: number = "string";');
+    });
+    it('should fail at type checking step', () => {
+      const output = helper.general.runWithTryCatch('bit validate');
+      expect(output).to.include('1/3 Type Checking');
+      expect(output).to.include('Validation failed');
+      expect(output).to.not.include('2/3 Linting');
+    });
+  });
+
+  describe('validating components with lint errors', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(1);
+      // Create a real linting error (undefined variable)
+      helper.fs.outputFile('comp1/comp1.js', 'console.log(undefinedVariable);');
+    });
+    it('should fail at linting step', () => {
+      const output = helper.general.runWithTryCatch('bit validate');
+      expect(output).to.include('1/3 Type Checking');
+      expect(output).to.include('2/3 Linting');
+      expect(output).to.include('Validation failed');
+      expect(output).to.not.include('3/3 Testing');
+    });
+    it('should show the lint error details', () => {
+      const output = helper.general.runWithTryCatch('bit validate');
+      expect(output).to.include('error');
+    });
+  });
+
+  describe('validating with --all flag', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(2);
+    });
+    it('should validate all components', () => {
+      const output = helper.command.runCmd('bit validate --all');
+      expect(output).to.include('Validating 2 component(s)');
+      expect(output).to.include('All validation checks passed');
+    });
+  });
+
+  describe('validating with component pattern', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(2);
+    });
+    it('should validate only matching components', () => {
+      const output = helper.command.runCmd('bit validate comp1');
+      expect(output).to.include('Validating 1 component(s)');
+      expect(output).to.include('All validation checks passed');
+    });
+  });
+
+  describe('validating with no components', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+    });
+    it('should show no components message', () => {
+      const output = helper.command.runCmd('bit validate');
+      expect(output).to.include('No components found to validate');
+    });
+  });
+});

--- a/scopes/defender/validator/index.ts
+++ b/scopes/defender/validator/index.ts
@@ -1,0 +1,4 @@
+import { ValidatorAspect } from './validator.aspect';
+export type { ValidatorMain } from './validator.main.runtime';
+export { ValidatorAspect };
+export default ValidatorAspect;

--- a/scopes/defender/validator/validate.cmd.ts
+++ b/scopes/defender/validator/validate.cmd.ts
@@ -15,7 +15,10 @@ by default validates only new and modified components. use --all to validate all
   arguments = [{ name: 'component-pattern', description: COMPONENT_PATTERN_HELP }];
   alias = '';
   group = 'testing';
-  options = [['a', 'all', 'validate all components, not only modified and new']] as CommandOptions;
+  options = [
+    ['a', 'all', 'validate all components, not only modified and new'],
+    ['c', 'continue-on-error', 'run all validation checks even when errors are found'],
+  ] as CommandOptions;
 
   constructor(
     private validator: ValidatorMain,
@@ -23,7 +26,10 @@ by default validates only new and modified components. use --all to validate all
     private logger: Logger
   ) {}
 
-  async report([pattern]: [string], { all = false }: { all: boolean }) {
+  async report(
+    [pattern]: [string],
+    { all = false, continueOnError = false }: { all: boolean; continueOnError: boolean }
+  ) {
     if (!this.workspace) throw new OutsideWorkspaceError();
 
     this.logger.console(chalk.bold('\n🔍 Running validation checks...\n'));
@@ -38,7 +44,7 @@ by default validates only new and modified components. use --all to validate all
 
     this.logger.console(`Validating ${components.length} component(s)\n`);
 
-    const result = await this.validator.validate(components);
+    const result = await this.validator.validate(components, continueOnError);
     const totalTime = ((Date.now() - startTime) / 1000).toFixed(2);
 
     if (result.code !== 0) {

--- a/scopes/defender/validator/validate.cmd.ts
+++ b/scopes/defender/validator/validate.cmd.ts
@@ -1,0 +1,52 @@
+import type { Command, CommandOptions } from '@teambit/cli';
+import type { Logger } from '@teambit/logger';
+import type { Workspace } from '@teambit/workspace';
+import { OutsideWorkspaceError } from '@teambit/workspace';
+import chalk from 'chalk';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
+import type { ValidatorMain } from './validator.main.runtime';
+
+export class ValidateCmd implements Command {
+  name = 'validate [component-pattern]';
+  description = 'run type-checking, linting, and testing in sequence';
+  extendedDescription = `validates components by running check-types, lint, and test commands in sequence.
+stops at the first failure and returns a non-zero exit code.
+by default validates only new and modified components. use --all to validate all components.`;
+  arguments = [{ name: 'component-pattern', description: COMPONENT_PATTERN_HELP }];
+  alias = '';
+  group = 'testing';
+  options = [['a', 'all', 'validate all components, not only modified and new']] as CommandOptions;
+
+  constructor(
+    private validator: ValidatorMain,
+    private workspace: Workspace,
+    private logger: Logger
+  ) {}
+
+  async report([pattern]: [string], { all = false }: { all: boolean }) {
+    if (!this.workspace) throw new OutsideWorkspaceError();
+
+    this.logger.console(chalk.bold('\n🔍 Running validation checks...\n'));
+
+    const startTime = Date.now();
+    const components = await this.workspace.getComponentsByUserInput(pattern ? false : all, pattern, true);
+
+    if (components.length === 0) {
+      this.logger.console(chalk.yellow('No components found to validate'));
+      return { code: 0, data: 'No components found to validate' };
+    }
+
+    this.logger.console(`Validating ${components.length} component(s)\n`);
+
+    const result = await this.validator.validate(components);
+    const totalTime = ((Date.now() - startTime) / 1000).toFixed(2);
+
+    if (result.code !== 0) {
+      this.logger.console(chalk.red(`\n✗ Validation failed\n`));
+      return { code: result.code, data: `Validation failed after ${totalTime} seconds` };
+    }
+
+    this.logger.console(chalk.green(`\n✓ All validation checks passed in ${totalTime} seconds\n`));
+    return { code: 0, data: `Validation completed successfully in ${totalTime} seconds` };
+  }
+}

--- a/scopes/defender/validator/validator.aspect.ts
+++ b/scopes/defender/validator/validator.aspect.ts
@@ -1,0 +1,5 @@
+import { Aspect } from '@teambit/harmony';
+
+export const ValidatorAspect = Aspect.create({
+  id: 'teambit.defender/validator',
+});

--- a/scopes/defender/validator/validator.main.runtime.ts
+++ b/scopes/defender/validator/validator.main.runtime.ts
@@ -32,23 +32,29 @@ export class ValidatorMain {
     private logger: Logger
   ) {}
 
-  async validate(components: Component[]): Promise<ValidationResult> {
+  async validate(components: Component[], continueOnError = false): Promise<ValidationResult> {
     // Step 1: Check types
     this.logger.console(chalk.cyan('1/3 Type Checking...'));
     const checkTypesResult = await this.checkTypes(components);
     this.logger.console(checkTypesResult.message);
-    if (checkTypesResult.code !== 0) return checkTypesResult;
+    if (checkTypesResult.code !== 0 && !continueOnError) return checkTypesResult;
 
     // Step 2: Lint
     this.logger.console(chalk.cyan('\n2/3 Linting...'));
     const lintResult = await this.lint(components);
     this.logger.console(lintResult.message);
-    if (lintResult.code !== 0) return lintResult;
+    if (lintResult.code !== 0 && !continueOnError) return lintResult;
 
     // Step 3: Test
     this.logger.console(chalk.cyan('\n3/3 Testing...'));
     const testResult = await this.test(components);
     this.logger.console(testResult.message);
+
+    // When continueOnError is true, return the first error found, or success if all passed
+    if (continueOnError) {
+      if (checkTypesResult.code !== 0) return checkTypesResult;
+      if (lintResult.code !== 0) return lintResult;
+    }
     return testResult;
   }
 

--- a/scopes/defender/validator/validator.main.runtime.ts
+++ b/scopes/defender/validator/validator.main.runtime.ts
@@ -1,0 +1,146 @@
+import type { CLIMain } from '@teambit/cli';
+import { CLIAspect, MainRuntime } from '@teambit/cli';
+import type { LoggerMain, Logger } from '@teambit/logger';
+import { LoggerAspect } from '@teambit/logger';
+import type { Workspace } from '@teambit/workspace';
+import { WorkspaceAspect } from '@teambit/workspace';
+import type { TypescriptMain } from '@teambit/typescript';
+import { TypescriptAspect } from '@teambit/typescript';
+import type { LinterMain } from '@teambit/linter';
+import { LinterAspect } from '@teambit/linter';
+import type { TesterMain } from '@teambit/tester';
+import { TesterAspect } from '@teambit/tester';
+import type { Component } from '@teambit/component';
+import chalk from 'chalk';
+import { ValidatorAspect } from './validator.aspect';
+import { ValidateCmd } from './validate.cmd';
+
+export type ValidationResult = {
+  code: number;
+  message: string;
+};
+
+export class ValidatorMain {
+  static runtime = MainRuntime;
+  static dependencies = [CLIAspect, WorkspaceAspect, LoggerAspect, TypescriptAspect, LinterAspect, TesterAspect];
+
+  constructor(
+    private workspace: Workspace,
+    private typescript: TypescriptMain,
+    private linter: LinterMain,
+    private tester: TesterMain,
+    private logger: Logger
+  ) {}
+
+  async validate(components: Component[]): Promise<ValidationResult> {
+    // Step 1: Check types
+    this.logger.console(chalk.cyan('1/3 Type Checking...'));
+    const checkTypesResult = await this.checkTypes(components);
+    this.logger.console(checkTypesResult.message);
+    if (checkTypesResult.code !== 0) return checkTypesResult;
+
+    // Step 2: Lint
+    this.logger.console(chalk.cyan('\n2/3 Linting...'));
+    const lintResult = await this.lint(components);
+    this.logger.console(lintResult.message);
+    if (lintResult.code !== 0) return lintResult;
+
+    // Step 3: Test
+    this.logger.console(chalk.cyan('\n3/3 Testing...'));
+    const testResult = await this.test(components);
+    this.logger.console(testResult.message);
+    return testResult;
+  }
+
+  private async checkTypes(components: Component[]): Promise<ValidationResult> {
+    const files = this.typescript.getSupportedFilesForTsserver(components);
+
+    await this.typescript.initTsserverClientFromWorkspace(
+      { aggregateDiagnosticData: false, printTypeErrors: true },
+      files
+    );
+
+    const tsserver = this.typescript.getTsserverClient();
+    if (!tsserver) throw new Error('unable to start tsserver');
+
+    await tsserver.getDiagnostic(files);
+    const errorCount = tsserver.lastDiagnostics.length;
+    tsserver.killTsServer();
+
+    return {
+      code: errorCount > 0 ? 1 : 0,
+      message: errorCount > 0 ? `found errors in ${errorCount} files` : 'no type errors found',
+    };
+  }
+
+  private async lint(components: Component[]): Promise<ValidationResult> {
+    const linterResults = await this.linter.lint(components, {});
+
+    let totalErrors = 0;
+    let totalWarnings = 0;
+    const dirtyComponents: string[] = [];
+
+    linterResults.results.forEach((res) => {
+      if (res.data) {
+        const componentErrors = (res.data.totalErrorCount || 0) + (res.data.totalFatalErrorCount || 0);
+        totalErrors += componentErrors;
+        totalWarnings += res.data.totalWarningCount || 0;
+
+        // Show detailed output for components with errors
+        res.data.results.forEach((compResult) => {
+          const hasErrors = compResult.totalErrorCount > 0 || (compResult.totalFatalErrorCount || 0) > 0;
+          if (hasErrors && compResult.output) {
+            const compTitle = chalk.bold.cyan(compResult.component.id.toString({ ignoreVersion: true }));
+            dirtyComponents.push(`${compTitle}\n${compResult.output}`);
+          }
+        });
+      }
+    });
+
+    let message = '';
+    if (dirtyComponents.length > 0) {
+      message = dirtyComponents.join('\n\n') + '\n\n';
+    }
+    message +=
+      totalErrors > 0
+        ? `found ${totalErrors} error(s) and ${totalWarnings} warning(s)`
+        : totalWarnings > 0
+          ? `found ${totalWarnings} warning(s), no errors`
+          : 'no linting issues found';
+
+    return {
+      code: totalErrors > 0 ? 1 : 0,
+      message,
+    };
+  }
+
+  private async test(components: Component[]): Promise<ValidationResult> {
+    if (components.length === 0) {
+      return { code: 0, message: 'no components found to test' };
+    }
+
+    const tests = await this.tester.test(components, { watch: false, debug: false });
+    const hasErrors = tests.hasErrors();
+
+    return {
+      code: hasErrors ? 1 : 0,
+      message: hasErrors ? 'tests failed' : `all tests passed for ${components.length} component(s)`,
+    };
+  }
+
+  static async provider([cli, workspace, loggerAspect, typescript, linter, tester]: [
+    CLIMain,
+    Workspace,
+    LoggerMain,
+    TypescriptMain,
+    LinterMain,
+    TesterMain,
+  ]) {
+    const logger = loggerAspect.createLogger(ValidatorAspect.id);
+    const validator = new ValidatorMain(workspace, typescript, linter, tester, logger);
+    cli.register(new ValidateCmd(validator, workspace, logger));
+    return validator;
+  }
+}
+
+ValidatorAspect.addRuntime(ValidatorMain);

--- a/scopes/harmony/bit/manifests.ts
+++ b/scopes/harmony/bit/manifests.ts
@@ -49,6 +49,7 @@ import { WorkspaceConfigFilesAspect } from '@teambit/workspace-config-files';
 import { InstallAspect } from '@teambit/install';
 import { LinterAspect } from '@teambit/linter';
 import { FormatterAspect } from '@teambit/formatter';
+import { ValidatorAspect } from '@teambit/validator';
 import { ChangelogAspect } from '@teambit/changelog';
 import { CodeAspect } from '@teambit/code';
 import { CommandBarAspect } from '@teambit/command-bar';
@@ -125,6 +126,7 @@ export const manifestsMap = {
   [CompilerAspect.id]: CompilerAspect,
   [LinterAspect.id]: LinterAspect,
   [FormatterAspect.id]: FormatterAspect,
+  [ValidatorAspect.id]: ValidatorAspect,
   [ComponentAspect.id]: ComponentAspect,
   [MDXAspect.id]: MDXAspect,
   [ReadmeAspect.id]: ReadmeAspect,


### PR DESCRIPTION
Adds a new `bit validate` command that runs check-types, lint, and test in sequence.

- Created new validator aspect in `scopes/defender/validator`
- Command stops at first failure and returns non-zero exit code (use `--continue-on-error` to run all checks)
- Shows detailed error output for each validation step
- By default validates only new/modified components, use `--all` for all components

## Usage
```bash
bit validate                     # Validate modified/new components
bit validate --all               # Validate all components
bit validate --continue-on-error # Run all checks even when errors are found
bit validate [pattern]           # Validate specific components
```