### PR TITLE
fix: show error when --tasks flag doesn't match any tasks in build command

### DIFF
--- a/e2e/harmony/build-cmd.e2e.ts
+++ b/e2e/harmony/build-cmd.e2e.ts
@@ -299,6 +299,19 @@ describe('build command', function () {
       expect(output).to.have.string('Total 2 components to build');
     });
   });
+
+  describe('build with invalid --tasks flag', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+    });
+    it('should throw an error when --tasks does not match any available tasks', () => {
+      const output = helper.general.runWithTryCatch('bit build --tasks non-existent-task');
+      expect(output).to.have.string('Pipeline error - no tasks found matching the specified filter');
+      expect(output).to.have.string('non-existent-task');
+      expect(output).to.have.string('Available tasks:');
+    });
+  });
 });
 
 function getNodeEnvExtension() {


### PR DESCRIPTION
Fixes an issue where `bit build --tasks <non-existent-task>` would show a misleading success message instead of an error.

**Before:**
```
✔ Running build pipeline using 6 environment(s), total 0 tasks. Succeeded in 10s
```

**After:**
```
Pipeline error - no tasks found matching the specified filter: "non-existent-task". Available tasks: BabelCompile, JestTest, teambit.compilation/compiler, teambit.defender/tester, ...
```

**Changes:**
- Added validation in `calculatePipelineOrder()` to check if task filtering resulted in an empty queue
- Error message now shows which tasks were requested and lists all available tasks
- Added e2e test to verify the error is thrown correctly