### PR TITLE
fix: show deleted env as not loaded in bit envs command on lanes

### DIFF
--- a/e2e/harmony/lanes/lanes-with-issues.e2e.ts
+++ b/e2e/harmony/lanes/lanes-with-issues.e2e.ts
@@ -37,4 +37,54 @@ describe('lanes with various issues', function () {
       expect(() => helper.command.diffLane('main')).not.to.throw();
     });
   });
+  describe('issue - deleting a custom env on lane that is used by components', () => {
+    let envId: string;
+    let envName: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.workspaceJsonc.setPackageManager();
+      // Create a custom env
+      envName = helper.env.setCustomEnv();
+      envId = `${helper.scopes.remote}/${envName}`;
+      // Create some components that use the custom env
+      helper.fixtures.populateComponents(3);
+      helper.extensions.addExtensionToVariant('*', envId);
+      helper.command.compile();
+      // Tag and export on main
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      // Create a new lane
+      helper.command.createLane('dev');
+      // Snap all components and export
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      // Delete the env on the lane
+      helper.command.softRemoveOnLane(envName);
+    });
+    it('bit status should show an issue about the missing env', () => {
+      const status = helper.command.runCmd('bit status');
+      // The status should indicate something about the env being deleted or missing
+      // This could be a component issue or a status message
+      expect(status).to.satisfy((str: string) => {
+        return str.includes('deleted') || str.includes('missing') || str.includes('removed') || str.includes(envName);
+      });
+    });
+    it('components should show in status as having issues', () => {
+      const statusJson = helper.command.statusJson();
+      // Components should be listed with issues since their env is deleted
+      const hasIssues = statusJson.componentsWithIssues && statusJson.componentsWithIssues.length > 0;
+      expect(hasIssues).to.be.true;
+    });
+    it('bit envs should show the env as not loaded', () => {
+      const envsOutput = helper.command.envs();
+      expect(envsOutput).to.have.string('(not loaded)');
+      expect(envsOutput).to.have.string(envName);
+    });
+    it('bit envs should show a warning about not being able to load the env', () => {
+      const envsOutput = helper.command.envs();
+      expect(envsOutput).to.have.string('warning');
+      expect(envsOutput).to.have.string("bit wasn't able to load");
+      expect(envsOutput).to.have.string(envName);
+    });
+  });
 });

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -1014,6 +1014,30 @@ if needed, use "bit env set" command to align the env id`;
     return Boolean(this.envSlot.get(id));
   }
 
+  /**
+   * checks if an env component is removed/deleted.
+   */
+  public async isEnvRemoved(envId: ComponentID): Promise<boolean> {
+    try {
+      if (!envId.hasVersion()) return false;
+      const host = this.componentMain.getHost();
+      if (!host) return false;
+
+      const bitmapEntry = host.bitMap.getBitmapEntryIfExist(envId);
+      if (bitmapEntry && bitmapEntry.isRemoved()) return true;
+      if (bitmapEntry && bitmapEntry.isRecovered()) return false;
+
+      const modelComp = await host.scope.getBitObjectModelComponent(envId.changeVersion(undefined));
+      if (!modelComp) return false;
+
+      const isRemoved = await modelComp.isRemoved(host.scope.legacyScope.objects, envId.version as string);
+      return isRemoved;
+    } catch {
+      // If there's an error checking, assume it's not removed
+      return false;
+    }
+  }
+
   isUsingAspectEnv(component: Component): boolean {
     const data = this.getEnvData(component);
     if (!data) return false;

--- a/scopes/envs/envs/envs.cmd.ts
+++ b/scopes/envs/envs/envs.cmd.ts
@@ -116,7 +116,8 @@ environments control how components are built, tested, linted, and deployed.`;
       // const envId = this.envs.getEnvId(component);
       const envId = await this.envs.calculateEnvId(component);
       const envIdStr = envId.toString();
-      const isLoaded = this.envs.isEnvRegistered(envIdStr);
+      const isRemoved = await this.envs.isEnvRemoved(envId);
+      const isLoaded = this.envs.isEnvRegistered(envIdStr) && !isRemoved;
       if (!isLoaded) {
         this.nonLoadedEnvs.add(envIdStr);
       }


### PR DESCRIPTION
## Summary
Fixes an issue where `bit envs` command doesn't show deleted envs as "(not loaded)" when an env is deleted on a lane.

## Changes
- Added `isEnvRemoved()` method to detect if an env component is marked as deleted on a lane
- Modified `bit envs` command to check for removed envs before determining if they're loaded
- Added e2e test covering the scenario: create components with custom env, tag on main, create lane, snap, delete env on lane

## Test Plan
- Created e2e test that verifies `bit envs` shows deleted env as "(not loaded)" with warning message
- All existing tests pass