### PR TITLE
fix: stop loader before merge strategy prompt

### DIFF
--- a/scopes/component/modules/merge-helper/merge-version.ts
+++ b/scopes/component/modules/merge-helper/merge-version.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { BitError } from '@teambit/bit-error';
 import { prompt } from 'enquirer';
+import { loader } from '@teambit/legacy.loader';
 
 export const mergeOptionsCli = { o: 'ours', t: 'theirs', m: 'manual' };
 export const MergeOptions = { ours: 'ours', theirs: 'theirs', manual: 'manual' };
@@ -19,6 +20,7 @@ export const FileStatus = {
 };
 
 export async function getMergeStrategyInteractive(): Promise<MergeStrategy> {
+  loader.stop();
   try {
     const { mergeStrategy } = await prompt<{ mergeStrategy: 'o' | 't' | 'm' }>({
       type: 'select',


### PR DESCRIPTION
Fixes the issue where the loader spinner was still spinning when the merge strategy selection prompt appeared.

Added `loader.stop()` in `getMergeStrategyInteractive()` before showing the prompt to ensure the spinner stops before the user is asked to choose between "ours", "theirs", or "manual" merge strategies.