### PR TITLE
fix: preserve aspect data when applying merged config during snapFromScope

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -488,9 +488,9 @@ export class SnappingMain {
     // When merging main into a lane, if aspects data can be successfully merged (no conflicts), we skip the
     // expensive aspect loading process. Only components with data conflicts need full aspect loading.
     // NOTE: This means executeOnCompAspectReCalcSlot (which recalculates aspect data like packageName, dependencies, etc.)
-    // only runs for components in loadAspectOnlyForIds. Components not in this list rely on:
-    // 1. Their existing aspect data being preserved when the merged config is applied (see addAspectsFromConfigObject)
-    // 2. The addDeps() method updating the dependencies field with the calculated policy
+    // only runs for components in loadAspectOnlyForIds. Components not in this list rely on their existing aspect data
+    // from when the component was loaded from the scope. For extensions that are part of the merged config, their data
+    // is preserved by addAspectsFromConfigObject to prevent data loss during config merge.
     const { loadAspectOnlyForIds } = params;
     const compsToLoadAspects = loadAspectOnlyForIds
       ? components.filter((c) => loadAspectOnlyForIds.hasWithoutVersion(c.id))


### PR DESCRIPTION
## Summary

Fixes a bug where aspect data fields (like `packageName`, `componentRangePrefix`) were being lost during bare-scope lane merges.

## Root Cause

When merging lanes using bare-scope merge:
1. Components are loaded from scope with correct data ✅
2. Merged config is applied via `addAspectsFromConfigObject`
3. `ExtensionDataList.fromConfigObject` creates entries with only config, no data
4. When merging configs, the config-only entries overwrite existing entries that contain data ❌

## The Fix

Added code in `addAspectsFromConfigObject` to restore data fields from original extensions after merging configs:

```typescript
extensionDataList.forEach((ext) => {
  const originalExt = consumerComponent.extensions.findExtension(ext.stringId, true);
  if (originalExt && originalExt.data) {
    ext.data = originalExt.data;
  }
});
```

This ensures components that skip aspect loading (PR #9570 optimization) still have their data preserved.