### PR TITLE
fix: log error when http listing filters out components with missing versions

### DIFF
--- a/components/legacy/scope/repositories/sources.ts
+++ b/components/legacy/scope/repositories/sources.ts
@@ -130,7 +130,7 @@ export default class SourceRepository {
         return component;
       }
       const hash = component.getRef(bitId.version as string);
-      if (!hash) throw new Error(`sources.get: unable to get has for ${bitId.toString()}`);
+      if (!hash) throw new Error(`sources.get: unable to get hash for ${bitId.toString()}`);
       const hasLocalVersion = this.scope.stagedSnaps.has(hash.toString());
       if (hasLocalVersion) {
         // no point to go to the remote, it's local.

--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -47,7 +47,17 @@ export class ScopeComponentLoader {
       id = id.changeScope(this.scope.name);
       modelComponent = await this.scope.legacyScope.getModelComponentIfExist(id);
     }
-    if (!modelComponent) return undefined;
+
+    if (!modelComponent) {
+      if (this.scope.legacyScope.isLocal(id)) {
+        const existsWithoutVersion = await this.scope.legacyScope.getModelComponentIfExist(id.changeVersion(undefined));
+        const errMsg = existsWithoutVersion
+          ? `failed loading ${id.toString()}: the component exists but version ${id.version} is missing.`
+          : `failed loading ${id.toString()}: the component does not exist in the local scope.`;
+        this.logger.error(errMsg);
+      }
+      return undefined;
+    }
 
     const versionStr = id.hasVersion()
       ? (id.version as string)


### PR DESCRIPTION
## Summary

When listing components over HTTP protocol (bit list http-remote), components with missing version objects were silently filtered out without any error or warning, making it difficult to diagnose issues.

## Changes

- Add error logging in scope-component-loader when a ModelComponent exists but the requested version is missing
- Distinguish between two scenarios:
  - Component not found in local scope
  - Component exists but specific version is missing
- Fix typo in sources.ts error message (has → hash)

## Behavior

The component still gets filtered out from the listing (preserving existing behavior), but now the server logs an error explaining why, making it easier to diagnose missing version issues.

## Why Not Show Corrupted Components in the List?

We considered showing these components in `bit list` output with error labels (similar to [Deprecated] or [Deleted] labels), but decided against it because:

1. **Component validity**: Creating Component objects with null/invalid state would require guarding every code path that accesses `component.state`, making the codebase fragile and error-prone
2. **Clean architecture**: Component objects should always be valid and fully loaded. Mixing valid and invalid components creates complexity throughout the system
3. **Better alternative**: For users who need to diagnose scope issues, we're considering adding a check to `bit doctor` that can validate all components in a scope and report detailed integrity issues

The current approach keeps Component objects clean while still providing diagnostic information through server logs.