### PR TITLE
fix(delete): improve error and prompt messages for lane deletion

### DIFF
--- a/scopes/component/remove/delete-cmd.ts
+++ b/scopes/component/remove/delete-cmd.ts
@@ -74,14 +74,16 @@ to remove components from your local workspace only, use "bit remove" instead.`;
     }
   ) {
     if (this.workspace?.isOnLane() && !hard && !lane && !updateMain) {
-      throw new BitError(`error: to delete components when on a lane, use --lane flag`);
+      throw new BitError(`error: to delete components when on a lane, use either --lane or --update-main flag.
+--lane: delete the component from this lane only
+--update-main: delete the component from main after this lane is merged`);
     }
     if (this.workspace?.isOnMain() && updateMain) {
       throw new BitError(`--update-main is relevant only when on a lane`);
     }
 
     if (!silent) {
-      await this.removePrompt(hard, lane);
+      await this.removePrompt(hard, lane, updateMain);
     }
 
     if (hard) {
@@ -112,11 +114,19 @@ ${chalk.bold('to update the remote, please tag/snap and then export. to revert, 
     return removedObjectsArray.map((item) => removeTemplate(item, true));
   }
 
-  private async removePrompt(hard?: boolean, lane?: boolean) {
+  private async removePrompt(hard?: boolean, lane?: boolean, updateMain?: boolean) {
     this.remove.logger.clearStatusLine();
-    const laneOrMainWarning = lane
-      ? `this command will mark the component as removed from this lane, resetting the component to its pre-lane state and content (after tag/snap and export)`
-      : `this command will mark the component as deleted, and it won’t be visible on the remote scope (after tag/snap and export).`;
+
+    let laneOrMainWarning: string;
+    if (updateMain) {
+      laneOrMainWarning = `once this lane is merged, the component will be deleted from main (it won't be visible on the remote scope after tag/snap and export).
+if your intent was to undo all changes to this component done as part of the lane so the component in main will be intact, use --lane instead.`;
+    } else if (lane) {
+      laneOrMainWarning = `this command will mark the component as removed from this lane, resetting the component to its pre-lane state and content (after tag/snap and export)`;
+    } else {
+      laneOrMainWarning = `this command will mark the component as deleted, and it won't be visible on the remote scope (after tag/snap and export).`;
+    }
+
     const remoteOrLocalOutput = hard
       ? `WARNING: the component(s) will be permanently deleted from the remote with no option to recover. prefer omitting --hard to only mark the component as soft deleted`
       : `${laneOrMainWarning}


### PR DESCRIPTION
Enhances the error messages and prompts when deleting components on a lane:

**Error message improvements:**
- When on a lane without flags, now suggests both `--lane` and `--update-main` options with brief descriptions

**Prompt message improvements:**  
- When using `--update-main`, clarifies that the component will be deleted from main after the lane is merged
- Adds guidance to use `--lane` instead if the intent is to preserve the component in main