### PR TITLE
revert: install app dependencies workaround (PR #10040)

### DIFF
--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -978,21 +978,15 @@ export class InstallMain {
           (await this.app.listAppsComponents()).map(async (app) => {
             const appPkgName = this.dependencyResolver.getPackageName(app);
             const appManifest = Object.values(manifests).find(({ name }) => name === appPkgName);
-            if (!appManifest) {
-              // If the app doesn't have a manifest yet (e.g., not configured in workspace.jsonc),
-              // we still need to create a root manifest for it so its dependencies are installed
-              this.logger.debug(`app ${appPkgName} doesn't have a manifest, creating a basic one for root components`);
-            }
+            if (!appManifest) return null;
             const envId = await this.envs.calculateEnvId(app);
-            const envDependencies = await this._getEnvDependencies(envId);
-            const appDependencies = appManifest?.dependencies;
             return [
               await this.getRootComponentDirByRootId(this.workspace.rootComponentsPath, app.id),
               {
-                ...(appManifest ? omit(appManifest, ['name', 'version']) : {}),
+                ...omit(appManifest, ['name', 'version']),
                 dependencies: {
-                  ...envDependencies,
-                  ...appDependencies,
+                  ...(await this._getEnvDependencies(envId)),
+                  ...appManifest.dependencies,
                   ...workspaceDeps,
                 },
                 installConfig: {


### PR DESCRIPTION
Reverting PR #10040 since PR #10044 fixes the root cause by always loading components with seeders for dependency detection.

The workaround in #10040 is no longer needed as #10044 ensures that env detectors are properly available during install, fixing the Vue file dependency detection issue at its source.