### PR TITLE
perf: use Set for faster snap filtering in getDivergeDataBetweenTwoSnaps

### DIFF
--- a/scopes/component/snap-distance/get-diverge-data.ts
+++ b/scopes/component/snap-distance/get-diverge-data.ts
@@ -116,7 +116,9 @@ export function getDivergeDataBetweenTwoSnaps(
   let targetSubgraph = graph.successorsSubgraph(targetHead.toString(), { edgeFilter: (e) => e.attr === 'parent' });
   let sourceArr = sourceSubgraph.nodes.map((n) => n.id);
   let targetArr = targetSubgraph.nodes.map((n) => n.id);
-  let commonSnaps = sourceArr.filter((snap) => targetArr.includes(snap));
+
+  const targetSet = new Set(targetArr);
+  let commonSnaps = sourceArr.filter((snap) => targetSet.has(snap));
 
   if (!commonSnaps.length) {
     sourceSubgraph = graph.successorsSubgraph(localHead.toString());


### PR DESCRIPTION
Replace array `.includes()` with `Set.has()` for O(1) lookup when filtering common snaps between source and target subgraphs. This improves performance from O(n*m) to O(n+m) when computing diverge data.

The fix has been created by @guysaar223 