### PR TITLE
fix(scope): skip error log for new components without version

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -49,7 +49,7 @@ export class ScopeComponentLoader {
     }
 
     if (!modelComponent) {
-      if (this.scope.legacyScope.isLocal(id)) {
+      if (this.scope.legacyScope.isLocal(id) && id.hasVersion()) {
         const existsWithoutVersion = await this.scope.legacyScope.getModelComponentIfExist(id.changeVersion(undefined));
         const errMsg = existsWithoutVersion
           ? `failed loading ${id.toString()}: the component exists but version ${id.version} is missing.`


### PR DESCRIPTION
New components exist only in the workspace and don't have a version yet. The scope loader was incorrectly logging errors when trying to load these components, since the `isLocal` check passed but there was no version to look up.

Adding `id.hasVersion()` check prevents these spurious error logs for new components.