### PR TITLE
fix(deps): fallback to unversioned env path for root component dir

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -572,7 +572,7 @@ export class DependencyResolverMain {
     }
   ) {
     const envId = this.envs.getEnvId(component);
-    const envIdWithoutVersion = envId.split('@')[0];
+    const envIdWithoutVersion = ComponentID.fromString(envId).toStringWithoutVersion();
     const rootComponentsRelativePath = relative(options.workspacePath, options.rootComponentsPath);
     const rootComponentDirWithVersion = getRootComponentDir(rootComponentsRelativePath ?? '', envId);
     const rootComponentDirWithoutVersion = getRootComponentDir(rootComponentsRelativePath ?? '', envIdWithoutVersion);


### PR DESCRIPTION
Add fallback logic to check for env's root component directory without version suffix. If the unversioned path exists, use it instead of the versioned path.