### PR TITLE
chore: update use-lanes-menu component to 0.0.278

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -2488,7 +2488,7 @@
     "ui/menus/use-lanes-menu": {
         "name": "ui/menus/use-lanes-menu",
         "scope": "teambit.lanes",
-        "version": "0.0.277",
+        "version": "0.0.278",
         "mainFile": "index.ts",
         "rootDir": "components/ui/menus/use-lanes-menu"
     },


### PR DESCRIPTION
Update `teambit.lanes/ui/menus/use-lanes-menu` component to version 0.0.278 via `bit checkout head`.