### PR TITLE
feat(scope): add FetchVersionHistory action for lightweight version-history fetching

### DIFF
--- a/components/legacy/scope-api/lib/action.ts
+++ b/components/legacy/scope-api/lib/action.ts
@@ -8,6 +8,7 @@ import {
   FetchMissingDeps,
   PostSign,
   FetchMissingHistory,
+  FetchVersionHistory,
 } from '@teambit/scope.remote-actions';
 import type { AuthData } from '@teambit/scope.network';
 
@@ -36,6 +37,7 @@ export async function action(
     FetchMissingDeps,
     PostSign,
     FetchMissingHistory,
+    FetchVersionHistory,
   ];
   const ActionClass = actionList.find((a) => a.name === name);
   if (!ActionClass) {

--- a/scopes/scope/remote-actions/fetch-version-history.ts
+++ b/scopes/scope/remote-actions/fetch-version-history.ts
@@ -1,0 +1,33 @@
+import { ComponentIdList } from '@teambit/component-id';
+import type { Scope } from '@teambit/legacy.scope';
+import { logger } from '@teambit/legacy.logger';
+import type { Action } from './action';
+
+type Options = { ids: string[] };
+
+/**
+ * Fetches only the VersionHistory objects for components without fetching all Version objects.
+ * This is a lightweight alternative to FetchMissingHistory that doesn't block for long.
+ *
+ * Use this during export to quickly get the version-history graph, then run FetchMissingHistory
+ * asynchronously afterwards to get the full history.
+ */
+export class FetchVersionHistory implements Action<Options> {
+  async execute(scope: Scope, options: Options): Promise<void> {
+    logger.debugAndAddBreadCrumb('FetchVersionHistory', 'fetching version-history objects from original scopes');
+    const scopeComponentsImporter = scope.scopeImporter;
+    const bitIds: ComponentIdList = ComponentIdList.fromStringArray(options.ids);
+    const externals = bitIds.filter((bitId) => !scope.isLocal(bitId));
+    if (!externals.length) {
+      logger.debug('FetchVersionHistory, no external components, nothing to fetch');
+      return;
+    }
+    const externalIds = ComponentIdList.fromArray(externals);
+    await scopeComponentsImporter.importWithoutDeps(externalIds.toVersionLatest(), {
+      cache: false,
+      includeVersionHistory: true,
+      reason: 'fetching version-history objects for external components',
+    });
+    logger.debugAndAddBreadCrumb('FetchVersionHistory', 'completed successfully');
+  }
+}

--- a/scopes/scope/remote-actions/index.ts
+++ b/scopes/scope/remote-actions/index.ts
@@ -2,6 +2,7 @@ export { Action } from './action';
 export { ExportPersist } from './export-persist';
 export { ExportValidate } from './export-validate';
 export { FetchMissingHistory } from './fetch-missing-history';
+export { FetchVersionHistory } from './fetch-version-history';
 export { RemovePendingDir } from './remove-pending-dir';
 export { FetchMissingDeps } from './fetch-missing-deps';
 export { PostSign } from './post-sign';


### PR DESCRIPTION
Add a new `FetchVersionHistory` action that fetches only the VersionHistory object per component without fetching all Version objects.

**Why:** During export, `FetchMissingHistory` blocks while fetching the entire component history, which can take a long time for components with long history. This new action provides a lightweight alternative that only fetches the VersionHistory graph object.

**Key difference:**
- `FetchMissingHistory`: uses `collectParents: true` → fetches all Version objects (slow)
- `FetchVersionHistory`: uses only `includeVersionHistory: true` → fetches just the VersionHistory object (fast)