### PR TITLE
fix(compiler): copy transpileComponent output to all dist directories

### DIFF
--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -234,8 +234,12 @@ ${this.compileErrors.map(formatError).join('\n')}`);
           matches.map(async (match) => {
             const source = path.join(sourceDistDirAbs, match);
             const dest = path.join(distDirAbs, match);
-            await fs.ensureDir(path.dirname(dest));
-            await fs.copyFile(source, dest);
+            try {
+              await fs.ensureDir(path.dirname(dest));
+              await fs.copyFile(source, dest);
+            } catch (err: any) {
+              throw new Error(`failed to copy compiled file from "${source}" to "${dest}": ${err.message}`);
+            }
           })
         );
       })


### PR DESCRIPTION
Compilers using `transpileComponent` write directly to the filesystem with a single `outputDir`. After PR #10125 fixed the `outputDir` to use `bit_roots` for correct peer resolution, the compiled files were no longer available in `node_modules/<pkg>`.

This fix copies all compiled files from the `outputDir` to all other dist directories (injected dirs) after `transpileComponent` completes, ensuring bundlers like esbuild have their output available in all required locations.