### PR TITLE
fix(api-server): add auth headers to WebSocket proxy

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -191,6 +191,9 @@ export class ApiServerMain {
               proxyReq.setHeader(key, value);
             });
           },
+          error: (err) => {
+            this.logger.error('websocket cloud proxy error', err);
+          },
         },
         pathFilter: '/',
         target: symphonyUrl,


### PR DESCRIPTION
Forward authentication headers on WebSocket connections to cloud server using the `proxyReqWs` hook from http-proxy-middleware instead of manually handling server upgrade events.