### PR TITLE
fix(snap-distance): convert recursive traversal to iterative to prevent stack overflow

### DIFF
--- a/scopes/component/snap-distance/traverse-versions.ts
+++ b/scopes/component/snap-distance/traverse-versions.ts
@@ -283,15 +283,10 @@ export function getSubsetOfVersionParents(
 
   // Use iterative approach with a stack to avoid stack overflow on deep histories
   const stack: VersionParents[] = [head];
+  processedHashes.add(head.hash.toString());
 
   while (stack.length > 0) {
     const version = stack.pop()!;
-    const hashStr = version.hash.toString();
-
-    if (processedHashes.has(hashStr)) {
-      continue;
-    }
-    processedHashes.add(hashStr);
     results.push(version);
 
     // Add parents to stack in reverse order to maintain original traversal order
@@ -307,6 +302,8 @@ export function getSubsetOfVersionParents(
       }
       const parentVersion = getVersionParent(parent);
       if (parentVersion) {
+        // Mark as processed before pushing to prevent duplicate stack entries
+        processedHashes.add(parentHashStr);
         stack.push(parentVersion);
       }
     }

--- a/scopes/scope/objects/models/version-history.ts
+++ b/scopes/scope/objects/models/version-history.ts
@@ -122,15 +122,11 @@ export default class VersionHistory extends BitObject {
 
     // Use iterative approach with a stack to avoid stack overflow on deep histories
     const stack: VersionParents[] = [item];
+    hashSet.add(item.hash.toString());
 
     while (stack.length > 0) {
       const ver = stack.pop()!;
       const verHash = ver.hash.toString();
-
-      if (hashSet.has(verHash)) {
-        continue;
-      }
-      hashSet.add(verHash);
       allHashes.push(verHash);
 
       for (const parent of ver.parents) {
@@ -141,6 +137,8 @@ export default class VersionHistory extends BitObject {
           missing.push(parentHash);
           continue;
         }
+        // Mark as processed before pushing to prevent duplicate stack entries
+        hashSet.add(parentHash);
         stack.push(parentVer);
       }
     }


### PR DESCRIPTION
## Summary
- Convert recursive version history traversal to iterative approach using explicit stacks/queues
- Fixes "Maximum call stack size exceeded" error on repositories with deep version histories (2000+ versions)
- Also improves performance by using `Set<string>` for O(1) duplicate detection instead of array lookups

## Changes
- `getSubsetOfVersionParents`: recursive → iterative with stack
- `getAllVersionsInfo`: recursive → iterative with queue  
- `getAllHashesFrom`: recursive → iterative with stack