### PR TITLE
feat(export): add --allow-main flag to bypass lane requirement

### DIFF
--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -53,6 +53,7 @@ exporting is the final step after development and versioning to share components
       "don't throw an error when artifact files are missing. not recommended, unless you're sure the artifacts are in the remote",
     ],
     ['', 'fork-lane-new-scope', 'allow exporting a forked lane into a different scope than the original scope'],
+    ['', 'allow-main', 'EXPERIMENTAL. allow exporting directly to main (skip lane requirement on bit.cloud)'],
     ['', 'open-browser', 'open a browser once the export is completed in the cloud job url'],
     ['', 'verbose', 'per exported component, show the versions being exported'],
     ['j', 'json', 'show output in json format'],
@@ -74,6 +75,7 @@ exporting is the final step after development and versioning to share components
       resume,
       headOnly,
       forkLaneNewScope = false,
+      allowMain = false,
       openBrowser = false,
       verbose = false,
     }: any
@@ -97,6 +99,7 @@ exporting is the final step after development and versioning to share components
       headOnly,
       ignoreMissingArtifacts,
       forkLaneNewScope,
+      allowMainExport: allowMain,
     });
 
     if (isEmpty(componentsIds) && isEmpty(nonExistOnBitMap) && isEmpty(missingScope) && !exportedLanes.length) {
@@ -185,6 +188,7 @@ exporting is the final step after development and versioning to share components
       originDirectly = false,
       ignoreMissingArtifacts = false,
       resume,
+      allowMain = false,
     }: any
   ): Promise<ExportResult> {
     const results = await this.exportMain.export({
@@ -195,6 +199,7 @@ exporting is the final step after development and versioning to share components
       originDirectly,
       resumeExportId: resume,
       ignoreMissingArtifacts,
+      allowMainExport: allowMain,
     });
 
     return results;

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -70,6 +70,7 @@ export type PushToScopesParams = {
   includeParents?: boolean;
   filterOutExistingVersions?: boolean;
   exportOrigin?: ExportOrigin;
+  allowMainExport?: boolean;
 };
 type ObjectsPerRemoteExtended = ObjectsPerRemote & {
   objectListPerName: ObjectListPerName;
@@ -87,6 +88,7 @@ type ExportParams = {
   headOnly?: boolean;
   ignoreMissingArtifacts?: boolean;
   forkLaneNewScope?: boolean;
+  allowMainExport?: boolean;
 };
 
 export interface ExportResult {
@@ -276,6 +278,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     includeParents, // relevant when exportHeadsOnly is used. sometimes the parents head are needed as well
     filterOutExistingVersions, // go to the remote and check whether the version exists there. if so, don't export it
     exportOrigin = 'export',
+    allowMainExport,
   }: PushToScopesParams): Promise<PushToScopesResult> {
     this.logger.debug(`scope.exportMany, ids: ${ids.toString()}`);
     const scopeRemotes: Remotes = await getScopeRemotes(scope);
@@ -480,7 +483,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     const pushAllToCentralHub = async () => {
       const objectList = this.transformToOneObjectListWithScopeData(manyObjectsPerRemote);
       const http = await Http.connect(CENTRAL_BIT_HUB_URL, CENTRAL_BIT_HUB_NAME);
-      const pushResults = await http.pushToCentralHub(objectList, { origin: exportOrigin });
+      const pushResults = await http.pushToCentralHub(objectList, { origin: exportOrigin, allowMainExport });
       const { failedScopes, successIds, errors, metadata } = pushResults;
       if (failedScopes.length) {
         throw new PersistFailed(failedScopes, errors);

--- a/scopes/scope/network/http/http.ts
+++ b/scopes/scope/network/http/http.ts
@@ -73,6 +73,7 @@ export type PushCentralOptions = {
   origin: ExportOrigin;
   signComponents?: string[]; // relevant for bit-sign.
   idsHashMaps?: { [hash: string]: string }; // relevant for bit-sign. keys are the component hash, values are component-ids as strings
+  allowMainExport?: boolean; // allow exporting directly to main, bypassing the lane requirement
 
   /**
    * @deprecated prefer using "origin"


### PR DESCRIPTION
Adds a new `--allow-main` flag to `bit export` that allows exporting directly to main, bypassing the lane requirement enforced by bit.cloud.

By default, bit.cloud requires users to create a lane, snap, and merge. This flag provides an escape hatch for cases where direct export to main is needed.

**Usage:**
```bash
bit export --allow-main
```

The flag is passed to the central hub in the push options as `allowMainExport`.