### PR TITLE
fix(deps): prevent env tooling deps from polluting package.json in external PM mode

### DIFF
--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -229,7 +229,11 @@ export class InstallMain {
   async writeDependenciesToPackageJson(): Promise<void> {
     const installer = this.dependencyResolver.getInstaller({});
     const mergedRootPolicy = await this.addConfiguredAspectsToWorkspacePolicy();
-    await this.addConfiguredGeneratorEnvsToWorkspacePolicy(mergedRootPolicy);
+    // When using external package manager, don't add the env package itself.
+    // Users don't need the env installed - they manage their own tooling.
+    if (!this.dependencyResolver.config.externalPackageManager) {
+      await this.addConfiguredGeneratorEnvsToWorkspacePolicy(mergedRootPolicy);
+    }
     const componentsAndManifests = await this._getComponentsManifests(installer, mergedRootPolicy, {
       dedupe: true,
     });

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -2508,7 +2508,14 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
       ? Object.entries(dependencies).map(([name, currentRange]) => ({ name, currentRange }))
       : await this.getAllDedupedDirectDependencies();
     pkgJson.packageJsonObject.dependencies ??= {};
+    const existingDeps = pkgJson.packageJsonObject.dependencies;
+    const existingDevDeps = pkgJson.packageJsonObject.devDependencies ?? {};
+    const existingPeerDeps = pkgJson.packageJsonObject.peerDependencies ?? {};
     for (const dep of allDeps) {
+      // Skip if already exists - don't override user's existing dependency versions
+      if (existingDeps[dep.name] || existingDevDeps[dep.name] || existingPeerDeps[dep.name]) {
+        continue;
+      }
       pkgJson.packageJsonObject.dependencies[dep.name] = dep.currentRange;
     }
     await pkgJson.write();


### PR DESCRIPTION
## Summary

When using `externalPackageManager: true`, running `bit create` was adding ~40 env tooling dependencies (eslint, vitest, webpack, @types/*, etc.) to the user's package.json. These dependencies are needed for Bit-managed workspaces but should not be added when users manage their own package manager.

**Changes:**
- Skip adding env self peers (tooling deps) for external package manager mode
- Skip adding generator envs to workspace policy when writing to package.json
- Respect existing deps/devDeps/peerDeps - don't override user's versions

**Before:** `bit create react button` added 40+ dependencies to package.json
**After:** Only adds deps actually used by the component's source code