### PR TITLE
fix(init): add ws-config write to postinstall for external package manager mode

### DIFF
--- a/e2e/commands/init.e2e.1.ts
+++ b/e2e/commands/init.e2e.1.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import * as path from 'path';
 import { CURRENT_BITMAP_SCHEMA, SCHEMA_FIELD, InvalidBitMap } from '@teambit/legacy.bit-map';
 import { BIT_GIT_DIR, BIT_HIDDEN_DIR, BIT_MAP } from '@teambit/legacy.constants';
+import { EXTERNAL_PM_POSTINSTALL_SCRIPT } from '@teambit/host-initializer';
 import { Helper } from '@teambit/legacy.e2e-helper';
 import chaiFs from 'chai-fs';
 import assertArrays from 'chai-arrays';
@@ -320,7 +321,7 @@ describe('run bit init', function () {
       it('should create package.json with postinstall script', () => {
         const packageJson = helper.packageJson.read();
         expect(packageJson).to.have.property('scripts');
-        expect(packageJson.scripts).to.have.property('postinstall', 'bit link && bit compile');
+        expect(packageJson.scripts).to.have.property('postinstall', EXTERNAL_PM_POSTINSTALL_SCRIPT);
       });
     });
     describe('bit install in external package manager mode', () => {
@@ -354,7 +355,7 @@ describe('run bit init', function () {
         expect(workspaceConfig['teambit.dependencies/dependency-resolver']).to.have.property('rootComponent', false);
 
         const packageJson = helper.packageJson.read();
-        expect(packageJson.scripts).to.have.property('postinstall', 'bit link && bit compile');
+        expect(packageJson.scripts).to.have.property('postinstall', EXTERNAL_PM_POSTINSTALL_SCRIPT);
 
         // Test answering 'yes' to switch to Bit package manager
         const output = helper.command.runCmd('echo "y" | bit install');
@@ -415,7 +416,7 @@ describe('run bit init', function () {
         const packageJson = helper.packageJson.read();
         expect(packageJson.scripts).to.have.property('start', 'node index.js');
         expect(packageJson.scripts).to.have.property('build', 'webpack');
-        expect(packageJson.scripts).to.have.property('postinstall', 'bit link && bit compile');
+        expect(packageJson.scripts).to.have.property('postinstall', EXTERNAL_PM_POSTINSTALL_SCRIPT);
       });
       it('should add type module to existing package.json', () => {
         const packageJson = helper.packageJson.read();
@@ -478,7 +479,7 @@ describe('run bit init', function () {
 
         // Verify postinstall was added
         const packageJson = helper.packageJson.read();
-        expect(packageJson.scripts).to.have.property('postinstall', 'bit link && bit compile');
+        expect(packageJson.scripts).to.have.property('postinstall', EXTERNAL_PM_POSTINSTALL_SCRIPT);
 
         // Simulate removing only our postinstall script
         delete packageJson.scripts.postinstall;

--- a/scopes/harmony/host-initializer/create-consumer.ts
+++ b/scopes/harmony/host-initializer/create-consumer.ts
@@ -9,6 +9,12 @@ import { ConfigMain, WorkspaceConfig } from '@teambit/config';
 import { PackageJsonFile } from '@teambit/component.sources';
 import { pickBy } from 'lodash';
 
+/**
+ * The postinstall script added to package.json when using external package manager mode.
+ * This constant is exported so it can be used for checking/removing the script elsewhere.
+ */
+export const EXTERNAL_PM_POSTINSTALL_SCRIPT = 'bit link && bit compile && bit ws-config write';
+
 export async function createConsumer(
   projectPath: PathOsBasedAbsolute,
   standAlone = false, // no git
@@ -75,7 +81,7 @@ export async function createConsumer(
         const content = { ...existingPackageJson.packageJsonObject };
         content.type = 'module';
         content.scripts = content.scripts || {};
-        content.scripts.postinstall = 'bit link && bit compile && bit ws-config write';
+        content.scripts.postinstall = EXTERNAL_PM_POSTINSTALL_SCRIPT;
 
         const packageJson = PackageJsonFile.create(consumer.projectPath, undefined, content);
         consumer.setPackageJson(packageJson);
@@ -84,7 +90,7 @@ export async function createConsumer(
         const jsonContent = {
           type: 'module',
           scripts: {
-            postinstall: 'bit link && bit compile && bit ws-config write',
+            postinstall: EXTERNAL_PM_POSTINSTALL_SCRIPT,
           },
         };
         const packageJson = PackageJsonFile.create(consumer.projectPath, undefined, jsonContent);

--- a/scopes/harmony/host-initializer/index.ts
+++ b/scopes/harmony/host-initializer/index.ts
@@ -2,5 +2,6 @@ import { HostInitializerAspect } from './host-initializer.aspect';
 
 export { HostInitializerMain } from './host-initializer.main.runtime';
 export { ObjectsWithoutConsumer } from './objects-without-consumer';
+export { EXTERNAL_PM_POSTINSTALL_SCRIPT } from './create-consumer';
 export default HostInitializerAspect;
 export { HostInitializerAspect };

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -63,6 +63,7 @@ import type { BundlerMain } from '@teambit/bundler';
 import { BundlerAspect } from '@teambit/bundler';
 import type { UiMain } from '@teambit/ui';
 import { UIAspect } from '@teambit/ui';
+import { EXTERNAL_PM_POSTINSTALL_SCRIPT } from '@teambit/host-initializer';
 import { DependencyTypeNotSupportedInPolicy } from './exceptions';
 import { InstallAspect } from './install.aspect';
 import { pickOutdatedPkgs } from './pick-outdated-pkgs';
@@ -1447,7 +1448,7 @@ export class InstallMain {
       }
 
       // Only remove our specific postInstall script, preserve user's custom scripts
-      if (packageJsonFile.packageJsonObject.scripts?.postinstall === 'bit link && bit compile') {
+      if (packageJsonFile.packageJsonObject.scripts?.postinstall === EXTERNAL_PM_POSTINSTALL_SCRIPT) {
         delete packageJsonFile.packageJsonObject.scripts.postinstall;
 
         // Clean up empty scripts object


### PR DESCRIPTION
When initializing a workspace with `externalPackageManager: true`, the postinstall script now includes `bit ws-config write` to ensure TypeScript config files are generated after running the external package manager's install.

Previously the postinstall was:
```
"postinstall": "bit link && bit compile"
```

Now it's:
```
"postinstall": "bit link && bit compile && bit ws-config write"
```

This ensures that tsconfig files in `bit-components/` are properly generated, which is required for IDE support and TypeScript compilation.