### PR TITLE
fix(typescript): show message when check-types has no components to check

### DIFF
--- a/scopes/typescript/typescript/cmds/check-types.cmd.ts
+++ b/scopes/typescript/typescript/cmds/check-types.cmd.ts
@@ -94,7 +94,7 @@ otherwise, only new and modified components will be checked`);
     // If pattern is provided, don't pass the unmodified flag - the pattern should take precedence
     const components = await this.workspace.getComponentsByUserInput(pattern ? false : unmodified, pattern);
     if (!components.length) {
-      return { tsserver: null, componentsCount: 0 };
+      return { tsserver: undefined, componentsCount: 0 };
     }
     const files = this.typescript.getSupportedFilesForTsserver(components);
     await this.typescript.initTsserverClientFromWorkspace(


### PR DESCRIPTION
When `bit check-types` runs without finding any components (e.g., all are exported), it now shows a helpful message similar to other commands like `bit test`:

```
no components found to check.
use "--unmodified" flag to check all components or specify the ids to check.
otherwise, only new and modified components will be checked
```

Also added the component count to the success message for better feedback.