### PR TITLE
fix(import): clarify write-deps option in help output

### DIFF
--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -128,8 +128,8 @@ without arguments, fetches all workspace components' latest versions from their 
     ],
     [
       '',
-      'write-deps <workspace.jsonc|package.json>',
-      'write all workspace component dependencies to package.json or workspace.jsonc, resolving conflicts by picking the ranges that match the highest versions',
+      'write-deps <target>',
+      'write all workspace component dependencies to the specified target ("package.json" or "workspace.jsonc"), resolving conflicts by picking the ranges that match the highest versions',
     ],
     [
       '',


### PR DESCRIPTION
The `--write-deps` option was showing `<workspace.jsonc|package.json>` which rendered as boolean in the help output. Changed to use `<target>` placeholder with the valid values explained in the description.