### PR TITLE
fix(isolator): preserve merged package.json when populateArtifactsFrom is set

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -757,7 +757,7 @@ export class IsolatorMain {
 
     // rewrite the package-json with the component dependencies in it. the original package.json
     // that was written before, didn't have these dependencies in order for the package-manager to
-    // be able to install them without crushing when the versions don't exist yet.
+    // be able to install them without crashing when the versions don't exist yet.
     // skip this rewrite when populateArtifactsFrom is set, because the package.json was already
     // written with the correct (merged) dependencies from the last build in writeComponentsInCapsules.
     if (!opts.populateArtifactsFrom) {


### PR DESCRIPTION
When tagging after a snap, the isolator would overwrite the package.json that had correctly merged dependencies from the last build. This caused envs that clear dependencies during build (like pre-bundle envs) to have their dependencies incorrectly restored.

The fix skips the package.json rewrite when `populateArtifactsFrom` is set, since the correct merged package.json was already written by `writeComponentsInCapsules` via `mergePkgJsonFromLastBuild`.