### PR TITLE
fix: live controls popups

### DIFF
--- a/scopes/compositions/compositions/ui/compositions-panel/live-control-input.tsx
+++ b/scopes/compositions/compositions/ui/compositions-panel/live-control-input.tsx
@@ -72,7 +72,10 @@ function SelectInput({ value, onChange, meta }: InputComponentProps) {
 
   const placeholderContent = options.find((o) => o.value === selectedValue)?.label;
 
-  const { position, style } = useOverlay(triggerRef, open);
+  const { position, style } = useOverlay(triggerRef, open, 0, {
+    paddingTop: 8,
+    paddingBottom: 8,
+  });
 
   const commitSelection = (v: string) => {
     onChange(v);
@@ -87,6 +90,7 @@ function SelectInput({ value, onChange, meta }: InputComponentProps) {
         open={open}
         onChange={(_, isOpen) => setOpen(isOpen)}
         position={position}
+        dropClass={overlayStyles.suppressNativeMenu}
       />
 
       {open && style && (
@@ -135,7 +139,9 @@ function ColorPickerPortal(props: any) {
   const [open, setOpen] = React.useState(false);
   const triggerRef = React.useRef<HTMLDivElement>(null);
 
-  const { position, style } = useOverlay(triggerRef, open);
+  const { position, style } = useOverlay(triggerRef, open, 4, {
+    padding: 16,
+  });
 
   return (
     <div ref={triggerRef}>

--- a/scopes/compositions/compositions/ui/compositions-panel/overlay.module.scss
+++ b/scopes/compositions/compositions/ui/compositions-panel/overlay.module.scss
@@ -7,7 +7,7 @@
   background: var(--surface-neutral-color, #fff);
   border: 1px solid var(--border-medium-color, #ededed);
   border-radius: 8px;
-  box-shadow: var(--bit-shadow-hover-low);
+  box-shadow: var(--bit-shadow-hover-low, 0 2px 8px 0 rgba(0, 0, 0, 0.2));
 }
 
 .suppressNativeMenu {

--- a/scopes/compositions/compositions/ui/compositions-panel/use-overlay.ts
+++ b/scopes/compositions/compositions/ui/compositions-panel/use-overlay.ts
@@ -7,15 +7,18 @@ export type OverlayStyle = {
   top?: number;
   bottom?: number;
   left: number;
-  width: number;
+  maxWidth: number;
   maxHeight: number;
-};
+} & React.CSSProperties;
 
-const GAP = 8;
-const MIN_HEIGHT = 120;
-const MAX_HEIGHT = 240;
+const GAP = 4;
 
-export function useOverlay(anchorRef: React.RefObject<HTMLElement>, open: boolean) {
+export function useOverlay(
+  anchorRef: React.RefObject<HTMLElement>,
+  open: boolean,
+  gap: number = GAP,
+  extraStyle?: React.CSSProperties
+) {
   const [position, setPosition] = React.useState<OverlayPosition>('bottom');
   const [style, setStyle] = React.useState<OverlayStyle | null>(null);
 
@@ -24,21 +27,21 @@ export function useOverlay(anchorRef: React.RefObject<HTMLElement>, open: boolea
 
     const rect = anchorRef.current.getBoundingClientRect();
 
-    const below = window.innerHeight - rect.bottom - GAP;
-    const above = rect.top - GAP;
+    const below = window.innerHeight - rect.bottom - gap;
+    const above = rect.top - gap;
 
-    const maxHeight = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, below));
-    const shouldFlip = below < MIN_HEIGHT && above > below;
+    const shouldFlip = below < 240 && above > below;
 
     const pos: OverlayPosition = shouldFlip ? 'top' : 'bottom';
 
     setPosition(pos);
     setStyle({
+      ...extraStyle,
       left: rect.left,
-      width: rect.width,
-      maxHeight,
-      top: pos === 'bottom' ? rect.bottom + GAP : undefined,
-      bottom: pos === 'top' ? window.innerHeight - rect.top + GAP : undefined,
+      maxWidth: rect.width,
+      maxHeight: 240,
+      top: pos === 'bottom' ? rect.bottom + gap : undefined,
+      bottom: pos === 'top' ? window.innerHeight - rect.top + gap : undefined,
     });
   }, [open]);
 


### PR DESCRIPTION
## Proposed Changes

- gap is configurable: for color picker it should be 4, for select it should be 0 since the `<p>` already has a 4px margin-bottom
- no min-height and min-max calc, just fix the max-height as 240
- change the width into max-width
- support extra custom styles for the portal, in these cases, the color picker and dropdown menu have different paddings
- box shadow var somehow doesn’t work, I added a default value