### PR TITLE
fix(deps): filter core aspects from component deps in capsules

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
@@ -179,8 +179,14 @@ export class WorkspaceManifestFactory {
       if (excludeExtensionsDependencies) {
         depList = filterExtensions(depList);
       }
-      // Remove bit bin from dep list
-      depList = depList.filter((dep) => dep.id !== '@teambit/legacy');
+      // Remove core aspects from dep list - they should be linked, not installed
+      const coreAspectIds = this.aspectLoader.getCoreAspectIds();
+      const coreAspectPkgNames = new Set(coreAspectIds.map((id) => getCoreAspectPackageName(id)));
+      coreAspectPkgNames.add('@teambit/legacy');
+      depList = depList.filter((dep) => {
+        const pkgName = dep.getPackageName?.() ?? dep.id;
+        return !coreAspectPkgNames.has(pkgName);
+      });
       if (dependencyFilterFn) {
         depList = dependencyFilterFn(depList);
       }


### PR DESCRIPTION
## Summary
- Core aspects (e.g., `@teambit/objects`, `@teambit/workspace`, `@teambit/remove`) were being installed via pnpm in capsules instead of being linked
- This caused TypeScript compilation errors during `bit ci merge` due to multiple copies with different peer dependency hashes
- Now all core aspects are filtered from component dependencies, ensuring they are only linked (not installed) in capsules

## Test plan
- [x] Verified locally that `@teambit/objects` is now linked to workspace instead of installed via pnpm
- [x] Verified no duplicate copies in `.pnpm` folder
- [ ] CI should pass on this branch