### PR TITLE
fix(check-types): batch getDiagnostic calls to avoid overwhelming tsserver

### DIFF
--- a/scopes/typescript/typescript/cmds/check-types.cmd.ts
+++ b/scopes/typescript/typescript/cmds/check-types.cmd.ts
@@ -106,7 +106,9 @@ otherwise, only new and modified components will be checked`);
     );
     const tsserver = this.typescript.getTsserverClient();
     if (!tsserver) throw new Error(`unable to start tsserver`);
-    await tsserver.getDiagnostic(files);
+    // Use batching for large file sets to avoid overwhelming tsserver
+    const BATCH_SIZE = 50;
+    await tsserver.getDiagnostic(files, files.length > BATCH_SIZE ? BATCH_SIZE : undefined);
     return { tsserver, componentsCount: components.length };
   }
 }


### PR DESCRIPTION
## Summary

When running `bit check-types` on workspaces with many components, tsserver can become overwhelmed and fail to detect type errors. This fix batches the `getDiagnostic` calls into groups of 50 files.

Bonus: ~35% performance improvement (33 sec vs 50 sec for 138 components).

## Changes

- Add optional `batchSize` parameter to `getDiagnostic()` method
- Use batching in `check-types` command for large file sets