### PR TITLE
fix(watcher): add micromatch as direct dependency for @parcel/watcher

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -546,6 +546,7 @@
         "lru-cache": "10.4.3",
         "memoizee": "0.4.15",
         "mime": "2.5.2",
+        "micromatch": "^4.0.5",
         "mini-css-extract-plugin": "2.2.2",
         "minimatch": "3.0.5",
         "mocha": "11.1.0",


### PR DESCRIPTION
@parcel/watcher requires micromatch but due to pnpm's strict hoisting behavior, micromatch may not be accessible in all contexts. This causes intermittent "Cannot find module 'micromatch'" errors when running the watcher.

Adding micromatch as a direct workspace dependency ensures it's hoisted to the root node_modules where @parcel/watcher's wrapper.js can resolve it.