### PR TITLE
feat: add --use-root-modules flag to bit start

### DIFF
--- a/scopes/preview/preview/preview.main.runtime.ts
+++ b/scopes/preview/preview/preview.main.runtime.ts
@@ -791,7 +791,6 @@ export class PreviewMain {
   writeLinkContents(contents: string, targetDir: string, prefix: string) {
     const hash = objectHash(contents);
     const targetPath = join(targetDir, `${prefix}-${this.timestamp}.js`);
-
     // write only if link has changed (prevents triggering fs watches)
     if (this.writeHash.get(targetPath) !== hash) {
       writeFileSync(targetPath, contents);
@@ -880,8 +879,10 @@ export class PreviewMain {
           visitedEnvs.add(envId);
         }
         const compilerInstance = environment.getCompiler?.();
-        const modulePath =
-          compilerInstance?.getPreviewComponentRootPath?.(component) || this.pkg.getRuntimeModulePath(component);
+        const useRootModules = this.ui.runtimeOptions?.useRootModules;
+        const modulePath = useRootModules
+          ? this.pkg.getModulePath(component)
+          : compilerInstance?.getPreviewComponentRootPath?.(component) || this.pkg.getRuntimeModulePath(component);
         return files.map((file) => {
           if (!this.workspace || !compilerInstance) {
             return file.path;

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -17,6 +17,7 @@ type StartFlags = {
   skipCompilation: boolean;
   skipUiBuild: boolean;
   uiRootName: string;
+  useRootModules: boolean;
 };
 
 export class StartCmd implements Command {
@@ -51,6 +52,11 @@ includes hot module reloading for development.`;
       'ui-root-name [type]',
       'name of the ui root to use, e.g. "teambit.scope/scope" or "teambit.workspace/workspace"',
     ],
+    [
+      '',
+      'use-root-modules',
+      'EXPERIMENTAL. resolve component previews from root node_modules instead of .bit_roots. mainly for internal usage, use with caution only if you understand the implications',
+    ],
   ] as CommandOptions;
 
   constructor(
@@ -74,6 +80,7 @@ includes hot module reloading for development.`;
       skipUiBuild,
       showInternalUrls,
       uiRootName: uiRootAspectIdOrName,
+      useRootModules,
     }: StartFlags
   ) {
     const spinnies = this.logger.multiSpinner;
@@ -97,6 +104,7 @@ includes hot module reloading for development.`;
       rebuild,
       verbose,
       showInternalUrls,
+      useRootModules,
     });
 
     uiServer

--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -130,6 +130,11 @@ export type RuntimeOptions = {
    * Show the internal urls of the dev servers
    */
   showInternalUrls?: boolean;
+
+  /**
+   * resolve component previews from root node_modules instead of .bit_roots
+   */
+  useRootModules?: boolean;
 };
 
 export class UiMain {


### PR DESCRIPTION
Add experimental `--use-root-modules` flag to `bit start` that resolves component preview imports from root `node_modules` instead of `.bit_roots` per-env directories.

When the dev server is kept live while generating a large number of components (e.g. by AI agents working on live workspaces), the `.bit_roots` structure undergoes significant changes. This causes the dev server's file watcher to reference missing files, leading to crashes. The `--use-root-modules` flag bypasses `.bit_roots` entirely by resolving preview entry imports via `pkg.getModulePath(component)` (root `node_modules/@scope/component`) instead of `compilerInstance.getPreviewComponentRootPath(component)` (`.bit_roots/<envId>/node_modules/@scope/component`), providing a more stable path resolution during heavy component generation.