### PR TITLE
fix(install): only filter env peer deps when using external package manager

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
@@ -223,7 +223,7 @@ export class WorkspaceManifestFactory {
       // When false, only include peer deps that the component actually uses, to avoid
       // writing unnecessary deps to the generated install manifest.
       let peerDepsForManifest: Record<string, string>;
-      if (includeAllEnvPeers) {
+      if (includeAllEnvPeers ?? true) {
         peerDepsForManifest = envPeerDependencies;
       } else {
         peerDepsForManifest = pickBy(envPeerDependencies, (_val, pkgName) => {

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -233,6 +233,7 @@ export class InstallMain {
     await this.addConfiguredGeneratorEnvsToWorkspacePolicy(mergedRootPolicy);
     const componentsAndManifests = await this._getComponentsManifests(installer, mergedRootPolicy, {
       dedupe: true,
+      includeAllEnvPeers: false,
     });
     const { dependencies, devDependencies } = componentsAndManifests.manifests[this.workspace.path];
     return this.workspace.writeDependenciesToPackageJson({ ...devDependencies, ...dependencies });
@@ -367,7 +368,6 @@ export class InstallMain {
       dedupe: !hasRootComponents && options?.dedupe,
       dependencyFilterFn: depsFilterFn,
       nodeLinker: this.dependencyResolver.nodeLinker(),
-      includeAllEnvPeers: true,
     };
     const linkOpts = {
       linkTeambitBit: true,


### PR DESCRIPTION
Include all env peer dependencies during normal installs to maintain consistent peer dependency contexts. The filtering is now only applied in the external package manager path (writeDependenciesToPackageJson).

## Proposed Changes

-
-
-
