### PR TITLE
fix(envs): allow version() to return Promise<string>

### DIFF
--- a/scopes/envs/envs/services/service-handler.ts
+++ b/scopes/envs/envs/services/service-handler.ts
@@ -14,7 +14,7 @@ export interface ServiceHandler {
   /**
    * version of the service. optional.
    */
-  version?: () => string;
+  version?: () => string | Promise<string>;
 
   /**
    * config of the service. e.g. tsconfig.json


### PR DESCRIPTION
Allow `ServiceHandler.version()` to return a `Promise<string>` in addition to a synchronous `string`, enabling async version resolution.