### PR TITLE
fix(scope): handle null parent versions when importing objects from remote

### DIFF
--- a/scopes/scope/objects/objects/objects-readable-generator.ts
+++ b/scopes/scope/objects/objects/objects-readable-generator.ts
@@ -1,6 +1,7 @@
 import pMapSeries from 'p-map-series';
 import { BitError } from '@teambit/bit-error';
 import { Readable } from 'stream';
+import { compact } from 'lodash';
 import type BitObject from './object';
 import type Repository from './repository';
 import type Ref from './ref';
@@ -155,7 +156,7 @@ export class ObjectsReadableGenerator {
       });
       const missingParentsHashes = allParentsHashes.filter((h) => !h.isEqual(version.hash()));
       const parentVersions = await pMapSeries(missingParentsHashes, (parentHash) => parentHash.load(this.repo));
-      allVersions.push(...(parentVersions as unknown as Version[]));
+      allVersions.push(...(compact(parentVersions) as Version[]));
       // note: don't bring the head. otherwise, component-delta of the head won't bring all history of this comp.
     }
     allVersions.push(version);

--- a/scopes/scope/objects/objects/objects-readable-generator.ts
+++ b/scopes/scope/objects/objects/objects-readable-generator.ts
@@ -156,6 +156,12 @@ export class ObjectsReadableGenerator {
       });
       const missingParentsHashes = allParentsHashes.filter((h) => !h.isEqual(version.hash()));
       const parentVersions = await pMapSeries(missingParentsHashes, (parentHash) => parentHash.load(this.repo));
+      const nullParentHashes = missingParentsHashes.filter((_, i) => !parentVersions[i]);
+      if (nullParentHashes.length) {
+        logger.warn(
+          `failed loading ${nullParentHashes.length} parent version(s) for ${component.id()}, missing: ${nullParentHashes.join(', ')}`
+        );
+      }
       allVersions.push(...(compact(parentVersions) as Version[]));
       // note: don't bring the head. otherwise, component-delta of the head won't bring all history of this comp.
     }

--- a/scopes/scope/objects/objects/objects-readable-generator.ts
+++ b/scopes/scope/objects/objects/objects-readable-generator.ts
@@ -159,7 +159,7 @@ export class ObjectsReadableGenerator {
       const nullParentHashes = missingParentsHashes.filter((_, i) => !parentVersions[i]);
       if (nullParentHashes.length) {
         logger.warn(
-          `failed loading ${nullParentHashes.length} parent version(s) for ${component.id()}, missing: ${nullParentHashes.join(', ')}`
+          `ObjectsReadableGenerator.pushComponentObjects: failed loading ${nullParentHashes.length} parent version(s) for ${component.id()} (version: ${componentWithOptions.version}), missing: ${nullParentHashes.join(', ')}`
         );
       }
       allVersions.push(...(compact(parentVersions) as Version[]));


### PR DESCRIPTION
In rare cases, importing objects from a remote scope fails with:
`Cannot read properties of null (reading 'refsWithOptions')`

This happens when `parentHash.load()` returns null for a parent version that exists in the hash list but can't be loaded from the repository. The loaded parent versions were cast directly to `Version[]` without filtering nulls, so a null entry would later crash in `collectVersionObjects` when calling `ver.refsWithOptions()`.

Fix: use lodash `compact()` to filter out null values before processing parent versions.