### PR TITLE
feat(cli): add "api" alias for schema command and fix help output for aliases

### DIFF
--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -233,7 +233,14 @@ export class CLIParser {
 
     const lines = help.split('\n');
     const linesWithoutEmpty = compact(lines);
-    const cmdLine = linesWithoutEmpty[0];
+    let cmdLine = linesWithoutEmpty[0];
+    if (command?.alias) {
+      const enteredCommand = process.argv[2];
+      if (enteredCommand === command.alias) {
+        const commandId = getCommandId(command.name);
+        cmdLine = cmdLine.replace(commandId, command.alias);
+      }
+    }
     const description: string[] = [];
     const options: string[] = [];
     const globalOptions: string[] = [];

--- a/scopes/semantics/schema/schema.cmd.ts
+++ b/scopes/semantics/schema/schema.cmd.ts
@@ -8,6 +8,7 @@ import type { SchemaMain } from './schema.main.runtime';
 
 export class SchemaCommand implements Command {
   name = 'schema <pattern>';
+  alias = 'api';
   description = 'display component API schema and type definitions';
   extendedDescription = `extracts and displays the public API structure of components including types, functions, classes, and interfaces.
 shows detailed type information, function signatures, and JSDoc documentation for exported elements.


### PR DESCRIPTION
- Add api as an alias for bit schema, so bit api <pattern> works as a shorthand for viewing component API schemas
- Fix CLI help output to show the alias name when a command is invoked via its alias (previously always showed the canonical name, e.g. bit api--help would print app.js schema <pattern> instead of app.js api <pattern>)
                                                              
