### PR TITLE
fix(scope): improve error message when Source object is missing from local scope

### DIFF
--- a/scopes/scope/objects/models/model-component.ts
+++ b/scopes/scope/objects/models/model-component.ts
@@ -1075,14 +1075,16 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
     ) {
       componentVersion = new ComponentVersion(this, version.hash().toString());
     }
+    const resolvedVersion = componentVersion.version;
     const loadFileInstance = (ClassName) => async (file) => {
       const loadP = file.file.load(repository);
       const content: Source = await loadP;
       if (!content)
         throw new BitError(
-          `failed loading file ${file.relativePath} from the model of ${this.id()}@${versionStr}.
-the Source object is missing from the local scope. to fix, run:
-  bit import ${this.id()}@${versionStr} --objects --all-history`
+          `failed loading file ${file.relativePath} (ref: ${file.file.toString()}) from the model of ${this.id()}@${resolvedVersion}.
+The Source object is missing from the local scope.
+To fix, run:
+bit import ${this.id()}@${resolvedVersion} --objects --all-history`
         );
       return new ClassName({ base: '.', path: file.relativePath, contents: content.contents, test: file.test });
     };

--- a/scopes/scope/objects/models/model-component.ts
+++ b/scopes/scope/objects/models/model-component.ts
@@ -1079,7 +1079,11 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
       const loadP = file.file.load(repository);
       const content: Source = await loadP;
       if (!content)
-        throw new BitError(`failed loading file ${file.relativePath} from the model of ${this.id()}@${versionStr}`);
+        throw new BitError(
+          `failed loading file ${file.relativePath} from the model of ${this.id()}@${versionStr}.
+the Source object is missing from the local scope. to fix, run:
+  bit import ${this.id()}@${versionStr} --objects --all-history`
+        );
       return new ClassName({ base: '.', path: file.relativePath, contents: content.contents, test: file.test });
     };
     const filesP = version.files ? Promise.all(version.files.map(loadFileInstance(SourceFile))) : null;


### PR DESCRIPTION
When a Version object exists locally but a referenced Source blob is missing (rare scope corruption, e.g. interrupted import), the error gave no hint on how to recover. `bit import --objects` alone won't fix it because the remote short-circuits via `returnNothingIfGivenVersionExists` when the Version hash already exists locally.

The error now tells the user to run `bit import <id>@<version> --objects --all-history`, which bypasses the delta optimization and re-fetches all referenced objects.