### PR TITLE
fix(ci): retry ci pr export on lane hash mismatch from concurrent pushes

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -385,6 +385,7 @@ export class CiMain {
     this.logger.console(chalk.blue(`Creating temporary lane ${laneId.scope}/${tempLaneName}`));
 
     let foundErr: Error | undefined;
+    let renamedToFinalName = false;
     try {
       await this.lanes.createLane(tempLaneName, {
         scope: laneId.scope,
@@ -452,10 +453,12 @@ export class CiMain {
       // Rename temp lane to original name
       this.logger.console(chalk.blue(`Renaming lane from ${tempLaneName} to ${laneId.name}`));
       await this.lanes.rename(laneId.name, tempLaneName);
+      renamedToFinalName = true;
 
-      // Export with the correct name
+      // Export with the correct name. Retry on hash-mismatch, which indicates a concurrent CI job
+      // pushed the same lane id between our pre-export delete and our merge on the hub.
       this.logger.console(chalk.blue(`Exporting ${snappedComponents.length} components`));
-      const exportResults = await this.exporter.export();
+      const exportResults = await this.exportWithRetryOnLaneHashMismatch(laneId.toString());
       this.logger.console(chalk.green(`Exported ${exportResults.componentsIds.length} components`));
     } catch (e: any) {
       foundErr = e;
@@ -477,8 +480,10 @@ export class CiMain {
         await this.lanes.checkout.checkout({ head: true, skipNpmInstall: true });
       }
 
-      // Clean up orphaned temporary lane on error
-      if (foundErr) {
+      // Clean up orphaned temporary lane on error. Skip if the rename to the final name already
+      // happened - in that case the temp name no longer exists locally, and the lane under the
+      // final name may have been partially exported; leave it alone rather than wipe evidence.
+      if (foundErr && !renamedToFinalName) {
         const tempLaneFullName = `${laneId.scope}/${tempLaneName}`;
         this.logger.console(chalk.blue(`Cleaning up temporary lane ${tempLaneFullName}`));
         try {
@@ -826,6 +831,38 @@ export class CiMain {
         chalk.yellow(`Error during lane cleanup for source branch '${sourceBranchName}': ${e.message}`)
       );
     }
+  }
+
+  /**
+   * Run `exporter.export()` and retry when the remote rejects the push because a lane with the same
+   * id already exists with a different hash. This race happens when a concurrent `bit ci pr` run
+   * (same PR, different workflow or re-run) pushed the same lane id between our pre-export
+   * existence check and our merge on the hub. Between "Exporting" and the hub's merge check there
+   * can be ~1-2 minutes of upload/processing - plenty of time for another run to persist a new lane.
+   *
+   * On retry we delete the remote lane (now populated by the winning concurrent push) and try
+   * the export again with our local hash. Bounded attempts guard against a tight push loop between
+   * two runners.
+   */
+  private async exportWithRetryOnLaneHashMismatch(laneIdStr: string, maxAttempts = 3) {
+    const isHashMismatchErr = (err: any) =>
+      (err?.message || err?.toString() || '').includes('a lane with the same id already exists with a different hash');
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await this.exporter.export();
+      } catch (e: any) {
+        if (!isHashMismatchErr(e) || attempt === maxAttempts) throw e;
+        this.logger.console(
+          chalk.yellow(
+            `Export attempt ${attempt}/${maxAttempts} failed with lane hash mismatch on "${laneIdStr}" (likely a concurrent CI push). Deleting remote lane and retrying.`
+          )
+        );
+        await this.archiveLane(laneIdStr, true);
+      }
+    }
+    // Unreachable: the loop either returns on success or throws on the last attempt.
+    throw new Error(`exportWithRetryOnLaneHashMismatch: exhausted ${maxAttempts} attempts for lane ${laneIdStr}`);
   }
 
   /**

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -27,6 +27,14 @@ import type { Version, LaneComponent } from '@teambit/objects';
 import { SourceBranchDetector } from './source-branch-detector';
 import { generateRandomStr } from '@teambit/toolbox.string.random';
 
+/**
+ * Sentinel substring emitted by the hub when a lane push is rejected because a lane with the same
+ * id already exists with a different hash. Thrown as `BitError` from
+ * `components/legacy/scope/repositories/sources.ts` and wrapped in `UnexpectedNetworkError` across
+ * the wire, so we match on the message text rather than an error class.
+ */
+const LANE_HASH_MISMATCH_MARKER = 'a lane with the same id already exists with a different hash';
+
 export interface CiWorkspaceConfig {
   /**
    * Path to a custom script that generates commit messages for `bit ci merge` operations.
@@ -841,8 +849,7 @@ export class CiMain {
    * snaps would regress the PR preview.
    */
   private async exportWithRetryOnLaneHashMismatch(laneIdStr: string, maxAttempts = 3) {
-    const isHashMismatchErr = (err: any) =>
-      (err?.message || err?.toString() || '').includes('a lane with the same id already exists with a different hash');
+    const isHashMismatchErr = (err: any) => (err?.message || err?.toString() || '').includes(LANE_HASH_MISMATCH_MARKER);
 
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
@@ -872,7 +879,7 @@ export class CiMain {
               `Failed to delete remote lane "${laneIdStr}" while recovering from hash mismatch: ${archiveErr?.message || archiveErr}. Rethrowing the original export error.`
             )
           );
-          if (e && typeof e === 'object' && !('cause' in e)) {
+          if (e && typeof e === 'object' && (e as any).cause == null) {
             (e as any).cause = archiveErr;
           }
           throw e;
@@ -894,7 +901,7 @@ export class CiMain {
       const localSha = (await git.revparse(['HEAD'])).trim();
       // `--` separator and fully-qualified ref so a branch name starting with `-` can't be
       // interpreted as a git option (defense in depth for untrusted PR branches).
-      await git.raw(['fetch', 'origin', '--', `refs/heads/${branch}`]);
+      await git.raw(['fetch', 'origin', '--', `refs/heads/${branch}:refs/remotes/origin/${branch}`]);
       const remoteSha = (await git.revparse([`refs/remotes/origin/${branch}`])).trim();
       if (remoteSha === localSha) return false;
       const mergeBase = (await git.raw(['merge-base', localSha, remoteSha])).trim();

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -834,20 +834,11 @@ export class CiMain {
   }
 
   /**
-   * Run `exporter.export()` and retry when the remote rejects the push because a lane with the same
-   * id already exists with a different hash. This race happens when a concurrent `bit ci pr` run
-   * (same PR, different workflow or re-run) pushed the same lane id between our pre-export
-   * existence check and our merge on the hub. Between "Exporting" and the hub's merge check there
-   * can be ~1-2 minutes of upload/processing - plenty of time for another run to persist a new lane.
-   *
-   * On retry we delete the remote lane (now populated by the winning concurrent push) and try
-   * the export again with our local hash. Bounded attempts guard against a tight push loop between
-   * two runners.
-   *
-   * Before each retry we verify we're not a stale run: if the PR branch has advanced past our
-   * commit on the remote, a newer CI run is on the way and clobbering its lane with our older
-   * snaps would regress the PR preview. In that case we surface the original error and let the
-   * newer run publish the correct lane.
+   * Export with retry on lane hash-mismatch, caused by a concurrent `bit ci pr` run pushing the
+   * same lane id between our pre-export delete and the hub's merge (the export takes 1-2 minutes,
+   * plenty of time to race). Before each retry we skip if the PR branch has advanced past our
+   * commit - in that case a newer run will publish the correct lane, and retrying with our older
+   * snaps would regress the PR preview.
    */
   private async exportWithRetryOnLaneHashMismatch(laneIdStr: string, maxAttempts = 3) {
     const isHashMismatchErr = (err: any) =>
@@ -888,7 +879,6 @@ export class CiMain {
         }
       }
     }
-    // Unreachable: the loop either returns on success or throws on the last attempt.
     throw new Error(`exportWithRetryOnLaneHashMismatch: exhausted ${maxAttempts} attempts for lane ${laneIdStr}`);
   }
 
@@ -902,14 +892,14 @@ export class CiMain {
       const branch = await this.getBranchName();
       if (!branch) return false;
       const localSha = (await git.revparse(['HEAD'])).trim();
-      // Fetch with fully-qualified ref and `--` separator so a branch name starting with `-`
-      // cannot be interpreted as a git option (defense in depth for untrusted PR branches).
+      // `--` separator and fully-qualified ref so a branch name starting with `-` can't be
+      // interpreted as a git option (defense in depth for untrusted PR branches).
       await git.raw(['fetch', 'origin', '--', `refs/heads/${branch}`]);
       const remoteSha = (await git.revparse([`refs/remotes/origin/${branch}`])).trim();
-      if (!remoteSha || !localSha || remoteSha === localSha) return false;
-      // If remote has a commit we don't, we're stale.
+      if (remoteSha === localSha) return false;
       const mergeBase = (await git.raw(['merge-base', localSha, remoteSha])).trim();
-      return mergeBase === localSha && mergeBase !== remoteSha;
+      // local is strictly behind remote - remote has commits we don't.
+      return mergeBase === localSha;
     } catch (err: any) {
       this.logger.console(chalk.yellow(`Unable to verify CI run freshness (assuming fresh): ${err?.message || err}`));
       return false;

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -843,6 +843,11 @@ export class CiMain {
    * On retry we delete the remote lane (now populated by the winning concurrent push) and try
    * the export again with our local hash. Bounded attempts guard against a tight push loop between
    * two runners.
+   *
+   * Before each retry we verify we're not a stale run: if the PR branch has advanced past our
+   * commit on the remote, a newer CI run is on the way and clobbering its lane with our older
+   * snaps would regress the PR preview. In that case we surface the original error and let the
+   * newer run publish the correct lane.
    */
   private async exportWithRetryOnLaneHashMismatch(laneIdStr: string, maxAttempts = 3) {
     const isHashMismatchErr = (err: any) =>
@@ -853,6 +858,14 @@ export class CiMain {
         return await this.exporter.export();
       } catch (e: any) {
         if (!isHashMismatchErr(e) || attempt === maxAttempts) throw e;
+        if (await this.isStaleCiRun()) {
+          this.logger.console(
+            chalk.yellow(
+              `Export failed with lane hash mismatch on "${laneIdStr}" and the PR branch has advanced past our commit. Not retrying - a newer CI run will publish the correct lane.`
+            )
+          );
+          throw e;
+        }
         this.logger.console(
           chalk.yellow(
             `Export attempt ${attempt}/${maxAttempts} failed with lane hash mismatch on "${laneIdStr}" (likely a concurrent CI push). Deleting remote lane and retrying.`
@@ -863,6 +876,28 @@ export class CiMain {
     }
     // Unreachable: the loop either returns on success or throws on the last attempt.
     throw new Error(`exportWithRetryOnLaneHashMismatch: exhausted ${maxAttempts} attempts for lane ${laneIdStr}`);
+  }
+
+  /**
+   * Returns true when the PR branch on the remote has advanced past our local HEAD, meaning a
+   * newer commit was pushed to the branch while this CI run was in flight. Best-effort: when we
+   * can't determine the branch or reach the remote we return false (don't block retry).
+   */
+  private async isStaleCiRun(): Promise<boolean> {
+    try {
+      const branch = await this.getBranchName();
+      if (!branch) return false;
+      const localSha = (await git.revparse(['HEAD'])).trim();
+      await git.fetch('origin', branch);
+      const remoteSha = (await git.revparse([`origin/${branch}`])).trim();
+      if (!remoteSha || !localSha || remoteSha === localSha) return false;
+      // If remote has a commit we don't, we're stale.
+      const mergeBase = (await git.raw(['merge-base', localSha, remoteSha])).trim();
+      return mergeBase === localSha && mergeBase !== remoteSha;
+    } catch (err: any) {
+      this.logger.console(chalk.yellow(`Unable to verify CI run freshness (assuming fresh): ${err?.message || err}`));
+      return false;
+    }
   }
 
   /**

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -871,7 +871,21 @@ export class CiMain {
             `Export attempt ${attempt}/${maxAttempts} failed with lane hash mismatch on "${laneIdStr}" (likely a concurrent CI push). Deleting remote lane and retrying.`
           )
         );
-        await this.archiveLane(laneIdStr, true);
+        try {
+          await this.archiveLane(laneIdStr, true);
+        } catch (archiveErr: any) {
+          // Preserve the original export error - rethrowing the archive error would hide the real
+          // reason the push was rejected.
+          this.logger.console(
+            chalk.yellow(
+              `Failed to delete remote lane "${laneIdStr}" while recovering from hash mismatch: ${archiveErr?.message || archiveErr}. Rethrowing the original export error.`
+            )
+          );
+          if (e && typeof e === 'object' && !('cause' in e)) {
+            (e as any).cause = archiveErr;
+          }
+          throw e;
+        }
       }
     }
     // Unreachable: the loop either returns on success or throws on the last attempt.
@@ -888,8 +902,10 @@ export class CiMain {
       const branch = await this.getBranchName();
       if (!branch) return false;
       const localSha = (await git.revparse(['HEAD'])).trim();
-      await git.fetch('origin', branch);
-      const remoteSha = (await git.revparse([`origin/${branch}`])).trim();
+      // Fetch with fully-qualified ref and `--` separator so a branch name starting with `-`
+      // cannot be interpreted as a git option (defense in depth for untrusted PR branches).
+      await git.raw(['fetch', 'origin', '--', `refs/heads/${branch}`]);
+      const remoteSha = (await git.revparse([`refs/remotes/origin/${branch}`])).trim();
       if (!remoteSha || !localSha || remoteSha === localSha) return false;
       // If remote has a commit we don't, we're stale.
       const mergeBase = (await git.raw(['merge-base', localSha, remoteSha])).trim();


### PR DESCRIPTION
When two `bit ci pr` runs race on the same PR (e.g. `bit-pull-request` + `bit-init-and-verify` workflows, or back-to-back commits within minutes), both can pass the pre-export "existing remote lane" check, each create a fresh-hash lane locally, and then compete on export. The loser sees:

```
unable to merge "<scope>/<lane>" lane. a lane with the same id already exists with a different hash.
```

The export upload/merge phase can take 1-2 minutes, which is plenty of time for the other runner to persist its lane on the hub.

- Added `exportWithRetryOnLaneHashMismatch` — on hash-mismatch the helper force-deletes the remote lane (now populated by the winning push) and re-exports. Bounded to 3 attempts. Other errors and the final attempt's error propagate unchanged.
- Fixed cleanup in the `finally` block: track whether the rename to the final lane name happened, and skip the temp-lane cleanup when it did. This removes the misleading "Failed to clean up temporary lane: … was not found" log after post-rename failures.