### PR TITLE
fix(application): list available apps when 'bit run' finds multiple

### DIFF
--- a/scopes/harmony/application/run.cmd.ts
+++ b/scopes/harmony/application/run.cmd.ts
@@ -71,7 +71,8 @@ when no app name is specified, automatically detects and runs the app if only on
     const resolvedApp = appName ? appName : ids.length === 1 ? ids[0].toString() : undefined;
     if (!resolvedApp) {
       const runStr = chalk.cyan(`bit run <app id or name>`);
-      this.logger.console(`multiple apps found, please specify one using "${runStr}"`);
+      const appList = ids.map((id) => `  - ${id.toString()}`).join('\n');
+      this.logger.console(`multiple apps found, please specify one using "${runStr}".\navailable apps:\n${appList}`);
       process.exit(1);
     }
     // remove wds logs until refactoring webpack to a worker through the Worker aspect.

--- a/scopes/harmony/application/run.cmd.ts
+++ b/scopes/harmony/application/run.cmd.ts
@@ -63,15 +63,15 @@ when no app name is specified, automatically detects and runs the app if only on
   ) {}
 
   async wait([appName]: [string], { dev, watch, ssr, port: exactPort, args, noBrowser }: RunOptions) {
-    const ids = await this.application.loadAllAppsAsAspects();
-    if (!ids.length) {
+    const idsAndNames = await this.application.listAppsIdsAndNames();
+    if (!idsAndNames.length) {
       this.logger.console('no apps found');
       process.exit(1);
     }
-    const resolvedApp = appName ? appName : ids.length === 1 ? ids[0].toString() : undefined;
+    const resolvedApp = appName ? appName : idsAndNames.length === 1 ? idsAndNames[0].name : undefined;
     if (!resolvedApp) {
-      const runStr = chalk.cyan(`bit run <app id or name>`);
-      const appList = ids.map((id) => `  - ${id.toString()}`).join('\n');
+      const runStr = chalk.cyan(`bit run <app-name>`);
+      const appList = idsAndNames.map(({ name }) => `  - ${name}`).join('\n');
       this.logger.console(`multiple apps found, please specify one using "${runStr}".\navailable apps:\n${appList}`);
       process.exit(1);
     }

--- a/scopes/harmony/application/run.cmd.ts
+++ b/scopes/harmony/application/run.cmd.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { Command, CommandOptions } from '@teambit/cli';
+import { formatItem, formatSection } from '@teambit/cli';
 import type { Logger } from '@teambit/logger';
 import open from 'open';
 import type { ApplicationMain } from './application.main.runtime';
@@ -71,8 +72,10 @@ when no app name is specified, automatically detects and runs the app if only on
     const resolvedApp = appName ? appName : idsAndNames.length === 1 ? idsAndNames[0].name : undefined;
     if (!resolvedApp) {
       const runStr = chalk.cyan(`bit run <app-name>`);
-      const appList = idsAndNames.map(({ name }) => `  - ${name}`).join('\n');
-      this.logger.console(`multiple apps found, please specify one using "${runStr}".\navailable apps:\n${appList}`);
+      const sortedNames = idsAndNames.map(({ name }) => name).sort((a, b) => a.localeCompare(b));
+      const items = sortedNames.map((name) => formatItem(name));
+      const section = formatSection('available apps', '', items);
+      this.logger.console(`multiple apps found, please specify one using "${runStr}".\n\n${section}`);
       process.exit(1);
     }
     // remove wds logs until refactoring webpack to a worker through the Worker aspect.


### PR DESCRIPTION
When running `bit run` without an app name in a workspace with multiple apps, list the available app names in the error message so users know what to pick.