### PR TITLE
fix(ci): fail fast when remote lane delete reports not-found but list still shows it

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -460,7 +460,14 @@ export class CiMain {
           // `getLanes` just reported the lane exists, but the delete API says "not found". Re-query
           // to confirm. If the lane still shows up, something is off on the remote (delete can't
           // see what list/export can), and retrying will never converge.
-          const stillExists = await this.lanes.getLanes({ remote: laneId.scope, name: laneId.name }).catch(() => []);
+          let stillExists;
+          try {
+            stillExists = await this.lanes.getLanes({ remote: laneId.scope, name: laneId.name });
+          } catch (verifyErr: any) {
+            throw new Error(
+              `failed to verify whether remote lane ${laneId.toString()} still exists after delete returned "not found": ${verifyErr?.message || verifyErr}`
+            );
+          }
           if (stillExists.length) {
             throw new Error(
               `unable to delete remote lane ${laneId.toString()}: the remote reports the lane as "not found" from ` +
@@ -905,10 +912,10 @@ export class CiMain {
       const archiveLane = await this.lanes.removeLanes([laneId], { remote: true, force: true });
       if (archiveLane.length) {
         this.logger.console(chalk.green(`Lane '${laneId}' archived successfully`));
-      } else {
-        this.logger.console(chalk.yellow(`Failed to archive lane '${laneId}' - no lanes were removed`));
+        return 'deleted';
       }
-      return 'deleted';
+      this.logger.console(chalk.yellow(`Failed to archive lane '${laneId}' - no lanes were removed`));
+      return 'not-found';
     } catch (e: any) {
       if (e.message?.includes('was not found') || e.toString().includes('was not found')) {
         this.logger.console(chalk.yellow(`Lane '${laneId}' was not found on the remote`));

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -455,7 +455,20 @@ export class CiMain {
 
       if (existingLanes.length) {
         this.logger.console(chalk.blue(`Deleting existing remote lane ${laneId.toString()}`));
-        await this.archiveLane(laneId.toString(), true); // throwOnError: delete must succeed before export
+        const archiveResult = await this.archiveLane(laneId.toString(), true); // throwOnError: delete must succeed before export
+        if (archiveResult === 'not-found') {
+          // `getLanes` just reported the lane exists, but the delete API says "not found". Re-query
+          // to confirm. If the lane still shows up, something is off on the remote (delete can't
+          // see what list/export can), and retrying will never converge.
+          const stillExists = await this.lanes.getLanes({ remote: laneId.scope, name: laneId.name }).catch(() => []);
+          if (stillExists.length) {
+            throw new Error(
+              `unable to delete remote lane ${laneId.toString()}: the remote reports the lane as "not found" from ` +
+                `the delete API but still lists it from the query API. maybe this is a remote issue on bit.cloud. ` +
+                `please contact support or manually delete the lane on bit.cloud before re-running CI.`
+            );
+          }
+        }
       }
 
       // Rename temp lane to original name
@@ -885,7 +898,7 @@ export class CiMain {
    * Archives (deletes) a lane with proper error handling and logging.
    * @param throwOnError - if true, throws on failure (use for critical operations like pre-export cleanup)
    */
-  private async archiveLane(laneId: string, throwOnError = false) {
+  private async archiveLane(laneId: string, throwOnError = false): Promise<'deleted' | 'not-found' | 'error'> {
     try {
       this.logger.console(chalk.blue(`Archiving lane ${laneId}`));
       // force means to remove the lane even if it was not merged. in this case, we don't care much because main already has the changes.
@@ -895,16 +908,17 @@ export class CiMain {
       } else {
         this.logger.console(chalk.yellow(`Failed to archive lane '${laneId}' - no lanes were removed`));
       }
+      return 'deleted';
     } catch (e: any) {
-      // "not found" is success - another concurrent job may have deleted it
       if (e.message?.includes('was not found') || e.toString().includes('was not found')) {
-        this.logger.console(chalk.yellow(`Lane '${laneId}' was already deleted (likely by concurrent job)`));
-        return;
+        this.logger.console(chalk.yellow(`Lane '${laneId}' was not found on the remote`));
+        return 'not-found';
       }
       this.logger.console(chalk.red(`Error archiving lane '${laneId}': ${e.message}`));
       if (throwOnError) {
         throw new Error(`Failed to delete remote lane '${laneId}': ${e.message}`);
       }
+      return 'error';
       // Don't throw the error - lane cleanup is not critical to the merge process
     }
   }


### PR DESCRIPTION
When `bit ci pr` tries to delete an existing remote lane before export, the hub's delete API can report "not found" while the query API still lists the lane. In that state, the export later fails with "lane with the same id already exists with a different hash" and the retry loop can't recover.

Detect the contradiction at the point of deletion: if `archiveLane` returns `not-found` but `getLanes` still shows the lane, fail immediately with a clear message pointing to a possible remote issue on bit.cloud, instead of retrying 3× and then erroring out with a confusing hash-mismatch message.

- `archiveLane` now returns `'deleted' | 'not-found' | 'error'` so the caller can distinguish a real delete from a silent no-op.
- In the pre-export flow, re-verify with `getLanes` when the delete reports not-found; throw if the lane is still listed.