### PR TITLE
feat(diff): add ai-agent-friendly output flags

### DIFF
--- a/components/legacy/component-diff/components-diff.ts
+++ b/components/legacy/component-diff/components-diff.ts
@@ -117,3 +117,107 @@ export function outputDiffResults(diffResults: DiffResults[]): string {
     })
     .join('\n\n');
 }
+
+export type DiffOutputOptions = {
+  /** show only file-content diffs, drop fieldsDiff (deps, configs, metadata) */
+  filesOnly?: boolean;
+  /** show only fieldsDiff, drop file-content diffs */
+  configsOnly?: boolean;
+  /** limit file diffs to these component-relative paths (exact match or suffix match) */
+  files?: string[];
+  /** summary: one line per changed file with status letter + path, one line per changed field */
+  nameOnly?: boolean;
+  /** like nameOnly but also shows +N -M line counts per file */
+  stat?: boolean;
+};
+
+function matchesFileFilter(filePath: string, filters: string[]): boolean {
+  return filters.some((f) => filePath === f || filePath.endsWith(f) || f.endsWith(filePath));
+}
+
+export function filterDiffResults(diffResults: DiffResults[], opts: DiffOutputOptions): DiffResults[] {
+  const { filesOnly, configsOnly, files } = opts;
+  const hasFileFilter = files && files.length > 0;
+  if (!filesOnly && !configsOnly && !hasFileFilter) return diffResults;
+
+  return diffResults.map((result) => {
+    if (!result.hasDiff) return result;
+    const filesDiff = configsOnly
+      ? []
+      : hasFileFilter
+        ? (result.filesDiff || []).filter((fd) => matchesFileFilter(fd.filePath, files as string[]))
+        : result.filesDiff;
+    const fieldsDiff = filesOnly || hasFileFilter ? null : result.fieldsDiff;
+    const hasDiff = Boolean((filesDiff && filesDiff.some((f) => f.diffOutput)) || (fieldsDiff && fieldsDiff.length));
+    return { ...result, filesDiff, fieldsDiff, hasDiff };
+  });
+}
+
+const STATUS_LETTER: Record<DiffStatus, string> = {
+  MODIFIED: 'M',
+  NEW: 'A',
+  DELETED: 'D',
+  UNCHANGED: ' ',
+};
+
+function countDiffLines(diffOutput: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diffOutput.split('\n')) {
+    if (line.startsWith('+++') || line.startsWith('---')) continue;
+    if (line.startsWith('+')) additions += 1;
+    else if (line.startsWith('-')) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+function formatComponentHeader(diffResult: DiffResults): string {
+  return `showing diff for ${chalk.bold(diffResult.id.toStringWithoutVersion())}`;
+}
+
+export function outputDiffResultsNameOnly(diffResults: DiffResults[]): string {
+  return diffResults
+    .map((diffResult) => {
+      if (!diffResult.hasDiff) {
+        return `no diff for ${chalk.bold(diffResult.id.toString())}`;
+      }
+      const header = formatComponentHeader(diffResult);
+      const fileLines = (diffResult.filesDiff || [])
+        .filter((fd) => fd.diffOutput)
+        .map((fd) => `${STATUS_LETTER[fd.status]} ${fd.filePath}`);
+      const fieldLines = (diffResult.fieldsDiff || []).map((fd) => `F ${fd.fieldName}`);
+      const lines = [...fileLines, ...fieldLines];
+      if (!lines.length) return `${header}\n(no matching changes)`;
+      return [header, ...lines].join('\n');
+    })
+    .join('\n\n');
+}
+
+export function outputDiffResultsStat(diffResults: DiffResults[]): string {
+  return diffResults
+    .map((diffResult) => {
+      if (!diffResult.hasDiff) {
+        return `no diff for ${chalk.bold(diffResult.id.toString())}`;
+      }
+      const header = formatComponentHeader(diffResult);
+      const filesWithDiff = (diffResult.filesDiff || []).filter((fd) => fd.diffOutput);
+      const pathWidth = filesWithDiff.reduce((max, fd) => Math.max(max, fd.filePath.length), 0);
+      const fileLines = filesWithDiff.map((fd) => {
+        const { additions, deletions } = countDiffLines(fd.diffOutput);
+        const paddedPath = fd.filePath.padEnd(pathWidth);
+        return `${STATUS_LETTER[fd.status]} ${paddedPath}  +${additions} -${deletions}`;
+      });
+      const fieldLines = (diffResult.fieldsDiff || []).map((fd) => `F ${fd.fieldName}`);
+      const lines = [...fileLines, ...fieldLines];
+      if (!lines.length) return `${header}\n(no matching changes)`;
+      return [header, ...lines].join('\n');
+    })
+    .join('\n\n');
+}
+
+export function outputDiffResultsFormatted(diffResults: DiffResults[], opts: DiffOutputOptions = {}): string {
+  const filtered = filterDiffResults(diffResults, opts);
+  if (opts.nameOnly) return outputDiffResultsNameOnly(filtered);
+  if (opts.stat) return outputDiffResultsStat(filtered);
+  return outputDiffResults(filtered);
+}

--- a/components/legacy/component-diff/components-diff.ts
+++ b/components/legacy/component-diff/components-diff.ts
@@ -175,16 +175,20 @@ function formatComponentHeader(diffResult: DiffResults): string {
   return `showing diff for ${chalk.bold(diffResult.id.toStringWithoutVersion())}`;
 }
 
-export function outputDiffResultsNameOnly(diffResults: DiffResults[]): string {
+function outputDiffResultsSummary(diffResults: DiffResults[], includeStats: boolean): string {
   return diffResults
     .map((diffResult) => {
       if (!diffResult.hasDiff) {
         return `no diff for ${chalk.bold(diffResult.id.toString())}`;
       }
       const header = formatComponentHeader(diffResult);
-      const fileLines = (diffResult.filesDiff || [])
-        .filter((fd) => fd.diffOutput)
-        .map((fd) => `${STATUS_LETTER[fd.status]} ${fd.filePath}`);
+      const filesWithDiff = (diffResult.filesDiff || []).filter((fd) => fd.diffOutput);
+      const pathWidth = includeStats ? filesWithDiff.reduce((max, fd) => Math.max(max, fd.filePath.length), 0) : 0;
+      const fileLines = filesWithDiff.map((fd) => {
+        if (!includeStats) return `${STATUS_LETTER[fd.status]} ${fd.filePath}`;
+        const { additions, deletions } = countDiffLines(fd.diffOutput);
+        return `${STATUS_LETTER[fd.status]} ${fd.filePath.padEnd(pathWidth)}  +${additions} -${deletions}`;
+      });
       const fieldLines = (diffResult.fieldsDiff || []).map((fd) => `F ${fd.fieldName}`);
       const lines = [...fileLines, ...fieldLines];
       if (!lines.length) return `${header}\n(no matching changes)`;
@@ -193,26 +197,12 @@ export function outputDiffResultsNameOnly(diffResults: DiffResults[]): string {
     .join('\n\n');
 }
 
+export function outputDiffResultsNameOnly(diffResults: DiffResults[]): string {
+  return outputDiffResultsSummary(diffResults, false);
+}
+
 export function outputDiffResultsStat(diffResults: DiffResults[]): string {
-  return diffResults
-    .map((diffResult) => {
-      if (!diffResult.hasDiff) {
-        return `no diff for ${chalk.bold(diffResult.id.toString())}`;
-      }
-      const header = formatComponentHeader(diffResult);
-      const filesWithDiff = (diffResult.filesDiff || []).filter((fd) => fd.diffOutput);
-      const pathWidth = filesWithDiff.reduce((max, fd) => Math.max(max, fd.filePath.length), 0);
-      const fileLines = filesWithDiff.map((fd) => {
-        const { additions, deletions } = countDiffLines(fd.diffOutput);
-        const paddedPath = fd.filePath.padEnd(pathWidth);
-        return `${STATUS_LETTER[fd.status]} ${paddedPath}  +${additions} -${deletions}`;
-      });
-      const fieldLines = (diffResult.fieldsDiff || []).map((fd) => `F ${fd.fieldName}`);
-      const lines = [...fileLines, ...fieldLines];
-      if (!lines.length) return `${header}\n(no matching changes)`;
-      return [header, ...lines].join('\n');
-    })
-    .join('\n\n');
+  return outputDiffResultsSummary(diffResults, true);
 }
 
 export function outputDiffResultsFormatted(diffResults: DiffResults[], opts: DiffOutputOptions = {}): string {

--- a/components/legacy/component-diff/components-diff.ts
+++ b/components/legacy/component-diff/components-diff.ts
@@ -131,8 +131,16 @@ export type DiffOutputOptions = {
   stat?: boolean;
 };
 
+function normalizeFileFilterPath(p: string): string {
+  return p.startsWith('./') ? p.slice(2) : p;
+}
+
 function matchesFileFilter(filePath: string, filters: string[]): boolean {
-  return filters.some((f) => filePath === f || filePath.endsWith(f) || f.endsWith(filePath));
+  const normalizedPath = normalizeFileFilterPath(filePath);
+  return filters.some((f) => {
+    const normalizedFilter = normalizeFileFilterPath(f);
+    return normalizedPath === normalizedFilter || normalizedPath.endsWith(`/${normalizedFilter}`);
+  });
 }
 
 export function filterDiffResults(diffResults: DiffResults[], opts: DiffOutputOptions): DiffResults[] {
@@ -164,7 +172,7 @@ function countDiffLines(diffOutput: string): { additions: number; deletions: num
   let additions = 0;
   let deletions = 0;
   for (const line of diffOutput.split('\n')) {
-    if (line.startsWith('+++') || line.startsWith('---')) continue;
+    if (line.startsWith('+++ ') || line.startsWith('--- ')) continue;
     if (line.startsWith('+')) additions += 1;
     else if (line.startsWith('-')) deletions += 1;
   }

--- a/components/legacy/component-diff/components-diff.ts
+++ b/components/legacy/component-diff/components-diff.ts
@@ -107,10 +107,13 @@ export function outputDiffResults(diffResults: DiffResults[]): string {
         const titleStr = `showing diff for ${chalk.bold(diffResult.id.toStringWithoutVersion())}`;
         const titleSeparator = Array.from({ length: titleStr.length }).fill('-').join('');
         const title = chalk.cyan(`${titleSeparator}\n${titleStr}\n${titleSeparator}`);
-        // @ts-ignore since hasDiff is true, filesDiff must be set
-        const filesWithDiff = diffResult.filesDiff.filter((file) => file.diffOutput);
+        const filesWithDiff = (diffResult.filesDiff || []).filter((file) => file.diffOutput);
+        const hasFields = Boolean(diffResult.fieldsDiff && diffResult.fieldsDiff.length);
+        if (!filesWithDiff.length && !hasFields) {
+          return `${title}\n(no matching changes for the given filters)`;
+        }
         const files = filesWithDiff.map((fileDiff) => fileDiff.diffOutput).join('\n');
-        const fields = diffResult.fieldsDiff ? diffResult.fieldsDiff.map((field) => field.diffOutput).join('\n') : '';
+        const fields = hasFields ? diffResult.fieldsDiff!.map((field) => field.diffOutput).join('\n') : '';
         return `${title}\n${files}\n${fields}`;
       }
       return `no diff for ${chalk.bold(diffResult.id.toString())} (consider running with --verbose)`;
@@ -156,8 +159,7 @@ export function filterDiffResults(diffResults: DiffResults[], opts: DiffOutputOp
         ? (result.filesDiff || []).filter((fd) => matchesFileFilter(fd.filePath, files as string[]))
         : result.filesDiff;
     const fieldsDiff = filesOnly || hasFileFilter ? null : result.fieldsDiff;
-    const hasDiff = Boolean((filesDiff && filesDiff.some((f) => f.diffOutput)) || (fieldsDiff && fieldsDiff.length));
-    return { ...result, filesDiff, fieldsDiff, hasDiff };
+    return { ...result, filesDiff, fieldsDiff };
   });
 }
 
@@ -168,7 +170,7 @@ const STATUS_LETTER: Record<DiffStatus, string> = {
   UNCHANGED: ' ',
 };
 
-function countDiffLines(diffOutput: string): { additions: number; deletions: number } {
+export function countDiffLines(diffOutput: string): { additions: number; deletions: number } {
   let additions = 0;
   let deletions = 0;
   for (const line of diffOutput.split('\n')) {

--- a/components/legacy/component-diff/index.ts
+++ b/components/legacy/component-diff/index.ts
@@ -11,6 +11,7 @@ export {
   DiffResults,
   FieldsDiff,
   FileDiff,
+  countDiffLines,
   filterDiffResults,
   getFilesDiff,
   outputDiffResults,

--- a/components/legacy/component-diff/index.ts
+++ b/components/legacy/component-diff/index.ts
@@ -5,4 +5,16 @@ export {
   diffBetweenComponentsObjects,
 } from './components-object-diff';
 
-export { DiffOptions, DiffResults, FieldsDiff, FileDiff, getFilesDiff, outputDiffResults } from './components-diff';
+export {
+  DiffOptions,
+  DiffOutputOptions,
+  DiffResults,
+  FieldsDiff,
+  FileDiff,
+  filterDiffResults,
+  getFilesDiff,
+  outputDiffResults,
+  outputDiffResultsFormatted,
+  outputDiffResultsNameOnly,
+  outputDiffResultsStat,
+} from './components-diff';

--- a/components/legacy/e2e-helper/e2e-command-helper.ts
+++ b/components/legacy/e2e-helper/e2e-command-helper.ts
@@ -852,8 +852,8 @@ export default class CommandHelper {
   mergeMoveLane(laneName: string, options = '') {
     return this.runCmd(`bit lane merge-move ${laneName} ${options}`);
   }
-  diff(id = '') {
-    const output = this.runCmd(`bit diff ${id}`);
+  diff(id = '', flags = '') {
+    const output = this.runCmd(`bit diff ${id} ${flags}`);
     return removeChalkCharacters(output);
   }
   log(id: string, flags = '') {
@@ -894,7 +894,14 @@ export default class CommandHelper {
     runCmdOpts?: { envVariables?: Record<string, string> }
   ) {
     const parsedOpts = this.parseOptions(options);
-    return this.runCmd(`bit install ${packages} ${parsedOpts}`, cwd, 'pipe', undefined, false, runCmdOpts?.envVariables);
+    return this.runCmd(
+      `bit install ${packages} ${parsedOpts}`,
+      cwd,
+      'pipe',
+      undefined,
+      false,
+      runCmdOpts?.envVariables
+    );
   }
   update(flags?: string) {
     return this.runCmd(`bit update ${flags || ''}`);

--- a/e2e/commands/diff.e2e.ts
+++ b/e2e/commands/diff.e2e.ts
@@ -299,4 +299,115 @@ describe('bit diff command', function () {
       });
     });
   });
+  describe('ai-agent output flags', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.createComponentBarFoo(barFooV1);
+      helper.fixtures.addComponentBarFoo();
+      helper.fixtures.createComponentIsType();
+      helper.fixtures.addComponentUtilsIsType();
+      helper.command.tagAllComponents();
+      // modify source in bar/foo, and add a file in utils/is-type so both filesDiff and fieldsDiff appear
+      helper.fixtures.createComponentBarFoo(barFooV2);
+      helper.fs.createFile('is-type', 'extra.js', "module.exports = 'extra';\n");
+      helper.command.addComponent('is-type', { i: 'utils/is-type', m: 'is-type.js' });
+    });
+    describe('--name-only', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.diff('bar/foo', '--name-only');
+      });
+      it('should print the component header once', () => {
+        expect(output).to.have.string('showing diff for');
+        expect(output).to.have.string('bar/foo');
+      });
+      it('should list changed files with a status letter and path', () => {
+        expect(output).to.match(/^M foo\.js$/m);
+      });
+      it('should not include the unified diff body', () => {
+        expect(output).to.not.have.string('--- foo.js');
+        expect(output).to.not.have.string(barFooV2);
+      });
+    });
+    describe('--stat', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.diff('bar/foo', '--stat');
+      });
+      it('should include the changed file with +N -M counts', () => {
+        expect(output).to.match(/M foo\.js\s+\+\d+ -\d+/);
+      });
+      it('should not include the unified diff body', () => {
+        expect(output).to.not.have.string('@@ ');
+      });
+    });
+    describe('--file <path>', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.diff('utils/is-type', '--file extra.js');
+      });
+      it('should include the matching file diff', () => {
+        expect(output).to.have.string('extra.js');
+      });
+      it('should not include fields diff (implies --files-only)', () => {
+        expect(output).to.not.have.string('--- Main File');
+        expect(output).to.not.have.string('--- Files');
+      });
+    });
+    describe('--files-only', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.diff('utils/is-type', '--files-only');
+      });
+      it('should include file diffs', () => {
+        expect(output).to.have.string('extra.js');
+      });
+      it('should drop fields diff', () => {
+        expect(output).to.not.have.string('--- Files');
+        expect(output).to.not.have.string('--- Main File');
+      });
+    });
+    describe('--configs-only', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.diff('utils/is-type', '--configs-only');
+      });
+      it('should include fields diff', () => {
+        expect(output).to.have.string('--- Files');
+      });
+      it('should drop file-content diffs', () => {
+        expect(output).to.not.have.string('@@ ');
+      });
+    });
+    describe('--json', () => {
+      let parsed: any;
+      before(() => {
+        const raw = helper.command.runCmd('bit diff bar/foo --json');
+        parsed = JSON.parse(raw);
+      });
+      it('should return an array with one entry per matching component', () => {
+        expect(parsed).to.be.an('array');
+        expect(parsed).to.have.lengthOf(1);
+      });
+      it('should expose id, hasDiff, filesDiff, fieldsDiff', () => {
+        expect(parsed[0]).to.have.property('id').that.is.a('string');
+        expect(parsed[0]).to.have.property('hasDiff').that.is.a('boolean');
+        expect(parsed[0]).to.have.property('filesDiff');
+      });
+    });
+    describe('mutually exclusive flags', () => {
+      it('--files-only + --configs-only should error', () => {
+        const out = helper.general.runWithTryCatch('bit diff bar/foo --files-only --configs-only');
+        expect(out).to.have.string('mutually exclusive');
+      });
+      it('--name-only + --stat should error', () => {
+        const out = helper.general.runWithTryCatch('bit diff bar/foo --name-only --stat');
+        expect(out).to.have.string('mutually exclusive');
+      });
+      it('--configs-only + --file should error', () => {
+        const out = helper.general.runWithTryCatch('bit diff bar/foo --configs-only --file foo.js');
+        expect(out).to.have.string('cannot be combined');
+      });
+    });
+  });
 });

--- a/e2e/commands/diff.e2e.ts
+++ b/e2e/commands/diff.e2e.ts
@@ -406,7 +406,7 @@ describe('bit diff command', function () {
       });
       it('--configs-only + --file should error', () => {
         const out = helper.general.runWithTryCatch('bit diff bar/foo --configs-only --file foo.js');
-        expect(out).to.have.string('cannot be combined');
+        expect(out).to.have.string('mutually exclusive');
       });
     });
   });

--- a/e2e/commands/diff.e2e.ts
+++ b/e2e/commands/diff.e2e.ts
@@ -394,6 +394,33 @@ describe('bit diff command', function () {
         expect(parsed[0]).to.have.property('hasDiff').that.is.a('boolean');
         expect(parsed[0]).to.have.property('filesDiff');
       });
+      it('should include diffOutput in each filesDiff entry by default', () => {
+        expect(parsed[0].filesDiff[0]).to.have.property('diffOutput').that.is.a('string');
+      });
+    });
+    describe('--json --name-only', () => {
+      let parsed: any;
+      before(() => {
+        const raw = helper.command.runCmd('bit diff bar/foo --json --name-only');
+        parsed = JSON.parse(raw);
+      });
+      it('should omit diffOutput from filesDiff entries', () => {
+        expect(parsed[0].filesDiff[0]).to.have.property('filePath');
+        expect(parsed[0].filesDiff[0]).to.have.property('status');
+        expect(parsed[0].filesDiff[0]).to.not.have.property('diffOutput');
+      });
+    });
+    describe('--json --stat', () => {
+      let parsed: any;
+      before(() => {
+        const raw = helper.command.runCmd('bit diff bar/foo --json --stat');
+        parsed = JSON.parse(raw);
+      });
+      it('should include additions/deletions and omit diffOutput', () => {
+        expect(parsed[0].filesDiff[0]).to.have.property('additions').that.is.a('number');
+        expect(parsed[0].filesDiff[0]).to.have.property('deletions').that.is.a('number');
+        expect(parsed[0].filesDiff[0]).to.not.have.property('diffOutput');
+      });
     });
     describe('mutually exclusive flags', () => {
       it('--files-only + --configs-only should error', () => {

--- a/e2e/commands/diff.e2e.ts
+++ b/e2e/commands/diff.e2e.ts
@@ -313,7 +313,7 @@ describe('bit diff command', function () {
       helper.command.addComponent('is-type', { i: 'utils/is-type', m: 'is-type.js' });
     });
     describe('--name-only', () => {
-      let output: string;
+      let output: string | null | undefined;
       before(() => {
         output = helper.command.diff('bar/foo', '--name-only');
       });
@@ -330,7 +330,7 @@ describe('bit diff command', function () {
       });
     });
     describe('--stat', () => {
-      let output: string;
+      let output: string | null | undefined;
       before(() => {
         output = helper.command.diff('bar/foo', '--stat');
       });
@@ -342,7 +342,7 @@ describe('bit diff command', function () {
       });
     });
     describe('--file <path>', () => {
-      let output: string;
+      let output: string | null | undefined;
       before(() => {
         output = helper.command.diff('utils/is-type', '--file extra.js');
       });
@@ -355,7 +355,7 @@ describe('bit diff command', function () {
       });
     });
     describe('--files-only', () => {
-      let output: string;
+      let output: string | null | undefined;
       before(() => {
         output = helper.command.diff('utils/is-type', '--files-only');
       });
@@ -368,7 +368,7 @@ describe('bit diff command', function () {
       });
     });
     describe('--configs-only', () => {
-      let output: string;
+      let output: string | null | undefined;
       before(() => {
         output = helper.command.diff('utils/is-type', '--configs-only');
       });

--- a/scopes/component/component-compare/diff-cmd.ts
+++ b/scopes/component/component-compare/diff-cmd.ts
@@ -96,7 +96,7 @@ if both "version" and "to-version" are provided, compare those two versions dire
     return filtered.map((result) => ({
       id: result.id.toString(),
       hasDiff: result.hasDiff,
-      filesDiff: result.filesDiff,
+      filesDiff: result.filesDiff?.map(({ filePath, diffOutput, status }) => ({ filePath, diffOutput, status })),
       fieldsDiff: result.fieldsDiff,
     }));
   }
@@ -125,7 +125,7 @@ if both "version" and "to-version" are provided, compare those two versions dire
       throw new BitError('--files-only and --configs-only are mutually exclusive');
     }
     if (configsOnly && files && files.length) {
-      throw new BitError('--file cannot be combined with --configs-only');
+      throw new BitError('--file and --configs-only are mutually exclusive');
     }
     if (nameOnly && stat) {
       throw new BitError('--name-only and --stat are mutually exclusive');

--- a/scopes/component/component-compare/diff-cmd.ts
+++ b/scopes/component/component-compare/diff-cmd.ts
@@ -1,17 +1,31 @@
 import chalk from 'chalk';
+import { BitError } from '@teambit/bit-error';
 import type { Command, CommandOptions } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
-import type { DiffResults } from '@teambit/legacy.component-diff';
-import { outputDiffResults } from '@teambit/legacy.component-diff';
+import type { DiffOutputOptions, DiffResults } from '@teambit/legacy.component-diff';
+import { filterDiffResults, outputDiffResultsFormatted } from '@teambit/legacy.component-diff';
 import type { ComponentCompareMain } from './component-compare.main.runtime';
+
+type DiffFlags = {
+  verbose?: boolean;
+  table?: boolean;
+  parent?: boolean;
+  file?: string;
+  filesOnly?: boolean;
+  configsOnly?: boolean;
+  nameOnly?: boolean;
+  stat?: boolean;
+};
 
 export class DiffCmd implements Command {
   name = 'diff [component-pattern] [version] [to-version]';
   group = 'info-analysis';
   description = 'compare component changes between versions or against the current workspace';
-  extendedDescription = `shows a detailed diff of component files, dependencies, and configuration changes. 
+  extendedDescription = `shows a detailed diff of component files, dependencies, and configuration changes.
 by default, compares workspace changes against the latest version. specify versions to compare historical changes.
-supports pattern matching to filter components and various output formats for better readability.`;
+supports pattern matching to filter components and various output formats for better readability.
+for ai-agent workflows, use --name-only to list what changed, --file to drill into a specific file,
+--files-only / --configs-only to focus on one diff category, or --json for machine-readable output.`;
   helpUrl = 'docs/components/merging-changes#compare-component-snaps';
   arguments = [
     {
@@ -33,6 +47,16 @@ if both "version" and "to-version" are provided, compare those two versions dire
     ['p', 'parent', 'compare the specified "version" to its immediate parent instead of comparing to the current one'],
     ['v', 'verbose', 'show a more verbose output where possible'],
     ['t', 'table', 'show tables instead of plain text for dependencies diff'],
+    [
+      '',
+      'file <paths>',
+      'show only file diffs for the given component-relative path(s). comma-separated. implies --files-only',
+    ],
+    ['', 'files-only', 'show only file-content diffs; omit dependency, env, and aspect-config changes'],
+    ['', 'configs-only', 'show only dependency, env, and aspect-config changes; omit file-content diffs'],
+    ['', 'name-only', 'summary: list changed files with status (M/A/D) and changed field categories; no diff bodies'],
+    ['', 'stat', 'summary: like --name-only but includes +N -M line counts per file'],
+    ['j', 'json', 'return the diff result as json'],
   ] as CommandOptions;
   examples = [
     { cmd: 'diff', description: 'show diff for all modified components' },
@@ -47,23 +71,72 @@ if both "version" and "to-version" are provided, compare those two versions dire
       cmd: 'diff foo 0.0.2 --parent',
       description: 'compare "foo@0.0.2" to its parent version. showing what changed in 0.0.2',
     },
+    { cmd: 'diff foo --name-only', description: 'list changed files and field categories without diff bodies' },
+    { cmd: 'diff foo --file src/index.ts', description: 'show the diff of a single file in a component' },
+    { cmd: 'diff foo --files-only', description: 'show only source-code diffs, skip dependency/config changes' },
+    { cmd: 'diff foo --json', description: 'return the diff result as json for programmatic consumption' },
   ];
   loader = true;
 
   constructor(private componentCompareMain: ComponentCompareMain) {}
 
-  async report(
+  async report([pattern, version, toVersion]: [string, string, string], flags: DiffFlags) {
+    const outputOpts = this.parseOutputOpts(flags);
+    const diffResults = await this.runDiff([pattern, version, toVersion], flags);
+    if (!diffResults.length) {
+      return chalk.yellow('there are no modified components to diff');
+    }
+    return outputDiffResultsFormatted(diffResults, outputOpts);
+  }
+
+  async json([pattern, version, toVersion]: [string, string, string], flags: DiffFlags) {
+    const outputOpts = this.parseOutputOpts(flags);
+    const diffResults = await this.runDiff([pattern, version, toVersion], flags);
+    const filtered = filterDiffResults(diffResults, outputOpts);
+    return filtered.map((result) => ({
+      id: result.id.toString(),
+      hasDiff: result.hasDiff,
+      filesDiff: result.filesDiff,
+      fieldsDiff: result.fieldsDiff,
+    }));
+  }
+
+  private async runDiff(
     [pattern, version, toVersion]: [string, string, string],
-    { verbose = false, table = false, parent }: { verbose?: boolean; table: boolean; parent?: boolean }
-  ) {
-    const diffResults: DiffResults[] = await this.componentCompareMain.diffByCLIValues(pattern, version, toVersion, {
+    { verbose = false, table = false, parent }: DiffFlags
+  ): Promise<DiffResults[]> {
+    return this.componentCompareMain.diffByCLIValues(pattern, version, toVersion, {
       verbose,
       table,
       parent,
     });
-    if (!diffResults.length) {
-      return chalk.yellow('there are no modified components to diff');
+  }
+
+  private parseOutputOpts(flags: DiffFlags): DiffOutputOptions {
+    const { file, filesOnly, configsOnly, nameOnly, stat } = flags;
+    const files = file
+      ? file
+          .split(',')
+          .map((f) => f.trim())
+          .filter(Boolean)
+      : undefined;
+
+    if (filesOnly && configsOnly) {
+      throw new BitError('--files-only and --configs-only are mutually exclusive');
     }
-    return outputDiffResults(diffResults);
+    if (configsOnly && files && files.length) {
+      throw new BitError('--file cannot be combined with --configs-only');
+    }
+    if (nameOnly && stat) {
+      throw new BitError('--name-only and --stat are mutually exclusive');
+    }
+
+    return {
+      filesOnly,
+      configsOnly,
+      files,
+      nameOnly,
+      stat,
+    };
   }
 }

--- a/scopes/component/component-compare/diff-cmd.ts
+++ b/scopes/component/component-compare/diff-cmd.ts
@@ -2,8 +2,8 @@ import chalk from 'chalk';
 import { BitError } from '@teambit/bit-error';
 import type { Command, CommandOptions } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
-import type { DiffOutputOptions, DiffResults } from '@teambit/legacy.component-diff';
-import { filterDiffResults, outputDiffResultsFormatted } from '@teambit/legacy.component-diff';
+import type { DiffOutputOptions, DiffResults, FileDiff } from '@teambit/legacy.component-diff';
+import { countDiffLines, filterDiffResults, outputDiffResultsFormatted } from '@teambit/legacy.component-diff';
 import type { ComponentCompareMain } from './component-compare.main.runtime';
 
 type DiffFlags = {
@@ -15,6 +15,7 @@ type DiffFlags = {
   configsOnly?: boolean;
   nameOnly?: boolean;
   stat?: boolean;
+  json?: boolean;
 };
 
 export class DiffCmd implements Command {
@@ -96,9 +97,20 @@ if both "version" and "to-version" are provided, compare those two versions dire
     return filtered.map((result) => ({
       id: result.id.toStringWithoutVersion(),
       hasDiff: result.hasDiff,
-      filesDiff: result.filesDiff?.map(({ filePath, diffOutput, status }) => ({ filePath, diffOutput, status })),
+      filesDiff: result.filesDiff?.map((fd) => this.projectFileDiffForJson(fd, outputOpts)),
       fieldsDiff: result.fieldsDiff,
     }));
+  }
+
+  private projectFileDiffForJson(fd: FileDiff, opts: DiffOutputOptions) {
+    const { filePath, status } = fd;
+    if (opts.stat) {
+      return { filePath, status, ...countDiffLines(fd.diffOutput) };
+    }
+    if (opts.nameOnly) {
+      return { filePath, status };
+    }
+    return { filePath, status, diffOutput: fd.diffOutput };
   }
 
   private async runDiff(

--- a/scopes/component/component-compare/diff-cmd.ts
+++ b/scopes/component/component-compare/diff-cmd.ts
@@ -94,7 +94,7 @@ if both "version" and "to-version" are provided, compare those two versions dire
     const diffResults = await this.runDiff([pattern, version, toVersion], flags);
     const filtered = filterDiffResults(diffResults, outputOpts);
     return filtered.map((result) => ({
-      id: result.id.toString(),
+      id: result.id.toStringWithoutVersion(),
       hasDiff: result.hasDiff,
       filesDiff: result.filesDiff?.map(({ filePath, diffOutput, status }) => ({ filePath, diffOutput, status })),
       fieldsDiff: result.fieldsDiff,

--- a/scopes/component/component-compare/diff-cmd.ts
+++ b/scopes/component/component-compare/diff-cmd.ts
@@ -97,7 +97,9 @@ if both "version" and "to-version" are provided, compare those two versions dire
     return filtered.map((result) => ({
       id: result.id.toStringWithoutVersion(),
       hasDiff: result.hasDiff,
-      filesDiff: result.filesDiff?.map((fd) => this.projectFileDiffForJson(fd, outputOpts)),
+      filesDiff: result.filesDiff
+        ?.filter((fd) => fd.status !== 'UNCHANGED' && fd.diffOutput)
+        .map((fd) => this.projectFileDiffForJson(fd, outputOpts)),
       fieldsDiff: result.fieldsDiff,
     }));
   }
@@ -144,7 +146,7 @@ if both "version" and "to-version" are provided, compare those two versions dire
     }
 
     return {
-      filesOnly,
+      filesOnly: filesOnly || Boolean(files && files.length),
       configsOnly,
       files,
       nameOnly,


### PR DESCRIPTION
Make `bit diff` output usable for AI agents: let them discover what changed cheaply, drill into a specific file/category, and parse results structurally.

New flags on `bit diff`:
- `--name-only` — list changed files (M/A/D) + changed field categories, no diff bodies
- `--stat` — like `--name-only` plus `+N -M` line counts per file
- `--file <paths>` — comma-separated; show only the matching file diffs (implies `--files-only`)
- `--files-only` — drop `fieldsDiff` (deps/env/aspect-config/metadata)
- `--configs-only` — drop `filesDiff` (inverse)
- `--json` / `-j` — machine-readable output, mirrors `bit status --json`

Mutex pairs validated: `--files-only` + `--configs-only`, `--name-only` + `--stat`, `--configs-only` + `--file`.

All flags are output-layer filters over the existing `DiffResults` — no change to how diffs are computed. E2E coverage added in `e2e/commands/diff.e2e.ts`.