### PR TITLE
feat(init): generate AGENTS.md on workspace initialization

### DIFF
--- a/scopes/generator/generator/new.cmd.ts
+++ b/scopes/generator/generator/new.cmd.ts
@@ -59,6 +59,7 @@ installs dependencies and configures the workspace for immediate development.`;
       'current-dir',
       'create the new workspace in current directory (default is to create a new directory, inside the current dir)',
     ],
+    ['', 'agent [type]', 'create an AI agent instructions file. options: claude, cursor, copilot (default: AGENTS.md)'],
   ] as CommandOptions;
 
   constructor(private generator: GeneratorMain) {}

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -72,6 +72,9 @@ export class WorkspaceGenerator {
         {}
       );
       await this.writeWorkspaceFiles();
+      // Write agent instructions — resolve flag: true means default AGENTS.md, string means a specific tool.
+      const agentType = this.options.agent === true ? undefined : this.options.agent || undefined;
+      await HostInitializerMain.writeAgentInstructions(this.workspacePath, agentType, true);
       await this.reloadBitInWorkspaceDir();
       // Setting the workspace to be in install context to prevent errors during the workspace generation
       // the workspace will be in install context until the end of the generation install process

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -59,6 +59,8 @@ export class WorkspaceGenerator {
     try {
       process.chdir(this.workspacePath);
       await this.initGit();
+      // Resolve agent flag: true means default AGENTS.md, string means a specific tool.
+      const agentType = this.options.agent === true ? undefined : this.options.agent || undefined;
       await HostInitializerMain.init(
         this.workspacePath,
         this.options.skipGit,
@@ -69,11 +71,13 @@ export class WorkspaceGenerator {
         false,
         false,
         false,
-        {}
+        {},
+        undefined,
+        agentType
       );
       await this.writeWorkspaceFiles();
-      // Write agent instructions — resolve flag: true means default AGENTS.md, string means a specific tool.
-      const agentType = this.options.agent === true ? undefined : this.options.agent || undefined;
+      // Write agent instructions with skipGitCheck since bit new always creates a fresh workspace.
+      // When --skip-git is used, init() already wrote the file; hasExistingAgentFile() prevents a duplicate.
       await HostInitializerMain.writeAgentInstructions(this.workspacePath, agentType, true);
       await this.reloadBitInWorkspaceDir();
       // Setting the workspace to be in install context to prevent errors during the workspace generation

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -59,8 +59,7 @@ export class WorkspaceGenerator {
     try {
       process.chdir(this.workspacePath);
       await this.initGit();
-      // Resolve agent flag: true means default AGENTS.md, string means a specific tool.
-      const agentType = this.options.agent === true ? undefined : this.options.agent || undefined;
+      const agentType = this.options.agent || undefined;
       await HostInitializerMain.init(
         this.workspacePath,
         this.options.skipGit,

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -43,6 +43,12 @@ export interface BaseWorkspaceOptions {
    * Useful during the development of a workspace-template.
    */
   loadFrom?: string;
+
+  /**
+   * AI agent target. When set, writes agent instructions to the tool-specific file
+   * (e.g. "claude" → CLAUDE.md). When omitted, writes the universal AGENTS.md.
+   */
+  agent?: string;
 }
 
 /**

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -1,0 +1,304 @@
+# AGENTS.md
+
+This file teaches AI agents how to work correctly inside a **Bit workspace**. Read it fully before touching any code.
+
+---
+
+## What is Bit?
+
+Bit is a composable development platform where every piece of functionality is an independent, versioned, composed **component**. Components live in **scopes** (remote registries of business domains) and are managed through the `bit` CLI.
+
+### Component Types
+
+Not all components are UI widgets. In Bit, a "component" can be any of these:
+
+| Type                 | What it is                                                                                                  | Example                              |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **Entity**           | Plain domain object — defines the shape and behavior of a domain model. No React, no side effects.          | `entities/user`, `entities/order`    |
+| **Hook**             | Encapsulates data fetching, mutations, or stateful logic for a domain. Consumed by UI components and pages. | `hooks/use-user`, `hooks/use-orders` |
+| **UI component**     | Reusable visual element, typically stateless or lightly stateful.                                           | `ui/button`, `ui/card`               |
+| **Feature / Aspect** | Self-contained domain slice — owns its entities, hooks, pages, and backend logic.                           | `customers`, `billing`               |
+| **App**              | A standard deployable application — a React frontend, Node.js server, etc.                                  | `my-react-app`, `my-node-server`     |
+
+Understanding which type you're working with matters because it shapes the dependency chain. A typical app looks like this:
+
+```
+App  →  Page  →  Hook (optional)  →  Entity (optional)
+             ↘  UI component
+```
+
+Entities and hooks sit at the bottom of the chain — they have no dependents of their own, so changes to them propagate upward. Everything above that consumes them must be local for your changes to take effect.
+
+The workspace is defined by `workspace.jsonc`. The owner and default scope are set there — always read them first.
+
+---
+
+## Project Orientation
+
+```bash
+cat workspace.jsonc                  # find owner, scope, envs
+bit list                             # see what's already local
+bit status                           # check for pending changes
+bit templates                        # see what generators are available
+```
+
+---
+
+## Understanding Component APIs
+
+When you need to understand how to **use** a component (its props, function signatures, return types), prefer structured API data over reading source files:
+
+- **Local workspace components:** run `bit schema <component-id>` — returns exported types, function signatures, and class methods.
+- **Remote components:** run `bit show <owner>.<scope>/<name>` to inspect metadata and dependencies.
+
+For understanding implementation details (how something works internally), read the source directly.
+
+---
+
+## Common Commands
+
+```bash
+bit status                           # workspace health + pending changes
+bit start                            # dev server (default port 3000)
+bit run [app_name]                   # run the app
+bit list                             # all locally tracked components (do not pass args)
+bit search <query>                   # search components locally and on remote scopes
+bit show <owner>.<scope>/<name>      # inspect a specific component
+bit schema <component-id>            # structured API of a local component
+bit import "<owner>.<scope>/**"      # import all components from a remote scope
+bit templates                        # list available generator templates
+bit create <template> <name>         # scaffold a new component
+bit install [pkg1] [pkg2] ...        # install package dependencies
+bit compile                          # manual compile (usually auto — use for troubleshooting)
+bit test                             # run tests
+bit lint                             # run linter
+bit check-types                      # TypeScript type checker
+```
+
+> **Always use `bit install`** to install packages. Never use `npm install`, `yarn`, or `pnpm` directly — they will corrupt the workspace's dependency resolution.
+>
+> **Use Bit for type checking and testing.** Never use `tsc` or `npx tsc` directly. Scope to specific components when useful:
+>
+> ```bash
+> bit check-types "[component-id1, component-id2]"
+> bit test "[component-id1, component-id2]"
+> ```
+
+---
+
+## Discovering Apps
+
+```bash
+bit app list
+```
+
+Use `bit import` to fetch remote apps and run them locally.
+
+---
+
+## The Golden Rule: One Component at a Time
+
+Never scaffold multiple components upfront. Bit development is an **iterative loop**:
+
+```
+render → identify gap → create ONE component → render again
+```
+
+### Step-by-step
+
+1. **Look before you create.** Search the workspace and remote scopes first:
+
+   ```bash
+   bit search <keyword>
+   bit show <owner>.<scope>/<name>
+   ```
+
+   A component may already exist locally or remotely. Don't duplicate.
+
+2. **Identify the entry point.** Depending on what you're building, the entry point could be an app or a feature. List what exists in the scope before creating anything new.
+
+3. **Create one component.** Scaffold it, wire it in, verify it compiles and renders.
+
+4. **Validate before moving on:**
+
+   ```bash
+   bit status
+   bit check-types
+   bit test
+   ```
+
+5. **Identify the next gap.** Only then decide what the next component should be.
+
+6. **Repeat.** Never pre-plan a list of components and create them all at once.
+
+#### Example
+
+Create a UI component:
+
+```bash
+bit create react pages/login --scope acme.people
+```
+
+Create a data entity:
+
+```bash
+bit create entity entities/user --scope acme.people
+```
+
+---
+
+## Importing Components for Modification
+
+Bit resolves **local workspace components** over their installed package versions. If you want to modify a component, it must be imported into the workspace — otherwise the app will use the published version and ignore your changes.
+
+### The full dependency chain must be local
+
+When modifying any component, import every component in the chain from the top down to your target:
+
+```
+App  →  Feature/Aspect  →  Page  →  UI component
+```
+
+You don't always need the full chain — only the layers in the dependency path of your change. But every layer between the entry point and your target must be local. If any layer in between is still installed as a package (not local), the app will ignore your changes to the layers below it.
+
+**Examples:**
+
+- Changing a UI component used by a feature page → import the feature, the page, and the UI component.
+- Changing a feature's backend logic → import the app and the feature/aspect.
+
+### Finding the component ID
+
+```bash
+cat node_modules/@<org>/<package-name>/package.json | grep -A3 '"componentId"'
+# "scope": "myorg.myfeature"
+# "name":  "pages/my-page"
+# → component ID: myorg.myfeature/pages/my-page
+```
+
+### Importing
+
+```bash
+bit import <scope>/<name>
+# e.g.
+bit import myorg.myfeature/pages/my-page myorg.myfeature/pages/lobby-page
+```
+
+Imported components land at `<scope-short-name>/<name>/` in the workspace.
+
+#### Importing whole scopes
+
+```bash
+bit import "<owner>.<scope>/**"
+```
+
+---
+
+## Saving and Publishing Changes
+
+**Never push directly to the main lane.** Always create a lane and submit a change request.
+
+Git does not manage component versions in a Bit workspace — use Bit for version control of components.
+
+```bash
+bit lane create <your-lane-name>     # create a new lane
+bit status                           # confirm no pending issues
+bit snap --message "describe change" # persist component versions
+bit export                           # push lane to remote
+```
+
+> Always run `bit lane create` first. If you're already on a non-main lane, continue using it — don't create a new one.
+
+---
+
+## Component Structure
+
+Each component directory follows this convention:
+
+| File                     | Purpose                              |
+| ------------------------ | ------------------------------------ |
+| `<name>.tsx`             | Main implementation                  |
+| `index.ts`               | Public barrel export                 |
+| `<name>.spec.tsx`        | Tests                                |
+| `<name>.composition.tsx` | Live previews (shown in `bit start`) |
+| `<name>.docs.mdx`        | Documentation                        |
+| `<name>.mock.ts`         | Mock data / fixtures                 |
+| `*-type.ts`              | Standalone type definitions          |
+
+> Add JSDocs to exported APIs, include two to three usage examples in the `.docs.mdx`, and two to three compositions for the live preview.
+
+---
+
+## Import Path Convention
+
+Components import each other using Bit's package notation:
+
+```ts
+import { Something } from '@<org>/<scope>.<namespace>.<name>';
+```
+
+Never use relative paths across component boundaries. Always use the package notation.
+
+---
+
+## Environment Setup
+
+Generator environments (React, Vue, Node, Angular, etc.) are configured in `workspace.jsonc`. Some may be commented out. Enable the relevant environment before creating components for a specific framework.
+
+---
+
+## Key Files
+
+| File              | Purpose                                                             |
+| ----------------- | ------------------------------------------------------------------- |
+| `workspace.jsonc` | Workspace config — scopes, envs, component patterns                 |
+| `.bitmap`         | Auto-generated — tracks component locations. **Must be committed.** |
+| `package.json`    | Usually `"type": "module"` for ES Modules                           |
+
+---
+
+## Runtime Code Crossing Environment Boundaries
+
+Importing frontend modules into Node.js runtime files or Node.js modules into browser runtime files causes app initialization failures. This typically happens when `index.ts` or runtime files import/export cross-environment modules by value instead of by type.
+
+**Rules for aspect `index.ts` files:**
+
+- The Aspect manifest (from `*.aspect.ts`) is the **only** allowed value export. Everything else must use `export type`.
+- Runtime modules (`*.node.runtime.ts`, `*.browser.runtime.ts`) must **always** be exported as types.
+
+```ts
+// ✅ Correct
+export type { MyBrowser } from './my.browser.runtime.js';
+export type { MyNode } from './my.node.runtime.js';
+export type { User } from './user.js';
+export default MyAspect;
+export { MyAspect };
+
+// ❌ Wrong — pulls frontend/backend code into the wrong runtime
+export { MyBrowser } from './my.browser.runtime.js';
+export { User } from './user.js';
+```
+
+**Rules for `*.node.runtime.ts` files:**
+
+- Must not import frontend modules (React components, SCSS, browser-only libraries) by value. Use `import type` if only the type is needed.
+
+**Rules for `*.browser.runtime.tsx` files:**
+
+- Must not import Node.js modules (`fs`, `path`, server-only libraries) by value. Use `import type` if only the type is needed.
+
+---
+
+## Common Mistakes to Avoid
+
+| Mistake                                                    | Correct approach                                                                                         |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Creating multiple components upfront                       | Create one, validate, then decide what's next                                                            |
+| Modifying an installed (node_modules) component            | Import it with `bit import` first                                                                        |
+| Importing only the target component but not its dependents | Import the full chain top-down: app → feature → page → component                                         |
+| Treating all components as UI widgets                      | Understand the type first — app, feature/aspect, hook, entity, or UI component — it determines the chain |
+| Pushing to the main lane                                   | Always create a lane, snap, then export                                                                  |
+| Using git to version components                            | Bit manages component versions — use `bit snap` / `bit export`                                           |
+| Guessing a component ID                                    | Check `package.json` under `componentId` or use `bit list`                                               |
+| Creating a component that already exists                   | Always run `bit search` first                                                                            |
+| Using `npm install`, `yarn`, or `pnpm`                     | Use `bit install`                                                                                        |
+| Using `tsc` or `npx tsc` to check types                    | Use `bit check-types` or `bit test`                                                                      |

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# Bit Workspace — AI Agent Instructions
 
 This file teaches AI agents how to work correctly inside a **Bit workspace**. Read it fully before touching any code.
 
@@ -75,7 +75,7 @@ bit lint                             # run linter
 bit check-types                      # TypeScript type checker
 ```
 
-> **Always use `bit install`** to install packages. Never use `npm install`, `yarn`, or `pnpm` directly — they will corrupt the workspace's dependency resolution.
+> **Always use `bit install`** to install packages. Never use `npm install`, `yarn`, or `pnpm` directly — unless the workspace is configured with `externalPackageManager` mode in `workspace.jsonc`, in which case use your configured package manager.
 >
 > **Use Bit for type checking and testing.** Never use `tsc` or `npx tsc` directly. Scope to specific components when useful:
 >

--- a/scopes/harmony/host-initializer/host-initializer.main.runtime.ts
+++ b/scopes/harmony/host-initializer/host-initializer.main.runtime.ts
@@ -160,6 +160,10 @@ export class HostInitializerMain {
     agent?: string,
     skipGitCheck = false
   ): Promise<string | undefined> {
+    if (agent && !HostInitializerMain.AGENT_FILE_MAP[agent]) {
+      const supported = Object.keys(HostInitializerMain.AGENT_FILE_MAP).join(', ');
+      throw new Error(`unknown --agent value "${agent}". supported values: ${supported}`);
+    }
     try {
       // Don't write in git repos — they use the interactive flow.
       // Callers like `bit new` set skipGitCheck because they always create a fresh workspace.
@@ -168,8 +172,7 @@ export class HostInitializerMain {
       // Don't write if any agent file already exists.
       if (await HostInitializerMain.hasExistingAgentFile(projectPath)) return undefined;
 
-      const relativePath = agent ? HostInitializerMain.AGENT_FILE_MAP[agent] : undefined;
-      const targetFile = relativePath || 'AGENTS.md';
+      const targetFile = agent ? HostInitializerMain.AGENT_FILE_MAP[agent] : 'AGENTS.md';
       const targetPath = path.join(projectPath, targetFile);
 
       // Read the shared template content.
@@ -203,12 +206,7 @@ export class HostInitializerMain {
    */
   static wrapWithFrontmatter(targetFile: string, content: string): string {
     if (targetFile === '.cursor/rules/bit.mdc') {
-      return `---
-description: Bit workspace instructions
-alwaysApply: true
----
-
-${content}`;
+      return ['---', 'description: Bit workspace instructions', 'alwaysApply: true', '---', '', content].join('\n');
     }
     return content;
   }

--- a/scopes/harmony/host-initializer/host-initializer.main.runtime.ts
+++ b/scopes/harmony/host-initializer/host-initializer.main.runtime.ts
@@ -62,8 +62,9 @@ export class HostInitializerMain {
     resetScope = false,
     force = false,
     workspaceConfigProps: WorkspaceExtensionProps = {},
-    generator?: string
-  ): Promise<{ created: boolean; consumer: Consumer }> {
+    generator?: string,
+    agent?: string
+  ): Promise<{ created: boolean; consumer: Consumer; agentFileWritten?: string }> {
     const consumerInfo = await getWorkspaceInfo(absPath || process.cwd());
     // if "bit init" was running without any flags, the user is probably trying to init a new workspace but wasn't aware
     // that he's already in a workspace.
@@ -115,7 +116,101 @@ export class HostInitializerMain {
       await consumer.resetLaneNew();
     }
     const writtenConsumer = await consumer.write();
-    return { created: !consumerInfo?.path, consumer: writtenConsumer };
+    const created = !consumerInfo?.path;
+    let agentFileWritten: string | undefined;
+    if (created) {
+      agentFileWritten = await HostInitializerMain.writeAgentInstructions(consumerPath, agent);
+    }
+    return { created, consumer: writtenConsumer, agentFileWritten };
+  }
+
+  /**
+   * Supported agent targets and their output file paths (relative to workspace root).
+   */
+  static readonly AGENT_FILE_MAP: Record<string, string> = {
+    claude: 'CLAUDE.md',
+    cursor: '.cursor/rules/bit.mdc',
+    copilot: '.github/copilot-instructions.md',
+  };
+
+  /**
+   * All known agent instruction file paths. Used to detect whether a workspace
+   * already contains any agent configuration.
+   */
+  static readonly ALL_AGENT_FILES = [
+    'AGENTS.md',
+    'CLAUDE.md',
+    '.cursorrules',
+    '.cursor/rules',
+    '.github/copilot-instructions.md',
+  ];
+
+  /**
+   * Write AI agent instructions into the workspace.
+   *
+   * - Skips if .git exists (git repos use the interactive init flow).
+   * - Skips if any known agent instruction file already exists.
+   * - When `agent` is provided, writes to the tool-specific path (e.g. CLAUDE.md).
+   * - When `agent` is omitted, writes the universal AGENTS.md.
+   *
+   * Returns the relative path of the file written, or undefined if skipped.
+   */
+  static async writeAgentInstructions(
+    projectPath: string,
+    agent?: string,
+    skipGitCheck = false
+  ): Promise<string | undefined> {
+    try {
+      // Don't write in git repos — they use the interactive flow.
+      // Callers like `bit new` set skipGitCheck because they always create a fresh workspace.
+      if (!skipGitCheck && (await HostInitializerMain.hasGitDirectory(projectPath))) return undefined;
+
+      // Don't write if any agent file already exists.
+      if (await HostInitializerMain.hasExistingAgentFile(projectPath)) return undefined;
+
+      const relativePath = agent ? HostInitializerMain.AGENT_FILE_MAP[agent] : undefined;
+      const targetFile = relativePath || 'AGENTS.md';
+      const targetPath = path.join(projectPath, targetFile);
+
+      // Read the shared template content.
+      const templatePath = path.join(__dirname, 'agents-template.md');
+      const content = await fs.readFile(templatePath, 'utf8');
+
+      // Some formats require frontmatter.
+      const finalContent = HostInitializerMain.wrapWithFrontmatter(targetFile, content);
+
+      await fs.ensureDir(path.dirname(targetPath));
+      await fs.writeFile(targetPath, finalContent);
+      return targetFile;
+    } catch {
+      // Don't fail initialization if the agent file cannot be written.
+      return undefined;
+    }
+  }
+
+  /**
+   * Check if any known agent instruction file or directory already exists.
+   */
+  static async hasExistingAgentFile(projectPath: string): Promise<boolean> {
+    for (const rel of HostInitializerMain.ALL_AGENT_FILES) {
+      if (await fs.pathExists(path.join(projectPath, rel))) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Wrap template content with tool-specific frontmatter where required.
+   */
+  static wrapWithFrontmatter(targetFile: string, content: string): string {
+    if (targetFile === '.cursor/rules/bit.mdc') {
+      return `---
+description: Bit workspace instructions
+alwaysApply: true
+---
+
+${content}`;
+    }
+    return content;
   }
 
   /**
@@ -321,7 +416,8 @@ node_modules
     reset: boolean,
     resetHard: boolean,
     resetScope: boolean,
-    interactiveConfig: InteractiveConfig | null
+    interactiveConfig: InteractiveConfig | null,
+    agentFileWritten?: string
   ): string {
     let initMessage = formatSuccessSummary('initialized a bit workspace.');
 
@@ -329,6 +425,12 @@ node_modules
     if (reset) initMessage = formatHint('your bit workspace has been reset successfully.');
     if (resetHard) initMessage = formatHint('your bit workspace has been hard-reset successfully.');
     if (resetScope) initMessage = formatHint('your local scope has been reset successfully.');
+
+    if (agentFileWritten) {
+      initMessage += formatHint(
+        `\n  Created ${chalk.cyan(agentFileWritten)} — instructions for AI agents working in this workspace`
+      );
+    }
 
     // Add additional information for interactive mode
     if (interactiveConfig) {

--- a/scopes/harmony/host-initializer/init-cmd.ts
+++ b/scopes/harmony/host-initializer/init-cmd.ts
@@ -63,6 +63,7 @@ supports various reset options to recover from corrupted state or restart from s
     ['s', 'shared <groupname>', 'add group write permissions to a scope properly'],
     ['', 'external-package-manager', 'enable external package manager mode (npm/yarn/pnpm)'],
     ['', 'skip-interactive', 'skip interactive mode for Git repositories'],
+    ['', 'agent [type]', 'create an AI agent instructions file. options: claude, cursor, copilot (default: AGENTS.md)'],
   ] as CommandOptions;
 
   constructor(
@@ -138,6 +139,7 @@ supports various reset options to recover from corrupted state or restart from s
       defaultDirectory,
       defaultScope,
       externalPackageManager,
+      agent,
     } = flags;
 
     if (path) path = pathlib.resolve(path);
@@ -167,7 +169,10 @@ supports various reset options to recover from corrupted state or restart from s
       externalPackageManager: interactiveConfig?.externalPackageManager || externalPackageManager,
     };
 
-    const { created } = await HostInitializerMain.init(
+    // Resolve agent flag: true means no specific type (use default AGENTS.md), string means a specific tool.
+    const agentType = agent === true ? undefined : agent || undefined;
+
+    const { created, agentFileWritten } = await HostInitializerMain.init(
       path,
       standalone,
       noPackageJson,
@@ -178,9 +183,17 @@ supports various reset options to recover from corrupted state or restart from s
       resetScope,
       force,
       workspaceExtensionProps,
-      interactiveConfig?.generator || generator
+      interactiveConfig?.generator || generator,
+      agentType
     );
 
-    return HostInitializerMain.generateInitMessage(created, reset, resetHard, resetScope, interactiveConfig);
+    return HostInitializerMain.generateInitMessage(
+      created,
+      reset,
+      resetHard,
+      resetScope,
+      interactiveConfig,
+      agentFileWritten
+    );
   }
 }


### PR DESCRIPTION
Write AI agent instructions when running `bit init` or `bit new` so AI coding tools (Claude Code, Cursor, Copilot, Gemini, Codex, etc.) understand how to work in a Bit workspace out of the box.

- By default writes `AGENTS.md` (the universal standard supported by 55+ tools)
- `--agent` flag targets a specific tool: `claude` → `CLAUDE.md`, `cursor` → `.cursor/rules/bit.mdc`, `copilot` → `.github/copilot-instructions.md`
- Skips writing in git repos (those use the interactive init flow)
- Skips if any existing agent config file is detected (AGENTS.md, CLAUDE.md, .cursorrules, etc.)
- Includes `bit search` in the generated instructions