### PR TITLE
fix(ci): use bit diff --json for no-op merge detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -712,9 +712,10 @@ jobs:
           command: |
             # Grepping stdout of `bit diff` is unsafe: unified-diff content of a modified
             # source file can contain the "no modified components" sentinel string itself
-            # (e.g. when diff-cmd.ts is modified). Use structured JSON output instead —
-            # `bit diff --json` returns the literal "[]" iff there are no modified components.
-            if cd bit && [ "$(bit diff --json)" = "[]" ]; then
+            # (e.g. when diff-cmd.ts is modified). Use structured JSON output instead.
+            # --name-only omits full diff bodies so this stays cheap on large merges;
+            # the top-level JSON array is empty iff there are no modified components.
+            if cd bit && bit diff --json --name-only | tr -d '[:space:]' | grep -q '^\[\]$'; then
               if grep -q '"nextVersion": {' .bitmap; then
                 echo "No changes detected, but soft-tagged components found. Continuing workflow."
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,7 +710,11 @@ jobs:
       - run:
           name: If no component has changed, exit the job
           command: |
-            if cd bit && bit diff | grep -q "there are no modified components to diff"; then
+            # Grepping stdout of `bit diff` is unsafe: unified-diff content of a modified
+            # source file can contain the "no modified components" sentinel string itself
+            # (e.g. when diff-cmd.ts is modified). Use structured JSON output instead —
+            # `bit diff --json` returns the literal "[]" iff there are no modified components.
+            if cd bit && [ "$(bit diff --json)" = "[]" ]; then
               if grep -q '"nextVersion": {' .bitmap; then
                 echo "No changes detected, but soft-tagged components found. Continuing workflow."
               else


### PR DESCRIPTION
The grep sentinel \`"there are no modified components to diff"\` is also the source code of \`diff-cmd.ts:88\`. Whenever a PR modifies that file, its unified diff contains the string inside a \`+\` line, grep matches, and \`bit_merge\` wrongly halts. #10307 surfaced this on master.

**Fix:** check \`bit diff --json --name-only\` for an empty top-level array. Structured data can't be mimicked by diff body content; \`--name-only\` keeps the payload tiny on large merges.

**Future-proofing:** don't grep human-readable CLI output for CI control flow — use \`--json\` or a dedicated exit code (e.g. a \`git diff --exit-code\`-style flag on \`bit diff\`, nice follow-up).