### PR TITLE
fix(snap-distance): throw actionable error when localHead missing from graph

### DIFF
--- a/e2e/harmony/local-head-not-found.e2e.ts
+++ b/e2e/harmony/local-head-not-found.e2e.ts
@@ -1,0 +1,49 @@
+import chai, { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+import { sha1 } from '@teambit/toolbox.crypto.sha1';
+import chaiFs from 'chai-fs';
+
+chai.use(chaiFs);
+
+describe('local head Version object is missing from scope', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('head ref points to a missing snap while bitmap is pinned to a valid older version', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      // snap a new version locally so the head points to something that's not on the remote.
+      helper.fixtures.populateComponents(1, false, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      const compAfterSnap = helper.command.catComponent(`${helper.scopes.remote}/comp1`);
+      const headHash = compAfterSnap.head as string;
+
+      // pin the bitmap back to 0.0.1 so component-loading stays valid while the
+      // modelComponent's head still points to the snap we're about to delete.
+      helper.command.checkoutVersion('0.0.1', 'comp1');
+
+      // delete the snap's Version object and the VersionHistory so the head is not
+      // recoverable from either the objects store or the VersionHistory.
+      helper.fs.deleteObject(helper.general.getHashPathOfObject(headHash));
+      const versionHistoryHash = sha1(`${helper.scopes.remote}/comp1:VersionHistory`);
+      helper.fs.deleteObject(helper.general.getHashPathOfObject(versionHistoryHash));
+    });
+    it('bit status should not surface the raw cleargraph "does not exist on graph" error', () => {
+      const output = helper.general.runWithTryCatch('bit status');
+      expect(output).to.not.include('does not exist on graph');
+      expect(output).to.include('comp1');
+    });
+    it('bit checkout head should not surface the raw cleargraph "does not exist on graph" error', () => {
+      const output = helper.general.runWithTryCatch('bit checkout head');
+      expect(output).to.not.include('does not exist on graph');
+    });
+  });
+});

--- a/e2e/harmony/local-head-not-found.e2e.ts
+++ b/e2e/harmony/local-head-not-found.e2e.ts
@@ -36,14 +36,16 @@ describe('local head Version object is missing from scope', function () {
       const versionHistoryHash = sha1(`${helper.scopes.remote}/comp1:VersionHistory`);
       helper.fs.deleteObject(helper.general.getHashPathOfObject(versionHistoryHash));
     });
-    it('bit status should not surface the raw cleargraph "does not exist on graph" error', () => {
+    it('bit status should surface LocalHeadNotFound with actionable "bit import --objects" instead of the raw graph error', () => {
       const output = helper.general.runWithTryCatch('bit status');
       expect(output).to.not.include('does not exist on graph');
-      expect(output).to.include('comp1');
+      expect(output).to.match(/bit import .*--objects/);
     });
-    it('bit checkout head should not surface the raw cleargraph "does not exist on graph" error', () => {
+    it('bit checkout head should fail early with LocalHeadNotFound (not a later ComponentNotFound) and suggest "bit import --objects"', () => {
       const output = helper.general.runWithTryCatch('bit checkout head');
       expect(output).to.not.include('does not exist on graph');
+      expect(output).to.not.include('ComponentNotFound');
+      expect(output).to.match(/bit import .*--objects/);
     });
   });
 });

--- a/scopes/component/snap-distance/get-diverge-data.ts
+++ b/scopes/component/snap-distance/get-diverge-data.ts
@@ -7,6 +7,7 @@ import { Ref, versionParentsToGraph } from '@teambit/objects';
 import { SnapsDistance } from './snaps-distance';
 import { getAllVersionHashes, getAllVersionParents } from './traverse-versions';
 import { TargetHeadNotFound } from './target-head-not-found';
+import { LocalHeadNotFound } from './local-head-not-found';
 
 /**
  * *** NEW WAY ***
@@ -87,6 +88,9 @@ export async function getDivergeData({
   const unmergedData = repo.unmergedComponents.getEntry(modelComponent.toComponentId());
   if (!versionParents.find((p) => p.hash.isEqual(targetHead))) {
     throw new TargetHeadNotFound(modelComponent.id(), targetHead.toString());
+  }
+  if (!versionParents.find((p) => p.hash.isEqual(localHead))) {
+    throw new LocalHeadNotFound(modelComponent.id(), localHead.toString());
   }
 
   return getDivergeDataBetweenTwoSnaps(

--- a/scopes/component/snap-distance/get-diverge-data.ts
+++ b/scopes/component/snap-distance/get-diverge-data.ts
@@ -86,15 +86,15 @@ export async function getDivergeData({
     versionParentsFromObjects,
   });
   const unmergedData = repo.unmergedComponents.getEntry(modelComponent.toComponentId());
+  // these are fatal data-integrity errors (head ref points to an object that can't be reached).
+  // always throw regardless of `throws`: callers such as `headIncludeRemote` don't inspect
+  // `SnapsDistance.err` and would otherwise proceed with a missing hash, leading to an opaque
+  // failure (e.g. ComponentNotFound) later in the flow — after partial work has already run.
   if (!versionParents.find((p) => p.hash.isEqual(targetHead))) {
-    const err = new TargetHeadNotFound(modelComponent.id(), targetHead.toString());
-    if (throws) throw err;
-    return new SnapsDistance([], [], undefined, err);
+    throw new TargetHeadNotFound(modelComponent.id(), targetHead.toString());
   }
   if (!versionParents.find((p) => p.hash.isEqual(localHead))) {
-    const err = new LocalHeadNotFound(modelComponent.id(), localHead.toString());
-    if (throws) throw err;
-    return new SnapsDistance([], [], undefined, err);
+    throw new LocalHeadNotFound(modelComponent.id(), localHead.toString());
   }
 
   return getDivergeDataBetweenTwoSnaps(

--- a/scopes/component/snap-distance/get-diverge-data.ts
+++ b/scopes/component/snap-distance/get-diverge-data.ts
@@ -87,10 +87,14 @@ export async function getDivergeData({
   });
   const unmergedData = repo.unmergedComponents.getEntry(modelComponent.toComponentId());
   if (!versionParents.find((p) => p.hash.isEqual(targetHead))) {
-    throw new TargetHeadNotFound(modelComponent.id(), targetHead.toString());
+    const err = new TargetHeadNotFound(modelComponent.id(), targetHead.toString());
+    if (throws) throw err;
+    return new SnapsDistance([], [], undefined, err);
   }
   if (!versionParents.find((p) => p.hash.isEqual(localHead))) {
-    throw new LocalHeadNotFound(modelComponent.id(), localHead.toString());
+    const err = new LocalHeadNotFound(modelComponent.id(), localHead.toString());
+    if (throws) throw err;
+    return new SnapsDistance([], [], undefined, err);
   }
 
   return getDivergeDataBetweenTwoSnaps(

--- a/scopes/component/snap-distance/index.ts
+++ b/scopes/component/snap-distance/index.ts
@@ -12,3 +12,4 @@ export {
   GetAllVersionHashesParams,
 } from './traverse-versions';
 export { TargetHeadNotFound } from './target-head-not-found';
+export { LocalHeadNotFound } from './local-head-not-found';

--- a/scopes/component/snap-distance/local-head-not-found.ts
+++ b/scopes/component/snap-distance/local-head-not-found.ts
@@ -1,0 +1,9 @@
+import { BitError } from '@teambit/bit-error';
+
+export class LocalHeadNotFound extends BitError {
+  constructor(componentId: string, localHead: string) {
+    super(`error: the local head of "${componentId}" is ${localHead}, which is missing from the VersionHistory object and its Version object cannot be loaded locally.
+this can happen when a previous import/fetch was interrupted or when the local scope is out of sync.
+try running "bit import ${componentId} --objects".`);
+  }
+}


### PR DESCRIPTION
Users occasionally hit `Node <hash> does not exist on graph` during `bit switch main` and `bit stash load`. The error is thrown by cleargraph when `successorsSubgraph` is called with a node that isn't in the graph.

Root cause: in `get-diverge-data.ts`, `targetHead` has an explicit `TargetHeadNotFound` guard but `localHead` doesn't. If the local head's Version object is missing from the scope (interrupted import/fetch, stale lane reference, etc.) and is also not in the VersionHistory, `getAllVersionParents` (called with `throws: false`) returns without pushing it, so the graph has no node for it.

This PR adds a matching `LocalHeadNotFound` error with an actionable message pointing the user to `bit import <id> --objects`.