### PR TITLE
feat(tester): agent-friendly bit test output with per-component rollup

### DIFF
--- a/scopes/defender/tester/test-output-formatter.spec.ts
+++ b/scopes/defender/tester/test-output-formatter.spec.ts
@@ -170,6 +170,23 @@ describe('formatTestReport()', () => {
     expect(out).to.include('1 components targeted');
   });
 
+  it('separates failed-tests component count from tester-error component count in failure headline', () => {
+    const err = new Error('parse error');
+    const results = mkResults('teambit.react/react', [
+      { name: 'comp-a', files: [mkFile(2, 3)] },
+      { name: 'comp-b', files: [mkFile(5, 0)] },
+      { name: 'comp-c', files: [mkFile(0, 0, 0, err)] },
+    ]);
+    const summary = aggregateTestResults(results, [
+      mkComponent('comp-a'),
+      mkComponent('comp-b'),
+      mkComponent('comp-c'),
+    ]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1s' });
+    expect(out).to.include('3 tests failed across 1 of 3 components');
+    expect(out).to.include('(+1 components had tester errors)');
+  });
+
   it('surfaces passed counts alongside tester errors when no tests failed', () => {
     const err = new Error('parse error');
     const results = mkResults('teambit.react/react', [

--- a/scopes/defender/tester/test-output-formatter.spec.ts
+++ b/scopes/defender/tester/test-output-formatter.spec.ts
@@ -33,8 +33,9 @@ function mkResults(envId: string, components: CompFixture[]): TestResults {
   const hasFailure = compResults.some(
     (c) => (c.errors?.length || 0) > 0 || c.results.testFiles.some((f) => f.failed > 0 || f.error)
   );
+  const envComponents = components.map((c) => mkComponent(c.name));
   return {
-    results: [{ env: { id: envId } as any, data: new Tests(compResults) }],
+    results: [{ env: { id: envId, components: envComponents } as any, data: new Tests(compResults) }],
     hasErrors: () => hasFailure,
     errors: [],
   } as unknown as TestResults;
@@ -66,15 +67,18 @@ describe('aggregateTestResults()', () => {
     expect(summary.componentsWithoutTests.map((id) => id.toString())).to.include('my-scope/comp-c');
   });
 
-  it('surfaces env-level errors', () => {
+  it('surfaces env-level errors and keeps affected components out of the no-tests bucket', () => {
     const err = new Error('tester crashed');
+    const compA = mkComponent('comp-a');
     const results = {
-      results: [{ env: { id: 'teambit.react/react' } as any, data: undefined, error: err }],
+      results: [{ env: { id: 'teambit.react/react', components: [compA] } as any, data: undefined, error: err }],
     } as unknown as TestResults;
-    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    const summary = aggregateTestResults(results, [compA]);
     expect(summary.envErrors).to.have.lengthOf(1);
     expect(summary.envErrors[0].error.message).to.equal('tester crashed');
-    expect(summary.totals.withoutTests).to.equal(1);
+    expect(summary.totals.withoutTests).to.equal(0);
+    expect(summary.totals.affectedByEnvError).to.equal(1);
+    expect(summary.componentsAffectedByEnvError.map((id) => id.toString())).to.include('my-scope/comp-a');
   });
 
   it('flags components with tester errors on test files', () => {
@@ -154,13 +158,23 @@ describe('formatTestReport()', () => {
 
   it('surfaces env errors in a dedicated section', () => {
     const err = new Error('tester crashed');
+    const compA = mkComponent('comp-a');
     const results = {
-      results: [{ env: { id: 'teambit.react/react' } as any, data: undefined, error: err }],
+      results: [{ env: { id: 'teambit.react/react', components: [compA] } as any, data: undefined, error: err }],
     } as unknown as TestResults;
-    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    const summary = aggregateTestResults(results, [compA]);
     const out = formatTestReport(summary, { verbose: false, duration: '0.3s' });
     expect(out).to.include('tester errors');
     expect(out).to.include('teambit.react/react');
     expect(out).to.include('tester crashed');
+    expect(out).to.include('1 components targeted');
+  });
+
+  it('includes pending tests in the headline when present', () => {
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(3, 0, 2)] }]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1s' });
+    expect(out).to.include('2 pending');
+    expect(out).to.include('3/5 tests passed');
   });
 });

--- a/scopes/defender/tester/test-output-formatter.spec.ts
+++ b/scopes/defender/tester/test-output-formatter.spec.ts
@@ -170,6 +170,15 @@ describe('formatTestReport()', () => {
     expect(out).to.include('1 components targeted');
   });
 
+  it('downgrades to a warning when all tests pass but tester exited non-zero (e.g. coverage threshold)', () => {
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(5, 0)] }]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1s', failedDueToExitCode: true });
+    expect(out).to.include('5/5 tests passed');
+    expect(out).to.include('non-zero code');
+    expect(out).to.not.include('tests failed across');
+  });
+
   it('includes pending tests in the headline when present', () => {
     const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(3, 0, 2)] }]);
     const summary = aggregateTestResults(results, [mkComponent('comp-a')]);

--- a/scopes/defender/tester/test-output-formatter.spec.ts
+++ b/scopes/defender/tester/test-output-formatter.spec.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { ComponentID } from '@teambit/component';
+import { TestsResult, TestsFiles } from '@teambit/tests-results';
+import type { Component } from '@teambit/component';
+import { aggregateTestResults, formatTestReport } from './test-output-formatter';
+import { Tests } from './tester';
+import type { TestResults } from './tester.main.runtime';
+
+function mkId(name: string): ComponentID {
+  return ComponentID.fromString(`my-scope/${name}`);
+}
+
+function mkComponent(name: string): Component {
+  return { id: mkId(name) } as unknown as Component;
+}
+
+function mkFile(pass: number, failed: number, pending = 0, error?: Error): TestsFiles {
+  return new TestsFiles('file.spec.ts', [], pass, failed, pending, 0, false, error);
+}
+
+type CompFixture = { name: string; files: TestsFiles[]; errors?: Error[] };
+
+function mkResults(envId: string, components: CompFixture[]): TestResults {
+  const compResults = components.map(({ name, files, errors }) => ({
+    componentId: mkId(name),
+    results: new TestsResult(
+      files,
+      files.every((f) => f.failed === 0 && !f.error),
+      0
+    ),
+    errors,
+  }));
+  const hasFailure = compResults.some(
+    (c) => (c.errors?.length || 0) > 0 || c.results.testFiles.some((f) => f.failed > 0 || f.error)
+  );
+  return {
+    results: [{ env: { id: envId } as any, data: new Tests(compResults) }],
+    hasErrors: () => hasFailure,
+    errors: [],
+  } as unknown as TestResults;
+}
+
+describe('aggregateTestResults()', () => {
+  it('counts passed/failed/pending across components', () => {
+    const results = mkResults('teambit.react/react', [
+      { name: 'comp-a', files: [mkFile(5, 0, 1)] },
+      { name: 'comp-b', files: [mkFile(2, 1, 0)] },
+    ]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a'), mkComponent('comp-b')]);
+    expect(summary.totals.testsPassed).to.equal(7);
+    expect(summary.totals.testsFailed).to.equal(1);
+    expect(summary.totals.testsPending).to.equal(1);
+    expect(summary.totals.tested).to.equal(2);
+    expect(summary.totals.withoutTests).to.equal(0);
+  });
+
+  it('identifies components without tests', () => {
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(3, 0)] }]);
+    const summary = aggregateTestResults(results, [
+      mkComponent('comp-a'),
+      mkComponent('comp-b'),
+      mkComponent('comp-c'),
+    ]);
+    expect(summary.totals.withoutTests).to.equal(2);
+    expect(summary.componentsWithoutTests.map((id) => id.toString())).to.include('my-scope/comp-b');
+    expect(summary.componentsWithoutTests.map((id) => id.toString())).to.include('my-scope/comp-c');
+  });
+
+  it('surfaces env-level errors', () => {
+    const err = new Error('tester crashed');
+    const results = {
+      results: [{ env: { id: 'teambit.react/react' } as any, data: undefined, error: err }],
+    } as unknown as TestResults;
+    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    expect(summary.envErrors).to.have.lengthOf(1);
+    expect(summary.envErrors[0].error.message).to.equal('tester crashed');
+    expect(summary.totals.withoutTests).to.equal(1);
+  });
+
+  it('flags components with tester errors on test files', () => {
+    const err = new Error('parse error');
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(0, 0, 0, err)] }]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    expect(summary.componentsWithTests[0].hasError).to.equal(true);
+  });
+});
+
+describe('formatTestReport()', () => {
+  it('renders a green success summary when all pass', () => {
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(5, 0)] }]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1.2s' });
+    expect(out).to.include('test results');
+    expect(out).to.include('my-scope/comp-a');
+    expect(out).to.include('5 passed');
+    expect(out).to.include('5/5 tests passed');
+    expect(out).to.include('Finished. (1.2s)');
+  });
+
+  it('renders warning summary with failure count when any fail', () => {
+    const results = mkResults('teambit.react/react', [
+      { name: 'comp-a', files: [mkFile(5, 0)] },
+      { name: 'comp-b', files: [mkFile(2, 3)] },
+    ]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a'), mkComponent('comp-b')]);
+    const out = formatTestReport(summary, { verbose: false, duration: '2.5s' });
+    expect(out).to.include('3 tests failed across 1 of 2 components');
+  });
+
+  it('collapses no-test components into a single hint line by default', () => {
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(1, 0)] }]);
+    const summary = aggregateTestResults(results, [
+      mkComponent('comp-a'),
+      mkComponent('comp-b'),
+      mkComponent('comp-c'),
+    ]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1s' });
+    expect(out).to.include('2 components have no tests (run with --verbose to list)');
+    expect(out).to.not.include('my-scope/comp-b');
+  });
+
+  it('lists no-test component ids when verbose', () => {
+    const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(1, 0)] }]);
+    const summary = aggregateTestResults(results, [
+      mkComponent('comp-a'),
+      mkComponent('comp-b'),
+      mkComponent('comp-c'),
+    ]);
+    const out = formatTestReport(summary, { verbose: true, duration: '1s' });
+    expect(out).to.include('2 components have no tests');
+    expect(out).to.include('my-scope/comp-b');
+    expect(out).to.include('my-scope/comp-c');
+  });
+
+  it('handles empty component list', () => {
+    const results = { results: [] } as unknown as TestResults;
+    const summary = aggregateTestResults(results, []);
+    const out = formatTestReport(summary, { verbose: false, duration: '0s' });
+    expect(out).to.include('no components to test');
+  });
+
+  it('surfaces env errors in a dedicated section', () => {
+    const err = new Error('tester crashed');
+    const results = {
+      results: [{ env: { id: 'teambit.react/react' } as any, data: undefined, error: err }],
+    } as unknown as TestResults;
+    const summary = aggregateTestResults(results, [mkComponent('comp-a')]);
+    const out = formatTestReport(summary, { verbose: false, duration: '0.3s' });
+    expect(out).to.include('tester errors');
+    expect(out).to.include('teambit.react/react');
+    expect(out).to.include('tester crashed');
+  });
+});

--- a/scopes/defender/tester/test-output-formatter.spec.ts
+++ b/scopes/defender/tester/test-output-formatter.spec.ts
@@ -139,6 +139,19 @@ describe('formatTestReport()', () => {
     expect(out).to.include('no components to test');
   });
 
+  it('emits only the final headline when summaryOnly is set', () => {
+    const results = mkResults('teambit.react/react', [
+      { name: 'comp-a', files: [mkFile(5, 0)] },
+      { name: 'comp-b', files: [mkFile(0, 2)] },
+    ]);
+    const summary = aggregateTestResults(results, [mkComponent('comp-a'), mkComponent('comp-b')]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1s', summaryOnly: true });
+    expect(out).to.not.include('test results');
+    expect(out).to.not.include('my-scope/comp-a');
+    expect(out).to.include('2 tests failed across 1 of 2 components');
+    expect(out).to.include('Finished. (1s)');
+  });
+
   it('surfaces env errors in a dedicated section', () => {
     const err = new Error('tester crashed');
     const results = {

--- a/scopes/defender/tester/test-output-formatter.spec.ts
+++ b/scopes/defender/tester/test-output-formatter.spec.ts
@@ -170,6 +170,24 @@ describe('formatTestReport()', () => {
     expect(out).to.include('1 components targeted');
   });
 
+  it('surfaces passed counts alongside tester errors when no tests failed', () => {
+    const err = new Error('parse error');
+    const results = mkResults('teambit.react/react', [
+      { name: 'comp-a', files: [mkFile(10, 0)] },
+      { name: 'comp-b', files: [mkFile(5, 0)] },
+      { name: 'comp-c', files: [mkFile(0, 0, 0, err)] },
+    ]);
+    const summary = aggregateTestResults(results, [
+      mkComponent('comp-a'),
+      mkComponent('comp-b'),
+      mkComponent('comp-c'),
+    ]);
+    const out = formatTestReport(summary, { verbose: false, duration: '1s' });
+    expect(out).to.include('15/15 tests passed across 2 components');
+    expect(out).to.include('1 components had tester errors');
+    expect(out).to.not.include('tester errors encountered (');
+  });
+
   it('downgrades to a warning when all tests pass but tester exited non-zero (e.g. coverage threshold)', () => {
     const results = mkResults('teambit.react/react', [{ name: 'comp-a', files: [mkFile(5, 0)] }]);
     const summary = aggregateTestResults(results, [mkComponent('comp-a')]);

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -1,0 +1,168 @@
+import chalk from 'chalk';
+import type { Component, ComponentID } from '@teambit/component';
+import {
+  formatTitle,
+  formatHint,
+  formatSuccessSummary,
+  formatWarningSummary,
+  joinSections,
+  successSymbol,
+  errorSymbol,
+  warnSymbol,
+} from '@teambit/cli';
+import type { TestResults } from './tester.main.runtime';
+
+export type ComponentTestSummary = {
+  id: ComponentID;
+  passed: number;
+  failed: number;
+  pending: number;
+  hasError: boolean;
+};
+
+export type EnvTestError = {
+  envId?: string;
+  error: Error;
+};
+
+export type TestOutputSummary = {
+  componentsWithTests: ComponentTestSummary[];
+  componentsWithoutTests: ComponentID[];
+  envErrors: EnvTestError[];
+  totals: {
+    totalComponents: number;
+    tested: number;
+    withoutTests: number;
+    testsPassed: number;
+    testsFailed: number;
+    testsPending: number;
+  };
+};
+
+export function aggregateTestResults(results: TestResults, allComponents: Component[]): TestOutputSummary {
+  const componentsWithTests: ComponentTestSummary[] = [];
+  const envErrors: EnvTestError[] = [];
+  const testedIds = new Set<string>();
+
+  for (const envResult of results.results) {
+    const envId = envResult.env?.id;
+    if (envResult.error) envErrors.push({ envId, error: envResult.error });
+    const tests = envResult.data;
+    if (!tests) continue;
+    for (const comp of tests.components) {
+      testedIds.add(comp.componentId.toString());
+      const summary = summarizeComponent(comp);
+      if (summary) componentsWithTests.push(summary);
+    }
+  }
+
+  const componentsWithoutTests = allComponents.filter((c) => !testedIds.has(c.id.toString())).map((c) => c.id);
+
+  const totals = {
+    totalComponents: allComponents.length,
+    tested: componentsWithTests.length,
+    withoutTests: componentsWithoutTests.length,
+    testsPassed: sum(componentsWithTests, (c) => c.passed),
+    testsFailed: sum(componentsWithTests, (c) => c.failed),
+    testsPending: sum(componentsWithTests, (c) => c.pending),
+  };
+
+  return { componentsWithTests, componentsWithoutTests, envErrors, totals };
+}
+
+function summarizeComponent(comp: {
+  componentId: ComponentID;
+  results?: { testFiles: Array<{ pass: number; failed: number; pending: number; error?: Error }> };
+  errors?: Error[];
+}): ComponentTestSummary | undefined {
+  const testFiles = comp.results?.testFiles ?? [];
+  if (!testFiles.length && !comp.errors?.length) return undefined;
+  const passed = sum(testFiles, (f) => f.pass || 0);
+  const failed = sum(testFiles, (f) => f.failed || 0);
+  const pending = sum(testFiles, (f) => f.pending || 0);
+  const hasError = Boolean(comp.errors?.length) || testFiles.some((f) => f.error);
+  return { id: comp.componentId, passed, failed, pending, hasError };
+}
+
+export function formatTestReport(summary: TestOutputSummary, opts: { verbose: boolean; duration: string }): string {
+  const { componentsWithTests, componentsWithoutTests, envErrors, totals } = summary;
+
+  const perComponentLines = componentsWithTests
+    .sort((a, b) => a.id.toString().localeCompare(b.id.toString()))
+    .map(formatComponentLine);
+
+  const resultsSection = perComponentLines.length ? [formatTitle('test results'), ...perComponentLines].join('\n') : '';
+
+  const envErrorsSection = envErrors.length
+    ? [
+        `${errorSymbol} ${formatTitle('tester errors')}`,
+        ...envErrors.map((e) => `   ${errorSymbol} ${e.envId ?? 'unknown env'}: ${e.error.message}`),
+      ].join('\n')
+    : '';
+
+  const noTestsSection = formatNoTestsSection(componentsWithoutTests, opts.verbose);
+
+  const failingComponents = componentsWithTests.filter((c) => c.failed > 0 || c.hasError).length;
+  const finalSummary = formatFinalSummary(totals, failingComponents, envErrors.length > 0, opts.duration);
+
+  return joinSections([resultsSection, envErrorsSection, noTestsSection, finalSummary]);
+}
+
+function formatComponentLine(c: ComponentTestSummary): string {
+  const id = c.id.toString({ ignoreVersion: true });
+  const parts: string[] = [];
+  if (c.failed > 0) parts.push(`${c.failed} failed`);
+  if (c.passed > 0) parts.push(`${c.passed} passed`);
+  if (c.pending > 0) parts.push(`${c.pending} pending`);
+  const stats = parts.length ? parts.join(', ') : 'no test counts reported';
+
+  if (c.failed > 0) return `   ${errorSymbol} ${id} — ${stats}`;
+  if (c.hasError) return `   ${warnSymbol} ${id} — ${stats} (tester reported errors)`;
+  return `   ${successSymbol()} ${id} — ${stats}`;
+}
+
+function formatNoTestsSection(ids: ComponentID[], verbose: boolean): string {
+  if (!ids.length) return '';
+  if (!verbose) {
+    return formatHint(`${ids.length} components have no tests (run with --verbose to list)`);
+  }
+  const lines = ids
+    .map((id) => id.toString({ ignoreVersion: true }))
+    .sort()
+    .map((s) => `   ${chalk.dim('›')} ${s}`);
+  return [formatHint(`${ids.length} components have no tests`), ...lines].join('\n');
+}
+
+function formatFinalSummary(
+  totals: TestOutputSummary['totals'],
+  failingComponents: number,
+  hasEnvError: boolean,
+  duration: string
+): string {
+  const totalTests = totals.testsPassed + totals.testsFailed;
+  const withoutSuffix = totals.withoutTests > 0 ? `, ${totals.withoutTests} without tests` : '';
+  const timing = formatHint(`Finished. (${duration})`);
+
+  if (hasEnvError || totals.testsFailed > 0 || failingComponents > 0) {
+    const headline =
+      totals.testsFailed > 0
+        ? `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${withoutSuffix}`
+        : `tester errors encountered (${totals.tested} components tested${withoutSuffix})`;
+    return `${formatWarningSummary(headline)}\n${timing}`;
+  }
+
+  if (totals.tested === 0) {
+    const none =
+      totals.totalComponents === 0
+        ? 'no components to test'
+        : `no tests found (${totals.totalComponents} components, none with tests)`;
+    return `${formatHint(none)}\n${timing}`;
+  }
+
+  const headline = `${totals.testsPassed}/${totalTests || totals.testsPassed} tests passed across ${totals.tested} components${withoutSuffix}`;
+  return `${formatSuccessSummary(headline)}\n${timing}`;
+}
+
+function sum<T>(items: T[], pick: (item: T) => number): number {
+  return items.reduce((acc, item) => acc + pick(item), 0);
+}

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -110,10 +110,12 @@ export function formatTestReport(
   opts: { verbose: boolean; duration: string; summaryOnly?: boolean; failedDueToExitCode?: boolean }
 ): string {
   const { componentsWithTests, componentsWithoutTests, envErrors, totals } = summary;
-  const failingComponents = componentsWithTests.filter((c) => c.failed > 0 || c.hasError).length;
+  const componentsWithFailedTests = componentsWithTests.filter((c) => c.failed > 0).length;
+  const componentsWithOnlyTesterErrors = componentsWithTests.filter((c) => c.failed === 0 && c.hasError).length;
   const finalSummary = formatFinalSummary(
     totals,
-    failingComponents,
+    componentsWithFailedTests,
+    componentsWithOnlyTesterErrors,
     envErrors.length > 0,
     opts.duration,
     opts.failedDueToExitCode ?? false
@@ -167,7 +169,8 @@ function formatNoTestsSection(ids: ComponentID[], verbose: boolean): string {
 
 function formatFinalSummary(
   totals: TestOutputSummary['totals'],
-  failingComponents: number,
+  componentsWithFailedTests: number,
+  componentsWithOnlyTesterErrors: number,
   hasEnvError: boolean,
   duration: string,
   failedDueToExitCode: boolean
@@ -179,17 +182,19 @@ function formatFinalSummary(
   const extraSuffix = suffixParts.length ? `, ${suffixParts.join(', ')}` : '';
   const pendingSuffix = totals.testsPending > 0 ? `, ${totals.testsPending} pending` : '';
   const timing = formatHint(`Finished. (${duration})`);
+  const anyFailing = componentsWithFailedTests + componentsWithOnlyTesterErrors;
 
-  if (hasEnvError || totals.testsFailed > 0 || failingComponents > 0) {
+  if (hasEnvError || totals.testsFailed > 0 || anyFailing > 0) {
     const attempted = totals.tested + totals.affectedByEnvError;
-    const totalTestsForWarning = totals.testsPassed + totals.testsFailed + totals.testsPending;
     let headline: string;
     if (totals.testsFailed > 0) {
-      headline = `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${pendingSuffix}${extraSuffix}`;
+      const testerErrorSuffix =
+        componentsWithOnlyTesterErrors > 0 ? ` (+${componentsWithOnlyTesterErrors} components had tester errors)` : '';
+      headline = `${totals.testsFailed} tests failed across ${componentsWithFailedTests} of ${totals.tested} components${testerErrorSuffix}${pendingSuffix}${extraSuffix}`;
     } else if (totals.testsPassed > 0) {
       // tests passed but some components had tester-level errors — surface both
-      const passedComponents = totals.tested - failingComponents;
-      headline = `${totals.testsPassed}/${totalTestsForWarning || totals.testsPassed} tests passed across ${passedComponents} components, but ${failingComponents} components had tester errors${pendingSuffix}${extraSuffix}`;
+      const passedComponents = totals.tested - componentsWithOnlyTesterErrors;
+      headline = `${totals.testsPassed}/${totalTests || totals.testsPassed} tests passed across ${passedComponents} components, but ${componentsWithOnlyTesterErrors} components had tester errors${pendingSuffix}${extraSuffix}`;
     } else {
       headline = `tester errors encountered (${attempted || totals.totalComponents} components targeted${extraSuffix})`;
     }

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -58,9 +58,10 @@ export function aggregateTestResults(results: TestResults, allComponents: Compon
     const tests = envResult.data;
     if (!tests) continue;
     for (const comp of tests.components) {
-      testedIds.add(comp.componentId.toString());
       const summary = summarizeComponent(comp);
-      if (summary) componentsWithTests.push(summary);
+      if (!summary) continue;
+      testedIds.add(comp.componentId.toString());
+      componentsWithTests.push(summary);
     }
   }
 

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -84,8 +84,15 @@ function summarizeComponent(comp: {
   return { id: comp.componentId, passed, failed, pending, hasError };
 }
 
-export function formatTestReport(summary: TestOutputSummary, opts: { verbose: boolean; duration: string }): string {
+export function formatTestReport(
+  summary: TestOutputSummary,
+  opts: { verbose: boolean; duration: string; summaryOnly?: boolean }
+): string {
   const { componentsWithTests, componentsWithoutTests, envErrors, totals } = summary;
+  const failingComponents = componentsWithTests.filter((c) => c.failed > 0 || c.hasError).length;
+  const finalSummary = formatFinalSummary(totals, failingComponents, envErrors.length > 0, opts.duration);
+
+  if (opts.summaryOnly) return finalSummary;
 
   const perComponentLines = componentsWithTests
     .sort((a, b) => a.id.toString().localeCompare(b.id.toString()))
@@ -101,9 +108,6 @@ export function formatTestReport(summary: TestOutputSummary, opts: { verbose: bo
     : '';
 
   const noTestsSection = formatNoTestsSection(componentsWithoutTests, opts.verbose);
-
-  const failingComponents = componentsWithTests.filter((c) => c.failed > 0 || c.hasError).length;
-  const finalSummary = formatFinalSummary(totals, failingComponents, envErrors.length > 0, opts.duration);
 
   return joinSections([resultsSection, envErrorsSection, noTestsSection, finalSummary]);
 }

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -7,6 +7,7 @@ import {
   formatSuccessSummary,
   formatWarningSummary,
   joinSections,
+  successSymbol,
   errorSymbol,
   warnSymbol,
 } from '@teambit/cli';
@@ -146,7 +147,7 @@ function formatComponentLine(c: ComponentTestSummary): string {
 
   if (c.failed > 0) return formatItem(text, errorSymbol);
   if (c.hasError) return formatItem(`${text} (tester reported errors)`, warnSymbol);
-  return formatItem(text);
+  return formatItem(text, successSymbol());
 }
 
 function formatNoTestsSection(ids: ComponentID[], verbose: boolean): string {
@@ -178,10 +179,17 @@ function formatFinalSummary(
 
   if (hasEnvError || totals.testsFailed > 0 || failingComponents > 0) {
     const attempted = totals.tested + totals.affectedByEnvError;
-    const headline =
-      totals.testsFailed > 0
-        ? `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${pendingSuffix}${extraSuffix}`
-        : `tester errors encountered (${attempted || totals.totalComponents} components targeted${extraSuffix})`;
+    const totalTestsForWarning = totals.testsPassed + totals.testsFailed + totals.testsPending;
+    let headline: string;
+    if (totals.testsFailed > 0) {
+      headline = `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${pendingSuffix}${extraSuffix}`;
+    } else if (totals.testsPassed > 0) {
+      // tests passed but some components had tester-level errors — surface both
+      const passedComponents = totals.tested - failingComponents;
+      headline = `${totals.testsPassed}/${totalTestsForWarning || totals.testsPassed} tests passed across ${passedComponents} components, but ${failingComponents} components had tester errors${pendingSuffix}${extraSuffix}`;
+    } else {
+      headline = `tester errors encountered (${attempted || totals.totalComponents} components targeted${extraSuffix})`;
+    }
     return `${formatWarningSummary(headline)}\n${timing}`;
   }
 

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -1,3 +1,4 @@
+import { sumBy } from 'lodash';
 import type { Component, ComponentID } from '@teambit/component';
 import {
   formatTitle,
@@ -63,21 +64,23 @@ export function aggregateTestResults(results: TestResults, allComponents: Compon
     }
   }
 
-  const componentsAffectedByEnvError = allComponents
-    .filter((c) => affectedByEnvErrorIds.has(c.id.toString()) && !testedIds.has(c.id.toString()))
-    .map((c) => c.id);
-  const componentsWithoutTests = allComponents
-    .filter((c) => !testedIds.has(c.id.toString()) && !affectedByEnvErrorIds.has(c.id.toString()))
-    .map((c) => c.id);
+  const componentsAffectedByEnvError: ComponentID[] = [];
+  const componentsWithoutTests: ComponentID[] = [];
+  for (const c of allComponents) {
+    const idStr = c.id.toString();
+    if (testedIds.has(idStr)) continue;
+    if (affectedByEnvErrorIds.has(idStr)) componentsAffectedByEnvError.push(c.id);
+    else componentsWithoutTests.push(c.id);
+  }
 
   const totals = {
     totalComponents: allComponents.length,
     tested: componentsWithTests.length,
     withoutTests: componentsWithoutTests.length,
     affectedByEnvError: componentsAffectedByEnvError.length,
-    testsPassed: sum(componentsWithTests, (c) => c.passed),
-    testsFailed: sum(componentsWithTests, (c) => c.failed),
-    testsPending: sum(componentsWithTests, (c) => c.pending),
+    testsPassed: sumBy(componentsWithTests, (c) => c.passed),
+    testsFailed: sumBy(componentsWithTests, (c) => c.failed),
+    testsPending: sumBy(componentsWithTests, (c) => c.pending),
   };
 
   return { componentsWithTests, componentsWithoutTests, componentsAffectedByEnvError, envErrors, totals };
@@ -90,9 +93,9 @@ function summarizeComponent(comp: {
 }): ComponentTestSummary | undefined {
   const testFiles = comp.results?.testFiles ?? [];
   if (!testFiles.length && !comp.errors?.length) return undefined;
-  const passed = sum(testFiles, (f) => f.pass || 0);
-  const failed = sum(testFiles, (f) => f.failed || 0);
-  const pending = sum(testFiles, (f) => f.pending || 0);
+  const passed = sumBy(testFiles, (f) => f.pass || 0);
+  const failed = sumBy(testFiles, (f) => f.failed || 0);
+  const pending = sumBy(testFiles, (f) => f.pending || 0);
   const hasError = Boolean(comp.errors?.length) || testFiles.some((f) => f.error);
   return { id: comp.componentId, passed, failed, pending, hasError };
 }
@@ -184,8 +187,4 @@ function formatFinalSummary(
 
   const headline = `${totals.testsPassed}/${totalTests || totals.testsPassed} tests passed across ${totals.tested} components${pendingSuffix}${extraSuffix}`;
   return `${formatSuccessSummary(headline)}\n${timing}`;
-}
-
-function sum<T>(items: T[], pick: (item: T) => number): number {
-  return items.reduce((acc, item) => acc + pick(item), 0);
 }

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -103,11 +103,17 @@ function summarizeComponent(comp: {
 
 export function formatTestReport(
   summary: TestOutputSummary,
-  opts: { verbose: boolean; duration: string; summaryOnly?: boolean }
+  opts: { verbose: boolean; duration: string; summaryOnly?: boolean; failedDueToExitCode?: boolean }
 ): string {
   const { componentsWithTests, componentsWithoutTests, envErrors, totals } = summary;
   const failingComponents = componentsWithTests.filter((c) => c.failed > 0 || c.hasError).length;
-  const finalSummary = formatFinalSummary(totals, failingComponents, envErrors.length > 0, opts.duration);
+  const finalSummary = formatFinalSummary(
+    totals,
+    failingComponents,
+    envErrors.length > 0,
+    opts.duration,
+    opts.failedDueToExitCode ?? false
+  );
 
   if (opts.summaryOnly) return finalSummary;
 
@@ -159,7 +165,8 @@ function formatFinalSummary(
   totals: TestOutputSummary['totals'],
   failingComponents: number,
   hasEnvError: boolean,
-  duration: string
+  duration: string,
+  failedDueToExitCode: boolean
 ): string {
   const totalTests = totals.testsPassed + totals.testsFailed + totals.testsPending;
   const suffixParts: string[] = [];
@@ -175,6 +182,15 @@ function formatFinalSummary(
       totals.testsFailed > 0
         ? `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${pendingSuffix}${extraSuffix}`
         : `tester errors encountered (${attempted || totals.totalComponents} components targeted${extraSuffix})`;
+    return `${formatWarningSummary(headline)}\n${timing}`;
+  }
+
+  if (failedDueToExitCode) {
+    const passedPart =
+      totals.tested > 0
+        ? `${totals.testsPassed}/${totalTests || totals.testsPassed} tests passed across ${totals.tested} components${pendingSuffix}${extraSuffix}`
+        : `no test failures reported${extraSuffix}`;
+    const headline = `${passedPart}, but tester exited with a non-zero code (e.g. coverage threshold not met)`;
     return `${formatWarningSummary(headline)}\n${timing}`;
   }
 

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -48,20 +48,23 @@ export function aggregateTestResults(results: TestResults, allComponents: Compon
   const envErrors: EnvTestError[] = [];
   const testedIds = new Set<string>();
   const affectedByEnvErrorIds = new Set<string>();
+  // normalize on both sides so a version-mismatch between the tester's ComponentsResults and the
+  // workspace `allComponents` list can't leak a tested component into `componentsWithoutTests`.
+  const idKey = (id: ComponentID) => id.toString({ ignoreVersion: true });
 
   for (const envResult of results.results) {
     const envId = envResult.env?.id;
     const envComponents: Component[] = envResult.env?.components ?? [];
     if (envResult.error) {
       envErrors.push({ envId, error: envResult.error });
-      envComponents.forEach((c) => affectedByEnvErrorIds.add(c.id.toString()));
+      envComponents.forEach((c) => affectedByEnvErrorIds.add(idKey(c.id)));
     }
     const tests = envResult.data;
     if (!tests) continue;
     for (const comp of tests.components) {
       const summary = summarizeComponent(comp);
       if (!summary) continue;
-      testedIds.add(comp.componentId.toString());
+      testedIds.add(idKey(comp.componentId));
       componentsWithTests.push(summary);
     }
   }
@@ -69,9 +72,9 @@ export function aggregateTestResults(results: TestResults, allComponents: Compon
   const componentsAffectedByEnvError: ComponentID[] = [];
   const componentsWithoutTests: ComponentID[] = [];
   for (const c of allComponents) {
-    const idStr = c.id.toString();
-    if (testedIds.has(idStr)) continue;
-    if (affectedByEnvErrorIds.has(idStr)) componentsAffectedByEnvError.push(c.id);
+    const key = idKey(c.id);
+    if (testedIds.has(key)) continue;
+    if (affectedByEnvErrorIds.has(key)) componentsAffectedByEnvError.push(c.id);
     else componentsWithoutTests.push(c.id);
   }
 

--- a/scopes/defender/tester/test-output-formatter.ts
+++ b/scopes/defender/tester/test-output-formatter.ts
@@ -1,12 +1,11 @@
-import chalk from 'chalk';
 import type { Component, ComponentID } from '@teambit/component';
 import {
   formatTitle,
   formatHint,
+  formatItem,
   formatSuccessSummary,
   formatWarningSummary,
   joinSections,
-  successSymbol,
   errorSymbol,
   warnSymbol,
 } from '@teambit/cli';
@@ -28,11 +27,14 @@ export type EnvTestError = {
 export type TestOutputSummary = {
   componentsWithTests: ComponentTestSummary[];
   componentsWithoutTests: ComponentID[];
+  /** components that belong to an env whose tester errored before producing results */
+  componentsAffectedByEnvError: ComponentID[];
   envErrors: EnvTestError[];
   totals: {
     totalComponents: number;
     tested: number;
     withoutTests: number;
+    affectedByEnvError: number;
     testsPassed: number;
     testsFailed: number;
     testsPending: number;
@@ -43,10 +45,15 @@ export function aggregateTestResults(results: TestResults, allComponents: Compon
   const componentsWithTests: ComponentTestSummary[] = [];
   const envErrors: EnvTestError[] = [];
   const testedIds = new Set<string>();
+  const affectedByEnvErrorIds = new Set<string>();
 
   for (const envResult of results.results) {
     const envId = envResult.env?.id;
-    if (envResult.error) envErrors.push({ envId, error: envResult.error });
+    const envComponents: Component[] = envResult.env?.components ?? [];
+    if (envResult.error) {
+      envErrors.push({ envId, error: envResult.error });
+      envComponents.forEach((c) => affectedByEnvErrorIds.add(c.id.toString()));
+    }
     const tests = envResult.data;
     if (!tests) continue;
     for (const comp of tests.components) {
@@ -56,18 +63,24 @@ export function aggregateTestResults(results: TestResults, allComponents: Compon
     }
   }
 
-  const componentsWithoutTests = allComponents.filter((c) => !testedIds.has(c.id.toString())).map((c) => c.id);
+  const componentsAffectedByEnvError = allComponents
+    .filter((c) => affectedByEnvErrorIds.has(c.id.toString()) && !testedIds.has(c.id.toString()))
+    .map((c) => c.id);
+  const componentsWithoutTests = allComponents
+    .filter((c) => !testedIds.has(c.id.toString()) && !affectedByEnvErrorIds.has(c.id.toString()))
+    .map((c) => c.id);
 
   const totals = {
     totalComponents: allComponents.length,
     tested: componentsWithTests.length,
     withoutTests: componentsWithoutTests.length,
+    affectedByEnvError: componentsAffectedByEnvError.length,
     testsPassed: sum(componentsWithTests, (c) => c.passed),
     testsFailed: sum(componentsWithTests, (c) => c.failed),
     testsPending: sum(componentsWithTests, (c) => c.pending),
   };
 
-  return { componentsWithTests, componentsWithoutTests, envErrors, totals };
+  return { componentsWithTests, componentsWithoutTests, componentsAffectedByEnvError, envErrors, totals };
 }
 
 function summarizeComponent(comp: {
@@ -119,10 +132,11 @@ function formatComponentLine(c: ComponentTestSummary): string {
   if (c.passed > 0) parts.push(`${c.passed} passed`);
   if (c.pending > 0) parts.push(`${c.pending} pending`);
   const stats = parts.length ? parts.join(', ') : 'no test counts reported';
+  const text = `${id} — ${stats}`;
 
-  if (c.failed > 0) return `   ${errorSymbol} ${id} — ${stats}`;
-  if (c.hasError) return `   ${warnSymbol} ${id} — ${stats} (tester reported errors)`;
-  return `   ${successSymbol()} ${id} — ${stats}`;
+  if (c.failed > 0) return formatItem(text, errorSymbol);
+  if (c.hasError) return formatItem(`${text} (tester reported errors)`, warnSymbol);
+  return formatItem(text);
 }
 
 function formatNoTestsSection(ids: ComponentID[], verbose: boolean): string {
@@ -133,7 +147,7 @@ function formatNoTestsSection(ids: ComponentID[], verbose: boolean): string {
   const lines = ids
     .map((id) => id.toString({ ignoreVersion: true }))
     .sort()
-    .map((s) => `   ${chalk.dim('›')} ${s}`);
+    .map((s) => formatItem(s));
   return [formatHint(`${ids.length} components have no tests`), ...lines].join('\n');
 }
 
@@ -143,15 +157,20 @@ function formatFinalSummary(
   hasEnvError: boolean,
   duration: string
 ): string {
-  const totalTests = totals.testsPassed + totals.testsFailed;
-  const withoutSuffix = totals.withoutTests > 0 ? `, ${totals.withoutTests} without tests` : '';
+  const totalTests = totals.testsPassed + totals.testsFailed + totals.testsPending;
+  const suffixParts: string[] = [];
+  if (totals.withoutTests > 0) suffixParts.push(`${totals.withoutTests} without tests`);
+  if (totals.affectedByEnvError > 0) suffixParts.push(`${totals.affectedByEnvError} not tested due to tester errors`);
+  const extraSuffix = suffixParts.length ? `, ${suffixParts.join(', ')}` : '';
+  const pendingSuffix = totals.testsPending > 0 ? `, ${totals.testsPending} pending` : '';
   const timing = formatHint(`Finished. (${duration})`);
 
   if (hasEnvError || totals.testsFailed > 0 || failingComponents > 0) {
+    const attempted = totals.tested + totals.affectedByEnvError;
     const headline =
       totals.testsFailed > 0
-        ? `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${withoutSuffix}`
-        : `tester errors encountered (${totals.tested} components tested${withoutSuffix})`;
+        ? `${totals.testsFailed} tests failed across ${failingComponents} of ${totals.tested} components${pendingSuffix}${extraSuffix}`
+        : `tester errors encountered (${attempted || totals.totalComponents} components targeted${extraSuffix})`;
     return `${formatWarningSummary(headline)}\n${timing}`;
   }
 
@@ -163,7 +182,7 @@ function formatFinalSummary(
     return `${formatHint(none)}\n${timing}`;
   }
 
-  const headline = `${totals.testsPassed}/${totalTests || totals.testsPassed} tests passed across ${totals.tested} components${withoutSuffix}`;
+  const headline = `${totals.testsPassed}/${totalTests || totals.testsPassed} tests passed across ${totals.tested} components${pendingSuffix}${extraSuffix}`;
   return `${formatSuccessSummary(headline)}\n${timing}`;
 }
 

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -163,8 +163,9 @@ supports watch mode, coverage reporting, and debug mode for development workflow
 
     if (watch) return '';
     const summary = tests ? aggregateTestResults(tests, components) : undefined;
+    const failedDueToExitCode = code !== 0 && !!tests && !tests.hasErrors();
     const data = summary
-      ? `${summaryOnly ? '' : '\n'}${formatTestReport(summary, { verbose, duration: `${seconds}s`, summaryOnly })}`
+      ? `${summaryOnly ? '' : '\n'}${formatTestReport(summary, { verbose, duration: `${seconds}s`, summaryOnly, failedDueToExitCode })}`
       : formatHint(`tests completed in ${seconds} seconds`);
     return {
       code,

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -152,6 +152,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         });
       } finally {
         restore?.();
+        if (summaryOnly) this.logger.on();
       }
       if (tests.hasErrors()) code = 1;
       if (process.exitCode && process.exitCode !== 0 && typeof process.exitCode === 'number') {
@@ -213,6 +214,9 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     }
 
     let code = 0;
+    // also disable the logger: testers like Jest reassign `console.warn` to `this.logger.warn`,
+    // which bypasses the stdout/console silencer and can corrupt machine-readable JSON output.
+    this.logger.off();
     const restore = silenceConsoleAndStdout();
     let tests: TestResults;
     try {
@@ -224,11 +228,10 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         coverage,
         updateSnapshot,
       });
-    } catch (err) {
+    } finally {
       restore();
-      throw err;
+      this.logger.on();
     }
-    restore();
     if (tests.hasErrors()) code = 1;
     if (process.exitCode && process.exitCode !== 0 && typeof process.exitCode === 'number') {
       // this is needed for testers such as "vitest", where it sets the exitCode to non zero when the coverage is not met.

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -137,6 +137,9 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         updateSnapshot,
       });
     } else {
+      // testers such as Jest reassign `console.warn` to forward into `this.logger.warn` inside their `test()`,
+      // bypassing our stdout/console monkey-patch. also turn the logger off so those re-routed calls don't surface.
+      if (summaryOnly) this.logger.off();
       const restore = summaryOnly ? silenceConsoleAndStdout() : undefined;
       try {
         tests = await this.tester.test(components, {
@@ -161,7 +164,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     if (watch) return '';
     const summary = tests ? aggregateTestResults(tests, components) : undefined;
     const data = summary
-      ? `\n${formatTestReport(summary, { verbose, duration: `${seconds}s`, summaryOnly })}`
+      ? `${summaryOnly ? '' : '\n'}${formatTestReport(summary, { verbose, duration: `${seconds}s`, summaryOnly })}`
       : formatHint(`tests completed in ${seconds} seconds`);
     return {
       code,

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -242,14 +242,16 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     const summary = {
       totals: aggregated.totals,
       componentsWithTests: aggregated.componentsWithTests.map((c) => ({
-        id: c.id.toString(),
+        id: c.id.toString({ ignoreVersion: true }),
         passed: c.passed,
         failed: c.failed,
         pending: c.pending,
         hasError: c.hasError,
       })),
-      componentsWithoutTests: aggregated.componentsWithoutTests.map((id) => id.toString()),
-      componentsAffectedByEnvError: aggregated.componentsAffectedByEnvError.map((id) => id.toString()),
+      componentsWithoutTests: aggregated.componentsWithoutTests.map((id) => id.toString({ ignoreVersion: true })),
+      componentsAffectedByEnvError: aggregated.componentsAffectedByEnvError.map((id) =>
+        id.toString({ ignoreVersion: true })
+      ),
       envErrors: aggregated.envErrors.map((e) => ({ envId: e.envId, message: e.error.message })),
     };
 

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -20,6 +20,7 @@ type TestFlags = {
   coverage?: boolean;
   updateSnapshot: boolean;
   verbose?: boolean;
+  summary?: boolean;
 };
 
 export class TestCmd implements Command {
@@ -53,6 +54,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     ],
     ['j', 'json', 'return the results in json format'],
     ['', 'verbose', 'show passing components and list components without tests'],
+    ['', 'summary', 'suppress tester output, print only the final pass/fail headline (or summary object with --json)'],
     // TODO: we need to reduce this redundant casting every time.
   ] as CommandOptions;
 
@@ -75,6 +77,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       unmodified = false,
       updateSnapshot = false,
       verbose = false,
+      summary: summaryOnly = false,
     }: TestFlags
   ) {
     const timer = Timer.create();
@@ -132,14 +135,19 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         updateSnapshot,
       });
     } else {
-      tests = await this.tester.test(components, {
-        watch,
-        debug,
-        env,
-        junit,
-        coverage,
-        updateSnapshot,
-      });
+      const restore = summaryOnly ? silenceConsoleAndStdout() : undefined;
+      try {
+        tests = await this.tester.test(components, {
+          watch,
+          debug,
+          env,
+          junit,
+          coverage,
+          updateSnapshot,
+        });
+      } finally {
+        restore?.();
+      }
       if (tests.hasErrors()) code = 1;
       if (process.exitCode && process.exitCode !== 0 && typeof process.exitCode === 'number') {
         // this is needed for testers such as "vitest", where it sets the exitCode to non zero when the coverage is not met.
@@ -151,7 +159,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     if (watch) return '';
     const summary = tests ? aggregateTestResults(tests, components) : undefined;
     const data = summary
-      ? `\n${formatTestReport(summary, { verbose, duration: `${seconds}s` })}`
+      ? `\n${formatTestReport(summary, { verbose, duration: `${seconds}s`, summaryOnly })}`
       : formatHint(`tests completed in ${seconds} seconds`);
     return {
       code,
@@ -169,6 +177,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       coverage = false,
       unmodified = false,
       updateSnapshot = false,
+      summary: summaryOnly = false,
     }: TestFlags
   ): Promise<GenericObject> {
     const timer = Timer.create();
@@ -220,17 +229,6 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       code = process.exitCode;
     }
 
-    const data = tests.results.map((r) => ({
-      data: {
-        components: r.data?.components.map((c) => ({
-          ...c,
-          componentId: c.componentId.toString(),
-        })),
-        errors: r.data?.errors,
-      },
-      error: r.error,
-    }));
-
     const aggregated = aggregateTestResults(tests, components);
     const summary = {
       totals: aggregated.totals,
@@ -245,10 +243,24 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       envErrors: aggregated.envErrors.map((e) => ({ envId: e.envId, message: e.error.message })),
     };
 
+    if (summaryOnly) {
+      return { code, data: summary };
+    }
+
+    const data = tests.results.map((r) => ({
+      data: {
+        components: r.data?.components.map((c) => ({
+          ...c,
+          componentId: c.componentId.toString(),
+        })),
+        errors: r.data?.errors,
+      },
+      error: r.error,
+    }));
+
     return {
       code,
       data,
-      summary,
     };
   }
 }

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -116,9 +116,11 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       };
     }
 
-    this.logger.console(
-      `testing total of ${components.length} components in workspace '${chalk.cyan(this.workspace.name)}'`
-    );
+    if (!summaryOnly) {
+      this.logger.console(
+        `testing total of ${components.length} components in workspace '${chalk.cyan(this.workspace.name)}'`
+      );
+    }
 
     let code = 0;
     let tests: TestResults | undefined;
@@ -272,25 +274,31 @@ supports watch mode, coverage reporting, and debug mode for development workflow
  * restores everything back to normal.
  */
 function silenceConsoleAndStdout(): () => void {
-  // Keep copies of the original methods so we can restore them later
-  const originalConsole = { ...console };
-  const originalStdoutWrite = process.stdout.write;
-  const originalStderrWrite = process.stderr.write;
+  const CONSOLE_METHODS = ['log', 'warn', 'error', 'info', 'debug'] as const;
+  const originalConsole = Object.fromEntries(
+    // eslint-disable-next-line no-console
+    CONSOLE_METHODS.map((m) => [m, console[m]])
+  ) as Record<(typeof CONSOLE_METHODS)[number], (...args: any[]) => void>;
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
-  // No-op implementations for console.* methods
-  for (const method of ['log', 'warn', 'error', 'info', 'debug'] as const) {
+  for (const method of CONSOLE_METHODS) {
     // eslint-disable-next-line no-console
     console[method] = () => {};
   }
 
-  // Replace process.stdout.write and process.stderr.write with no-ops
-  process.stdout.write = (() => true) as any;
-  process.stderr.write = (() => true) as any;
+  // process.stdout.write(chunk, encoding?, callback?) — callers may rely on the optional
+  // callback firing. Invoke it so we don't leave writers hanging.
+  const stubWrite = (...args: any[]): boolean => {
+    const cb = args.find((a) => typeof a === 'function') as ((err?: Error | null) => void) | undefined;
+    if (cb) cb();
+    return true;
+  };
+  process.stdout.write = stubWrite as typeof process.stdout.write;
+  process.stderr.write = stubWrite as typeof process.stderr.write;
 
-  // Return a function to restore original behavior
   return () => {
-    for (const method of Object.keys(originalConsole) as (keyof Console)[]) {
-      // @ts-ignore
+    for (const method of CONSOLE_METHODS) {
       // eslint-disable-next-line no-console
       console[method] = originalConsole[method];
     }

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -53,7 +53,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       'DEPRECATED. (use the pattern instead, e.g. "scopeName/**"). name of the scope to test',
     ],
     ['j', 'json', 'return the results in json format'],
-    ['', 'verbose', 'show passing components and list components without tests'],
+    ['', 'verbose', 'list the component ids that have no tests (default collapses them into a count)'],
     ['', 'summary', 'suppress tester output, print only the final pass/fail headline (or summary object with --json)'],
     // TODO: we need to reduce this redundant casting every time.
   ] as CommandOptions;
@@ -240,6 +240,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         hasError: c.hasError,
       })),
       componentsWithoutTests: aggregated.componentsWithoutTests.map((id) => id.toString()),
+      componentsAffectedByEnvError: aggregated.componentsAffectedByEnvError.map((id) => id.toString()),
       envErrors: aggregated.envErrors.map((e) => ({ envId: e.envId, message: e.error.message })),
     };
 

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -1,5 +1,5 @@
 import type { Command, CommandOptions, GenericObject } from '@teambit/cli';
-import { formatHint, formatSuccessSummary } from '@teambit/cli';
+import { formatHint } from '@teambit/cli';
 import chalk from 'chalk';
 import type { Logger } from '@teambit/logger';
 import type { Workspace } from '@teambit/workspace';
@@ -7,6 +7,7 @@ import { OutsideWorkspaceError } from '@teambit/workspace';
 import { Timer } from '@teambit/toolbox.time.timer';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { TesterMain, TestResults } from './tester.main.runtime';
+import { aggregateTestResults, formatTestReport } from './test-output-formatter';
 
 type TestFlags = {
   watch: boolean;
@@ -18,6 +19,7 @@ type TestFlags = {
   junit?: string;
   coverage?: boolean;
   updateSnapshot: boolean;
+  verbose?: boolean;
 };
 
 export class TestCmd implements Command {
@@ -50,6 +52,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       'DEPRECATED. (use the pattern instead, e.g. "scopeName/**"). name of the scope to test',
     ],
     ['j', 'json', 'return the results in json format'],
+    ['', 'verbose', 'show passing components and list components without tests'],
     // TODO: we need to reduce this redundant casting every time.
   ] as CommandOptions;
 
@@ -71,6 +74,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       coverage = false,
       unmodified = false,
       updateSnapshot = false,
+      verbose = false,
     }: TestFlags
   ) {
     const timer = Timer.create();
@@ -114,6 +118,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     );
 
     let code = 0;
+    let tests: TestResults | undefined;
     if (watch && !debug) {
       // avoid turning off the logger for non-watch scenario. otherwise, when this aspect throws errors, they'll be
       // swallowed. (Jest errors are shown regardless via Jest, but if the tester is unable to run Jest in the first
@@ -127,7 +132,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         updateSnapshot,
       });
     } else {
-      const tests = await this.tester.test(components, {
+      tests = await this.tester.test(components, {
         watch,
         debug,
         env,
@@ -144,10 +149,10 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     const { seconds } = timer.stop();
 
     if (watch) return '';
-    const data =
-      code === 0
-        ? formatSuccessSummary(`tests completed in ${seconds} seconds`)
-        : formatHint(`tests completed in ${seconds} seconds`);
+    const summary = tests ? aggregateTestResults(tests, components) : undefined;
+    const data = summary
+      ? `\n${formatTestReport(summary, { verbose, duration: `${seconds}s` })}`
+      : formatHint(`tests completed in ${seconds} seconds`);
     return {
       code,
       data,
@@ -226,9 +231,24 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       error: r.error,
     }));
 
+    const aggregated = aggregateTestResults(tests, components);
+    const summary = {
+      totals: aggregated.totals,
+      componentsWithTests: aggregated.componentsWithTests.map((c) => ({
+        id: c.id.toString(),
+        passed: c.passed,
+        failed: c.failed,
+        pending: c.pending,
+        hasError: c.hasError,
+      })),
+      componentsWithoutTests: aggregated.componentsWithoutTests.map((id) => id.toString()),
+      envErrors: aggregated.envErrors.map((e) => ({ envId: e.envId, message: e.error.message })),
+    };
+
     return {
       code,
       data,
+      summary,
     };
   }
 }

--- a/scopes/defender/tester/tester.service.ts
+++ b/scopes/defender/tester/tester.service.ts
@@ -109,18 +109,16 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
       return new Tests([]);
     }
     const tester: Tester = context.env.getTester();
-    const specFiles = ComponentMap.as(context.components, (component) => {
+    const allSpecFiles = ComponentMap.as(context.components, (component) => {
       return detectTestFiles(component, this.devFiles);
     });
-    const testCount = specFiles.toArray().reduce((acc, [, specs]) => acc + specs.length, 0);
+    // drop components with zero spec files before handing them to the tester — otherwise testers
+    // like Mocha invoke their reporter once per component and print "0 passing (0ms)" noise.
+    const specFiles = allSpecFiles.filter((files) => files.length > 0);
+    const componentWithTests = specFiles.toArray().length;
 
-    const componentWithTests = specFiles.toArray().reduce((acc: number, [, specs]) => {
-      if (specs.length > 0) acc += 1;
-      return acc;
-    }, 0);
-
-    if (testCount === 0 && !options.ui) {
-      this.logger.consoleWarning(`no tests found for components using environment ${chalk.cyan(context.id)}\n`);
+    if (componentWithTests === 0 && !options.ui) {
+      // silent: the final summary in `bit test` collapses no-test components into a single line.
       return new Tests([]);
     }
 


### PR DESCRIPTION
Rework `bit test` output so humans and AI agents can tell pass/fail at a glance:

- Per-component rollup after native tester output: one indented line per component (`›` bullet for pass, `✖` for fail, `⚠` for tester error), following the shared CLI style guide.
- Numeric headline summary (`✔ 359/359 tests passed across 17 components, 79 without tests`).
- Collapse components with zero spec files into a single hint line (`--verbose` expands to the full list).
- Skip empty-component invocations in `TesterService`, removing Mocha's `0 passing (0ms)` noise.
- Distinguish components affected by env/tester errors from components with no tests.
- New `--summary` flag: suppress tester output, print only the final headline. With `--json`, `data` becomes a structured summary (totals, per-component rollup, components-without-tests, env errors) — ideal for agents that just need to grep pass/fail.
- Remove the per-env `no tests found for components using environment X` warning — the new summary covers it.

Uses the shared `@teambit/cli` output toolkit. Unit tests cover aggregation and rendering.