### PR TITLE
fix(deps-graph): preserve workspace lockfile entries on reimport

### DIFF
--- a/components/legacy/scope/scope.ts
+++ b/components/legacy/scope/scope.ts
@@ -40,9 +40,8 @@ import type {
   ComponentItem,
   ObjectItem,
   ObjectList,
-  DependenciesGraph,
 } from '@teambit/objects';
-import { ModelComponent, Symlink, BitObject, Ref, Repository, IndexType } from '@teambit/objects';
+import { DependenciesGraph, ModelComponent, Symlink, BitObject, Ref, Repository, IndexType } from '@teambit/objects';
 import type { RemovedObjects } from './removed-components';
 import { Tmp } from './repositories';
 import SourcesRepository from './repositories/sources';
@@ -750,7 +749,9 @@ once done, to continue working, please run "bit cc"`
         const graph = await this.getDependenciesGraphByComponentId(componentId);
         if (graph == null || graph.isEmpty()) return;
         if (allGraph == null) {
-          allGraph = graph;
+          // loadDependenciesGraph caches the graph on the Version object; merging into
+          // it in place would mutate the cached instance and corrupt subsequent callers.
+          allGraph = DependenciesGraph.deserialize(graph.serialize());
         } else {
           allGraph.merge(graph);
         }

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -238,11 +238,11 @@ chai.use(chaiFs);
       helper.scopeHelper.destroy();
     });
   });
-  // Reproduces the "reimport drift" bug: when a second component is imported into a
-  // workspace that already has installed components, the graph-generated lockfile
-  // overwrites pnpm-lock.yaml using only the newly-imported component's subgraph.
-  // Existing workspace dependencies are then re-resolved by pnpm against the manifest
-  // specifiers, potentially drifting to newer versions.
+  // Covers the "reimport drift" path: when a second component is imported into a
+  // workspace that already has installed components, the graph-generated lockfile must
+  // not overwrite pnpm-lock.yaml with only the newly-imported component's subgraph — if
+  // it did, existing workspace dependencies would be re-resolved by pnpm against the
+  // manifest specifiers and drift to newer registry versions.
   describe('importing a component into a workspace that already has an installed component', function () {
     let randomStr: string;
     let initialLockfile: any;
@@ -301,17 +301,18 @@ chai.use(chaiFs);
     it('second import should include comp2 deps at the versions stored in its graph', () => {
       expect(lockfileAfterSecondImport.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
     });
-    // This assertion currently fails: the graph-based lockfile regeneration overwrites
-    // pnpm-lock.yaml with only comp2's subgraph, so foo is re-resolved from the manifest
-    // specifier and drifts to the newer registry version.
+    // Regression coverage: graph-based lockfile regeneration previously overwrote
+    // pnpm-lock.yaml with only comp2's subgraph, causing foo to be re-resolved from the
+    // manifest specifier and drift to the newer registry version.
     it('second import should preserve comp1 deps at their previously-locked versions', () => {
       expect(lockfileAfterSecondImport.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
       expect(lockfileAfterSecondImport.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
     });
   });
-  // Same class of bug as the previous block, but for the "pull updated version of an
-  // already-imported component" path. Only the re-imported component's IDs are passed
-  // to installPackagesGracefully, so only its graph is used to regenerate the lockfile.
+  // Same class of drift as the previous block, but for the "pull updated version of an
+  // already-imported component" path. Only the re-imported component's IDs are passed to
+  // installPackagesGracefully, so only its graph is used to regenerate the lockfile — the
+  // merge helper has to preserve unrelated components' previously-locked deps.
   describe('re-importing an updated version of an already-imported component', function () {
     let randomStr: string;
     let lockfileAfterReimport: any;
@@ -365,9 +366,9 @@ chai.use(chaiFs);
       helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
-    // This assertion currently fails: re-importing comp1 regenerates the lockfile from
-    // comp1's graph only, dropping comp2's bar entry. pnpm then re-resolves bar from the
-    // manifest specifier and drifts to the newer registry version.
+    // Regression coverage: re-importing comp1 must not regenerate the lockfile from
+    // comp1's graph only and drop comp2's bar entry. Otherwise pnpm may re-resolve bar
+    // from the manifest specifier and drift to the newer registry version.
     it('should preserve comp2 dependency versions that are unrelated to the re-imported component', () => {
       expect(lockfileAfterReimport.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
       expect(lockfileAfterReimport.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -238,4 +238,308 @@ chai.use(chaiFs);
       helper.scopeHelper.destroy();
     });
   });
+  // Reproduces the "reimport drift" bug: when a second component is imported into a
+  // workspace that already has installed components, the graph-generated lockfile
+  // overwrites pnpm-lock.yaml using only the newly-imported component's subgraph.
+  // Existing workspace dependencies are then re-resolved by pnpm against the manifest
+  // specifiers, potentially drifting to newer versions.
+  describe('importing a component into a workspace that already has an installed component', function () {
+    let randomStr: string;
+    let initialLockfile: any;
+    let lockfileAfterSecondImport: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        { policy: { peers: [] } },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/foo"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.fs.createFile('comp2', 'comp2.js', 'require("@pnpm.e2e/bar"); // eslint-disable-line');
+      helper.command.addComponent('comp2');
+      helper.extensions.addExtensionToVariant('comp2', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      helper.command.import(`${helper.scopes.remote}/comp1@latest`);
+      initialLockfile = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' });
+
+      helper.command.import(`${helper.scopes.remote}/comp2@latest`);
+      lockfileAfterSecondImport = yaml.load(
+        fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8')
+      );
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    it('first import should restore the lockfile from comp1 graph', () => {
+      expect(initialLockfile.bit.restoredFromModel).to.eq(true);
+      expect(initialLockfile.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+    });
+    it('second import should include comp2 deps at the versions stored in its graph', () => {
+      expect(lockfileAfterSecondImport.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
+    });
+    // This assertion currently fails: the graph-based lockfile regeneration overwrites
+    // pnpm-lock.yaml with only comp2's subgraph, so foo is re-resolved from the manifest
+    // specifier and drifts to the newer registry version.
+    it('second import should preserve comp1 deps at their previously-locked versions', () => {
+      expect(lockfileAfterSecondImport.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+      expect(lockfileAfterSecondImport.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
+    });
+  });
+  // Same class of bug as the previous block, but for the "pull updated version of an
+  // already-imported component" path. Only the re-imported component's IDs are passed
+  // to installPackagesGracefully, so only its graph is used to regenerate the lockfile.
+  describe('re-importing an updated version of an already-imported component', function () {
+    let randomStr: string;
+    let lockfileAfterReimport: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        { policy: { peers: [] } },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/foo"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.fs.createFile('comp2', 'comp2.js', 'require("@pnpm.e2e/bar"); // eslint-disable-line');
+      helper.command.addComponent('comp2');
+      helper.extensions.addExtensionToVariant('comp2', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      helper.fs.appendFile('comp1/comp1.js', '\nmodule.exports = 1;');
+      helper.command.tagAllComponents('--skip-tests --unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      helper.command.import(`${helper.scopes.remote}/comp1@0.0.1 ${helper.scopes.remote}/comp2@latest`);
+
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' });
+
+      helper.command.import(`${helper.scopes.remote}/comp1@latest`);
+      lockfileAfterReimport = yaml.load(
+        fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8')
+      );
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    // This assertion currently fails: re-importing comp1 regenerates the lockfile from
+    // comp1's graph only, dropping comp2's bar entry. pnpm then re-resolves bar from the
+    // manifest specifier and drifts to the newer registry version.
+    it('should preserve comp2 dependency versions that are unrelated to the re-imported component', () => {
+      expect(lockfileAfterReimport.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
+      expect(lockfileAfterReimport.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');
+    });
+  });
+  describe('three components sharing a peer dependency', function () {
+    let randomStr: string;
+    let lockfile: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        {
+          policy: {
+            peers: [
+              {
+                name: '@pnpm.e2e/abc',
+                version: '*',
+                supportedRange: '*',
+              },
+            ],
+          },
+        },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('bar', 'bar.js', 'require("@pnpm.e2e/abc"); // eslint-disable-line');
+      helper.command.addComponent('bar');
+      helper.extensions.addExtensionToVariant('bar', `${helper.scopes.remote}/custom-env/env`, {});
+      await addDistTag({ package: '@pnpm.e2e/abc', version: '1.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      await addDistTag({ package: '@pnpm.e2e/abc', version: '2.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' });
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.fs.createFile('foo', 'foo.js', `require("@pnpm.e2e/abc"); require("@ci/${randomStr}.bar");`);
+      helper.command.addComponent('foo');
+      helper.extensions.addExtensionToVariant('foo', `${helper.scopes.remote}/custom-env/env@0.0.1`, {});
+      helper.command.install('--add-missing-deps');
+      helper.command.snapAllComponentsWithoutBuild('--skip-tests');
+      helper.command.export();
+
+      // A third component re-uses one of the already-published versions (peer-a@1.0.0)
+      // so the merge has to reconcile three graphs where two of them agree on the lower
+      // version and one carries the higher version.
+      await addDistTag({ package: '@pnpm.e2e/abc', version: '1.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' });
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.fs.createFile('baz', 'baz.js', `require("@pnpm.e2e/abc"); require("@ci/${randomStr}.bar");`);
+      helper.command.addComponent('baz');
+      helper.extensions.addExtensionToVariant('baz', `${helper.scopes.remote}/custom-env/env@0.0.1`, {});
+      helper.command.install('--add-missing-deps');
+      helper.command.snapAllComponentsWithoutBuild('--skip-tests');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.import(
+        `${helper.scopes.remote}/foo@latest ${helper.scopes.remote}/bar@latest ${helper.scopes.remote}/baz@latest`
+      );
+      lockfile = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    it('should restore the lockfile from the merged graphs', () => {
+      expect(lockfile.bit.restoredFromModel).to.eq(true);
+    });
+    // The root edge of the merged graph picks the highest peer version per (name, specifier),
+    // so the highest variant must be present in the lockfile.
+    it('should include the highest version of the shared peer dependency across all three graphs', () => {
+      expect(lockfile.packages).to.have.property('@pnpm.e2e/abc@2.0.0');
+      expect(lockfile.packages).to.have.property('@pnpm.e2e/peer-a@1.0.1');
+    });
+    // Documents a known limitation of the merge: highest-wins is applied only to the root
+    // edge. Transitive snapshots from lower-version graphs still reference the older
+    // versions of non-peer packages, so pnpm retains them in the lockfile. (Peer versions
+    // get reconciled across the workspace at install time, so they don't leak; regular
+    // dependencies do.)
+    it('currently leaves the lower version of non-peer transitives in the lockfile', () => {
+      expect(lockfile.packages).to.have.property('@pnpm.e2e/abc@1.0.0');
+    });
+  });
+  // Regression coverage for devDependencies + optionalDependencies round-trip through
+  // the graph. The graph edge neighbours carry `lifecycle` and `optional` flags; these
+  // must make it back into the regenerated lockfile's importer entries and snapshots.
+  describe('dev and optional dependencies round-trip through the graph', function () {
+    let randomStr: string;
+    let depsGraph: any;
+    let lockfile: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        {
+          policy: {
+            dev: [
+              {
+                name: '@pnpm.e2e/foo',
+                version: '100.0.0',
+                hidden: true,
+                force: true,
+              },
+            ],
+          },
+        },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/bar"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      const versionObj = helper.command.catComponent('comp1@latest');
+      depsGraph = JSON.parse(helper.command.catObject(versionObj.dependenciesGraphRef));
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      helper.command.import(`${helper.scopes.remote}/comp1@latest`);
+      lockfile = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    it('should record the dev-only dependency in the graph with lifecycle=dev', () => {
+      const directDependencies = depsGraph.edges.find((edge) => edge.id === '.').neighbours;
+      const fooDep = directDependencies.find((dep) => dep.name === '@pnpm.e2e/foo');
+      expect(fooDep, 'foo should be a direct dependency in the graph').to.exist;
+      expect(fooDep.lifecycle).to.eq('dev');
+    });
+    it('should record the runtime dependency in the graph with lifecycle=runtime', () => {
+      const directDependencies = depsGraph.edges.find((edge) => edge.id === '.').neighbours;
+      const barDep = directDependencies.find((dep) => dep.name === '@pnpm.e2e/bar');
+      expect(barDep, 'bar should be a direct dependency in the graph').to.exist;
+      expect(barDep.lifecycle).to.eq('runtime');
+    });
+    it('should restore the lockfile from the graph', () => {
+      expect(lockfile.bit.restoredFromModel).to.eq(true);
+      expect(lockfile.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+      expect(lockfile.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
+    });
+  });
 });

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -517,6 +517,10 @@ function tryReadPackageJson(pkgDir: string) {
 // every workspace project, but only populates deps for manifests whose keys appear in the
 // graph's root edge — so per-importer overlay (instead of overwrite) is what keeps
 // unrelated workspace importers intact.
+//
+// Packages and snapshots are deep-merged per key so that pnpm-managed metadata the graph
+// doesn't round-trip (e.g. `optional`, `transitivePeerDependencies`, `dev`) survives on
+// entries the graph also knows about.
 function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileFile): LockfileFile {
   const importers: NonNullable<LockfileFile['importers']> = { ...existing.importers };
   for (const [importerId, graphImporter] of Object.entries(graph.importers ?? {})) {
@@ -535,11 +539,38 @@ function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileF
       },
     };
   }
-  return {
+  const existingBit = (existing as LockfileFile & { bit?: { depsRequiringBuild?: string[] } }).bit;
+  const graphBit = (graph as LockfileFile & { bit?: { depsRequiringBuild?: string[] } }).bit;
+  const mergedDepsRequiringBuild = Array.from(
+    new Set([...(existingBit?.depsRequiringBuild ?? []), ...(graphBit?.depsRequiringBuild ?? [])])
+  ).sort();
+  const merged = {
     ...existing,
     lockfileVersion: graph.lockfileVersion ?? existing.lockfileVersion,
     importers,
-    packages: { ...existing.packages, ...graph.packages },
-    snapshots: { ...existing.snapshots, ...graph.snapshots },
+    packages: mergeEntryRecords(existing.packages, graph.packages),
+    snapshots: mergeEntryRecords(existing.snapshots, graph.snapshots),
   };
+  if (existingBit || graphBit) {
+    (merged as LockfileFile & { bit?: Record<string, unknown> }).bit = {
+      ...existingBit,
+      ...graphBit,
+      depsRequiringBuild: mergedDepsRequiringBuild,
+    };
+  }
+  return merged;
+}
+
+function mergeEntryRecords<T extends object>(
+  existing: Record<string, T> | undefined,
+  graph: Record<string, T> | undefined
+): Record<string, T> | undefined {
+  if (!existing) return graph;
+  if (!graph) return existing;
+  const merged: Record<string, T> = { ...existing };
+  for (const [key, graphEntry] of Object.entries(graph)) {
+    const existingEntry = merged[key];
+    merged[key] = existingEntry ? ({ ...existingEntry, ...graphEntry } as T) : graphEntry;
+  }
+  return merged;
 }

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -546,7 +546,11 @@ function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileF
   ).sort();
   const merged = {
     ...existing,
-    lockfileVersion: graph.lockfileVersion ?? existing.lockfileVersion,
+    // Keep the existing lockfile's schema version. convertGraphToLockfile hardcodes
+    // lockfileVersion: '9.0', so preferring graph.lockfileVersion would silently
+    // downgrade workspaces whose pnpm already writes a newer schema and trigger a
+    // full rewrite on the next install.
+    lockfileVersion: existing.lockfileVersion ?? graph.lockfileVersion,
     importers,
     packages: mergeEntryRecords(existing.packages, graph.packages),
     snapshots: mergeEntryRecords(existing.snapshots, graph.snapshots),

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -91,17 +91,27 @@ export class PnpmPackageManager implements PackageManager {
       ...opts,
       registries,
     });
-    const lockfile: LockfileFile = await convertGraphToLockfile(dependenciesGraph, {
+    const graphLockfile: LockfileFile = await convertGraphToLockfile(dependenciesGraph, {
       ...opts,
       resolve,
     });
-    Object.assign(lockfile, {
+    // Merge the graph-derived subset into any existing wanted lockfile rather than
+    // overwriting. Only the importers, packages, and snapshots referenced by the
+    // imported components' subgraph are re-stated here; every other workspace dep's
+    // locked version must be preserved so pnpm doesn't re-resolve it to a newer
+    // registry version.
+    const existingLockfile = await readWantedLockfile(opts.rootDir, { ignoreIncompatible: true });
+    const mergedLockfile = existingLockfile
+      ? mergeGraphLockfileIntoExisting(convertLockfileObjectToLockfileFile(existingLockfile), graphLockfile)
+      : graphLockfile;
+    Object.assign(mergedLockfile, {
       bit: {
+        ...((mergedLockfile as LockfileFile & { bit?: Record<string, unknown> }).bit ?? {}),
         restoredFromModel: true,
       },
     });
     const lockfilePath = join(opts.rootDir, 'pnpm-lock.yaml');
-    await writeLockfileFile(lockfilePath, lockfile);
+    await writeLockfileFile(lockfilePath, mergedLockfile);
     this.logger.debug(`generated a lockfile from dependencies graph at ${lockfilePath}`);
     if (process.env.DEPS_GRAPH_LOG) {
       // eslint-disable-next-line no-console
@@ -498,4 +508,38 @@ function tryReadPackageJson(pkgDir: string) {
   } catch {
     return undefined;
   }
+}
+
+// Merge a graph-derived lockfile into an existing wanted lockfile. The graph lockfile is
+// authoritative for keys it contains (a re-imported component can change the resolution
+// of its own deps), but must not erase packages, snapshots, or importer entries that are
+// only known to the existing lockfile. convertGraphToLockfile emits importer entries for
+// every workspace project, but only populates deps for manifests whose keys appear in the
+// graph's root edge — so per-importer overlay (instead of overwrite) is what keeps
+// unrelated workspace importers intact.
+function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileFile): LockfileFile {
+  const importers: NonNullable<LockfileFile['importers']> = { ...(existing.importers ?? {}) };
+  for (const [importerId, graphImporter] of Object.entries(graph.importers ?? {})) {
+    const existingImporter = importers[importerId];
+    if (!existingImporter) {
+      importers[importerId] = graphImporter;
+      continue;
+    }
+    importers[importerId] = {
+      ...existingImporter,
+      dependencies: { ...(existingImporter.dependencies ?? {}), ...(graphImporter.dependencies ?? {}) },
+      devDependencies: { ...(existingImporter.devDependencies ?? {}), ...(graphImporter.devDependencies ?? {}) },
+      optionalDependencies: {
+        ...(existingImporter.optionalDependencies ?? {}),
+        ...(graphImporter.optionalDependencies ?? {}),
+      },
+    };
+  }
+  return {
+    ...existing,
+    lockfileVersion: graph.lockfileVersion ?? existing.lockfileVersion,
+    importers,
+    packages: { ...(existing.packages ?? {}), ...(graph.packages ?? {}) },
+    snapshots: { ...(existing.snapshots ?? {}), ...(graph.snapshots ?? {}) },
+  };
 }

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -106,7 +106,7 @@ export class PnpmPackageManager implements PackageManager {
       : graphLockfile;
     Object.assign(mergedLockfile, {
       bit: {
-        ...((mergedLockfile as LockfileFile & { bit?: Record<string, unknown> }).bit ?? {}),
+        ...(mergedLockfile as LockfileFile & { bit?: Record<string, unknown> }).bit,
         restoredFromModel: true,
       },
     });
@@ -518,7 +518,7 @@ function tryReadPackageJson(pkgDir: string) {
 // graph's root edge — so per-importer overlay (instead of overwrite) is what keeps
 // unrelated workspace importers intact.
 function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileFile): LockfileFile {
-  const importers: NonNullable<LockfileFile['importers']> = { ...(existing.importers ?? {}) };
+  const importers: NonNullable<LockfileFile['importers']> = { ...existing.importers };
   for (const [importerId, graphImporter] of Object.entries(graph.importers ?? {})) {
     const existingImporter = importers[importerId];
     if (!existingImporter) {
@@ -527,11 +527,11 @@ function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileF
     }
     importers[importerId] = {
       ...existingImporter,
-      dependencies: { ...(existingImporter.dependencies ?? {}), ...(graphImporter.dependencies ?? {}) },
-      devDependencies: { ...(existingImporter.devDependencies ?? {}), ...(graphImporter.devDependencies ?? {}) },
+      dependencies: { ...existingImporter.dependencies, ...graphImporter.dependencies },
+      devDependencies: { ...existingImporter.devDependencies, ...graphImporter.devDependencies },
       optionalDependencies: {
-        ...(existingImporter.optionalDependencies ?? {}),
-        ...(graphImporter.optionalDependencies ?? {}),
+        ...existingImporter.optionalDependencies,
+        ...graphImporter.optionalDependencies,
       },
     };
   }
@@ -539,7 +539,7 @@ function mergeGraphLockfileIntoExisting(existing: LockfileFile, graph: LockfileF
     ...existing,
     lockfileVersion: graph.lockfileVersion ?? existing.lockfileVersion,
     importers,
-    packages: { ...(existing.packages ?? {}), ...(graph.packages ?? {}) },
-    snapshots: { ...(existing.snapshots ?? {}), ...(graph.snapshots ?? {}) },
+    packages: { ...existing.packages, ...graph.packages },
+    snapshots: { ...existing.snapshots, ...graph.snapshots },
   };
 }


### PR DESCRIPTION
## Summary
- Re-importing a component into a populated workspace used to overwrite `pnpm-lock.yaml` with only the imported component's subgraph. pnpm then re-resolved every other workspace dep from the manifest specifiers and silently drifted to newer registry versions.
- This PR makes `PnpmPackageManager.dependenciesGraphToLockfile` merge the graph-derived subset into the existing wanted lockfile instead of overwriting it.
- Also fixes an in-place mutation in `Scope.getDependenciesGraphByComponentIds` that corrupted the cached `Version._dependenciesGraph`.
- Adds e2e coverage for the drift scenarios, 3-way merge, and dev/optional dep round-trip.

Context / full analysis: #10317.

## Changes

### `scopes/dependencies/pnpm/pnpm.package-manager.ts`
`dependenciesGraphToLockfile` now reads the existing wanted lockfile and overlays the graph's `importers` / `packages` / `snapshots` onto it. The importer overlay merges per-importer, per-dep-type, per-dep-key — which keeps unrelated projects' existing deps intact even though `convertGraphToLockfile` emits a sparse importer entry for every workspace project.

### `components/legacy/scope/scope.ts`
`getDependenciesGraphByComponentIds` clones the first loaded graph via `serialize`/`deserialize` before merging subsequent graphs into it. `Version.loadDependenciesGraph` caches the graph on the object, so merging into it in place was mutating the cache and leaking merged state to later callers.

### `e2e/harmony/deps-graph.e2e.ts`
Four new `describe` blocks:
1. `importing a component into a workspace that already has an installed component` — asserts the existing component's deps aren't re-resolved after importing a second component.
2. `re-importing an updated version of an already-imported component` — asserts unrelated components' deps aren't re-resolved on update.
3. `three components sharing a peer dependency` — 3-way merge, highest-wins on the root edge. Includes one assertion documenting a known remaining limitation where lower-version non-peer transitives stay in the lockfile.
4. `dev and optional dependencies round-trip through the graph`.

## Test plan
- [x] All 20 cases in `e2e/harmony/deps-graph.e2e.ts` pass locally.
- [x] `npm run lint` and `npm run oxlint` clean.
- [ ] CI green.

## Known follow-ups (tracked in #10317, not in this PR)
- Transitive snapshot reconciliation on merge (lower-version non-peer packages still linger after a 3-way merge).
- Coverage for: missing graph Source, `patchedDependencies`, `overrides`, `directory`-type resolutions, specifier drift between tag and import.
- Duplicate root edges accumulated by `DependenciesGraph.merge` (cosmetic today).