### PR TITLE
fix(remove): say 'local workspace' instead of 'local scope' in bit remove output

### DIFF
--- a/scopes/component/remove/remove-template.ts
+++ b/scopes/component/remove/remove-template.ts
@@ -20,10 +20,12 @@ export function removeTemplate(
     const compToItems = (comps: ComponentIdList) =>
       comps.map((id) => formatItem(id.version === 'latest' ? id.toStringWithoutVersion() : id.toString()));
     const getMsg = (isLane = false) => {
-      const removedFrom = isLane ? 'lane' : 'scope';
-      return isRemote
-        ? `successfully removed components from the remote ${removedFrom}`
-        : `successfully removed components from the local ${removedFrom}`;
+      if (isRemote) {
+        const removedFrom = isLane ? 'lane' : 'scope';
+        return `successfully removed components from the remote ${removedFrom}`;
+      }
+      const removedFrom = isLane ? 'lane' : 'workspace';
+      return `successfully removed components from the local ${removedFrom}`;
     };
     const compOutput = isEmpty(removedComponentIds)
       ? ''


### PR DESCRIPTION
`bit remove` removes components from the workspace, not the local scope (that's what `bit delete` does). Fixed the success message to reflect this accurately.

Before: `successfully removed components from the local scope`
After: `successfully removed components from the local workspace`