### PR TITLE
feat(preview): add supportsUseSource env preview config

### DIFF
--- a/scopes/preview/preview/preview.main.runtime.ts
+++ b/scopes/preview/preview/preview.main.runtime.ts
@@ -176,6 +176,13 @@ export type PreviewConfig = {
 export type EnvPreviewConfig = {
   strategyName?: PreviewStrategyName;
   splitComponentBundle?: boolean;
+  /**
+   * whether the env's preview pipeline can consume component source files directly
+   * (required when `bit start --use-source` is used).
+   * older envs without the matching preview/webpack config should leave this unset/false
+   * so bit falls back to the compiled dist paths for their components.
+   */
+  supportsUseSource?: boolean;
 };
 
 export type BundlingStrategySlot = SlotRegistry<BundlingStrategy>;
@@ -909,7 +916,8 @@ export class PreviewMain {
   }
 
   private getComponentPreviewPaths(files: AbstractVinyl[], component: Component, environment: PreviewEnv): string[] {
-    if (this._useSource) {
+    const envSupportsUseSource = this.getEnvPreviewConfig(environment).supportsUseSource ?? false;
+    if (this._useSource && envSupportsUseSource) {
       return files.map((file) => file.path);
     }
 

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -452,6 +452,7 @@ export class ReactEnv
       strategyName: COMPONENT_PREVIEW_STRATEGY_NAME as PreviewStrategyName,
       splitComponentBundle: true,
       isScaling: true,
+      supportsUseSource: true,
     };
   }
 

--- a/scopes/react/react/webpack/overlay/refreshOverlayInterop.js
+++ b/scopes/react/react/webpack/overlay/refreshOverlayInterop.js
@@ -1,6 +1,4 @@
 /* eslint-disable */
-/** this file was copied as is from react-dev-utils/refreshOverlayInterop */
-
 // @remove-on-eject-begin
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -11,27 +9,16 @@
 // @remove-on-eject-end
 'use strict';
 
+// Thin mapping between @pmmmwh/react-refresh-webpack-plugin's overlay
+// contract and react-error-overlay. Initialization (startReportingRuntimeErrors)
+// is handled by webpackHotDevClient.js which is added as the overlay entry.
+
 const {
   dismissBuildError,
   dismissRuntimeErrors,
   reportBuildError,
   reportRuntimeError,
-  setEditorHandler,
 } = require('react-error-overlay');
-const launchEditorEndpoint = require('./launchEditorEndpoint');
-
-setEditorHandler(function editorHandler(errorLocation) {
-  // Keep this in sync with the error overlay middleware endpoint.
-  fetch(
-    launchEditorEndpoint +
-      '?fileName=' +
-      window.encodeURIComponent(errorLocation.fileName) +
-      '&lineNumber=' +
-      window.encodeURIComponent(errorLocation.lineNumber || 1) +
-      '&colNumber=' +
-      window.encodeURIComponent(errorLocation.colNumber || 1)
-  );
-});
 
 module.exports = {
   clearCompileError: dismissBuildError,

--- a/scopes/react/react/webpack/webpack.config.base.ts
+++ b/scopes/react/react/webpack/webpack.config.base.ts
@@ -142,7 +142,7 @@ export default function (isEnvProduction = false): Configuration {
                 presets: [
                   require.resolve('@babel/preset-env'),
                   require.resolve('@babel/preset-typescript'),
-                  require.resolve('@babel/preset-react'),
+                  [require.resolve('@babel/preset-react'), { runtime: 'automatic' }],
                 ],
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/scopes/react/react/webpack/webpack.config.component.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.component.dev.ts
@@ -89,6 +89,7 @@ export default function (workDir: string, envId: string): Configuration {
       new ReactRefreshWebpackPlugin({
         overlay: {
           sockPath: `_hmr/${envId}`,
+          entry: require.resolve('./overlay/webpackHotDevClient'),
           module: require.resolve('./overlay/refreshOverlayInterop'),
         },
 

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -105,9 +105,6 @@ includes hot module reloading for development.`;
         `bit start can only be run inside a bit workspace or a bit scope - please ensure you are running the command in the correct directory`
       );
     }
-    if (useRootModules && useSource) {
-      throw new BitError(`--use-root-modules and --use-source cannot be used together`);
-    }
     const appName = this.ui.getUiName(uiRootAspectIdOrName);
     await this.ui.invokePreStart({ skipCompilation });
     this.logger.off();


### PR DESCRIPTION
Adds `supportsUseSource` to `EnvPreviewConfig` so envs can opt-in to `bit start --use-source`.
When the flag isn't declared (default `false`), the preview falls back to compiled dist paths — preventing breakage for workspaces that still use older envs without the babel-typescript + extensionAlias config introduced in #10314.

Core `react.env` declares `supportsUseSource: true` since its webpack base already has the required config.