### PR TITLE
feat(install): add --restore flag to rebuild the lockfile from component graphs

### DIFF
--- a/components/legacy/scope/scope.ts
+++ b/components/legacy/scope/scope.ts
@@ -743,8 +743,11 @@ once done, to continue working, please run "bit cc"`
     this.objects.scopeJson = scopeJson;
   }
 
-  public async getDependenciesGraphByComponentIds(componentIds: ComponentID[]): Promise<DependenciesGraph | undefined> {
-    if (!isFeatureEnabled(DEPS_GRAPH)) return undefined;
+  public async getDependenciesGraphByComponentIds(
+    componentIds: ComponentID[],
+    options?: { ignoreFeatureToggle?: boolean }
+  ): Promise<DependenciesGraph | undefined> {
+    if (!options?.ignoreFeatureToggle && !isFeatureEnabled(DEPS_GRAPH)) return undefined;
     let allGraph: DependenciesGraph | undefined;
     await pMapPool(
       componentIds,

--- a/components/legacy/scope/scope.ts
+++ b/components/legacy/scope/scope.ts
@@ -760,8 +760,11 @@ once done, to continue working, please run "bit cc"`
     this.objects.scopeJson = scopeJson;
   }
 
-  public async getDependenciesGraphByComponentIds(componentIds: ComponentID[]): Promise<DependenciesGraph | undefined> {
-    if (!isFeatureEnabled(DEPS_GRAPH)) return undefined;
+  public async getDependenciesGraphByComponentIds(
+    componentIds: ComponentID[],
+    options?: { ignoreFeatureToggle?: boolean }
+  ): Promise<DependenciesGraph | undefined> {
+    if (!options?.ignoreFeatureToggle && !isFeatureEnabled(DEPS_GRAPH)) return undefined;
     let allGraph: DependenciesGraph | undefined;
     await pMapPool(
       componentIds,

--- a/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
+++ b/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
@@ -439,7 +439,7 @@ Flags: --name <workspace-name>, --generator <env-id>, --standalone, --no-package
 install workspace dependencies
 
 installs workspace dependencies and prepares the workspace for development. when packages are specified, adds them to workspace.jsonc policy and installs. when no packages specified, installs existing dependencies. automatically imports components, compiles components, links to node_modules, and writes config files.
-Flags: --type [lifecycleType], --update, --save-prefix [savePrefix], --skip-dedupe, --skip-import, --skip-compile, --skip-write-config-files, --add-missing-deps, --skip-unavailable, --add-missing-peers, --recurring-install, --no-optional [noOptional], --lockfile-only, --allow-scripts [pkgNames], --disallow-scripts [pkgNames]
+Flags: --type [lifecycleType], --update, --save-prefix [savePrefix], --skip-dedupe, --skip-import, --skip-compile, --skip-write-config-files, --add-missing-deps, --skip-unavailable, --add-missing-peers, --recurring-install, --no-optional [noOptional], --lockfile-only, --restore, --allow-scripts [pkgNames], --disallow-scripts [pkgNames]
 
 ## bit internalize [component-pattern]
 

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -607,4 +607,66 @@ chai.use(chaiFs);
       expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');
     });
   });
+  // --restore is an explicit opt-in, so it has to bypass the DEPS_GRAPH feature toggle
+  // and work on workspaces that never enabled the flag. The graph itself was authored on
+  // a scope that had the flag on at tag time, but the consumer shouldn't need to flip
+  // the flag just to restore from it.
+  describe('bit install --restore works when the DEPS_GRAPH feature toggle is disabled', function () {
+    let randomStr: string;
+    let lockfileAfterRestore: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        { policy: { peers: [] } },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/foo"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+
+      // Turn the DEPS_GRAPH feature toggle off for the remainder of the test. The outer
+      // describe's after() hook will restore it via resetFeatures, but we also restore it
+      // here so subsequent describes in this suite aren't affected.
+      helper.command.resetFeatures();
+      try {
+        helper.command.import(`${helper.scopes.remote}/comp1@latest`);
+        await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' });
+        helper.fs.deletePath('pnpm-lock.yaml');
+        helper.fs.deletePath('node_modules');
+        helper.command.runCmd('bit install --restore');
+        lockfileAfterRestore = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+      } finally {
+        helper.command.setFeatures(DEPS_GRAPH);
+      }
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    it('should still restore the lockfile from the stored graph', () => {
+      expect(lockfileAfterRestore.bit.restoredFromModel).to.eq(true);
+      expect(lockfileAfterRestore.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+      expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
+    });
+  });
 });

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -543,4 +543,68 @@ chai.use(chaiFs);
       expect(lockfile.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
     });
   });
+  // `bit install --restore` seeds the lockfile from the dependency graphs stored on
+  // every bitmap entry, the same way `bit import` does for the components it writes.
+  // This lets a user recover from a deleted pnpm-lock.yaml without re-resolving from
+  // manifest specifiers (which would drift to whatever the registry considers latest).
+  describe('bit install --restore rebuilds the lockfile from workspace component graphs', function () {
+    let randomStr: string;
+    let lockfileAfterRestore: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        { policy: { peers: [] } },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/foo"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.fs.createFile('comp2', 'comp2.js', 'require("@pnpm.e2e/bar"); // eslint-disable-line');
+      helper.command.addComponent('comp2');
+      helper.extensions.addExtensionToVariant('comp2', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      helper.command.import(`${helper.scopes.remote}/comp1@latest ${helper.scopes.remote}/comp2@latest`);
+
+      // bump registry and blow away the lockfile + node_modules, then restore from graphs.
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' });
+      helper.fs.deletePath('pnpm-lock.yaml');
+      helper.fs.deletePath('node_modules');
+      helper.command.runCmd('bit install --restore');
+      lockfileAfterRestore = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    it('should mark the regenerated lockfile as restoredFromModel', () => {
+      expect(lockfileAfterRestore.bit.restoredFromModel).to.eq(true);
+    });
+    it('should keep both components locked to the versions stored in their graphs', () => {
+      expect(lockfileAfterRestore.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+      expect(lockfileAfterRestore.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
+      expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
+      expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');
+    });
+  });
 });

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -363,4 +363,63 @@ export default new ${className}();
       expect(lockfileAfterSecondImport.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
     });
   });
+  describe('bit install --restore rebuilds the lockfile from workspace component graphs', function () {
+    let randomStr: string;
+    let lockfileAfterRestore: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      npmCiRegistry.setRegistry();
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        { policy: { peers: [] } },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/foo"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.fs.createFile('comp2', 'comp2.js', 'require("@pnpm.e2e/bar"); // eslint-disable-line');
+      helper.command.addComponent('comp2');
+      helper.extensions.addExtensionToVariant('comp2', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      helper.command.import(`${helper.scopes.remote}/comp1@latest ${helper.scopes.remote}/comp2@latest`);
+
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' });
+      await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' });
+      helper.fs.deletePath('pnpm-lock.yaml');
+      helper.fs.deletePath('node_modules');
+      helper.command.runCmd('bit install --restore');
+      lockfileAfterRestore = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.scopeHelper.destroy();
+    });
+    it('should mark the regenerated lockfile as restoredFromModel', () => {
+      expect(lockfileAfterRestore.bit.restoredFromModel).to.eq(true);
+    });
+    it('should keep both components locked to the versions stored in their graphs', () => {
+      expect(lockfileAfterRestore.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+      expect(lockfileAfterRestore.packages).to.have.property('@pnpm.e2e/bar@100.0.0');
+      expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
+      expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');
+    });
+  });
 });

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -422,10 +422,6 @@ export default new ${className}();
       expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');
     });
   });
-  // --restore is an explicit opt-in, so it has to bypass the DEPS_GRAPH feature toggle
-  // and work on workspaces that never enabled the flag. The graph itself was authored on
-  // a scope that had the flag on at tag time, but the consumer shouldn't need to flip
-  // the flag just to restore from it.
   describe('bit install --restore works when the DEPS_GRAPH feature toggle is disabled', function () {
     let randomStr: string;
     let lockfileAfterRestore: any;
@@ -436,7 +432,7 @@ export default new ${className}();
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      npmCiRegistry.setRegistry();
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -456,11 +452,9 @@ export default new ${className}();
 
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
 
-      // Turn the DEPS_GRAPH feature toggle off for the remainder of the test. The outer
-      // describe's after() hook will restore it via resetFeatures, but we also restore it
-      // here so subsequent describes in this suite aren't affected.
       helper.command.resetFeatures();
       try {
         helper.command.import(`${helper.scopes.remote}/comp1@latest`);
@@ -475,7 +469,6 @@ export default new ${className}();
     });
     after(() => {
       npmCiRegistry.destroy();
-      helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
     it('should still restore the lockfile from the stored graph', () => {

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -422,4 +422,66 @@ export default new ${className}();
       expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/bar@100.1.0');
     });
   });
+  // --restore is an explicit opt-in, so it has to bypass the DEPS_GRAPH feature toggle
+  // and work on workspaces that never enabled the flag. The graph itself was authored on
+  // a scope that had the flag on at tag time, but the consumer shouldn't need to flip
+  // the flag just to restore from it.
+  describe('bit install --restore works when the DEPS_GRAPH feature toggle is disabled', function () {
+    let randomStr: string;
+    let lockfileAfterRestore: any;
+    before(async () => {
+      randomStr = generateRandomStr(4);
+      const name = `@ci/${randomStr}.{name}`;
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
+      await npmCiRegistry.init();
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        { policy: { peers: [] } },
+        false,
+        'custom-env/env',
+        'custom-env/env'
+      );
+      helper.fs.createFile('comp1', 'comp1.js', 'require("@pnpm.e2e/foo"); // eslint-disable-line');
+      helper.command.addComponent('comp1');
+      helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env`, {});
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' });
+      helper.command.install('--add-missing-deps');
+      helper.command.tagAllComponents('--skip-tests');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+
+      // Turn the DEPS_GRAPH feature toggle off for the remainder of the test. The outer
+      // describe's after() hook will restore it via resetFeatures, but we also restore it
+      // here so subsequent describes in this suite aren't affected.
+      helper.command.resetFeatures();
+      try {
+        helper.command.import(`${helper.scopes.remote}/comp1@latest`);
+        await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' });
+        helper.fs.deletePath('pnpm-lock.yaml');
+        helper.fs.deletePath('node_modules');
+        helper.command.runCmd('bit install --restore');
+        lockfileAfterRestore = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
+      } finally {
+        helper.command.setFeatures(DEPS_GRAPH);
+      }
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.command.delConfig('registry');
+      helper.scopeHelper.destroy();
+    });
+    it('should still restore the lockfile from the stored graph', () => {
+      expect(lockfileAfterRestore.bit.restoredFromModel).to.eq(true);
+      expect(lockfileAfterRestore.packages).to.have.property('@pnpm.e2e/foo@100.0.0');
+      expect(lockfileAfterRestore.packages).to.not.have.property('@pnpm.e2e/foo@100.1.0');
+    });
+  });
 });

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -181,6 +181,8 @@ export type PackageManagerInstallOptions = {
 
   dependenciesGraph?: DependenciesGraph;
 
+  failOnDependenciesGraphError?: boolean;
+
   forcedHarmonyVersion?: string;
 
   /**
@@ -228,6 +230,8 @@ export interface PackageManager {
    * Name of the package manager
    */
   name: string;
+
+  readonly supportsDependencyGraphRestoration?: boolean;
   /**
    * install dependencies
    * @param componentDirectoryMap

--- a/scopes/dependencies/pnpm/pnpm.package-manager.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.spec.ts
@@ -24,10 +24,46 @@ describe('PnpmPackageManager.getNetworkConfig', () => {
   });
 });
 
+describe('PnpmPackageManager.install', () => {
+  it('rethrows dependency graph conversion errors when strict restoration is requested', async () => {
+    const packageManager = createPackageManager({});
+    const restoreError = new Error('failed to restore lockfile');
+    packageManager.dependenciesGraphToLockfile = async () => {
+      throw restoreError;
+    };
+
+    let thrown: unknown;
+    try {
+      await packageManager.install(
+        {
+          rootDir: '/tmp/workspace',
+          manifests: {},
+          componentDirectoryMap: {} as any,
+        },
+        {
+          dependenciesGraph: {} as any,
+          rootComponents: true,
+          failOnDependenciesGraphError: true,
+        }
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(restoreError);
+  });
+});
+
 function createPackageManager(config: Partial<ResolvedConfig>) {
   const packageManager = new PnpmPackageManager(
-    {} as any,
-    {} as any,
+    {
+      getRegistries: async () => undefined,
+      getProxyConfig: async () => undefined,
+      getNetworkConfig: async () => undefined,
+    } as any,
+    {
+      error: () => {},
+    } as any,
     {
       getCurrentUser: async () => ({ username: 'test-user' }),
     } as any

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -12,7 +12,6 @@ import type {
   CalcDepsGraphOptions,
 } from '@teambit/dependency-resolver';
 import { Registries, Registry } from '@teambit/pkg.entities.registry';
-import { DEPS_GRAPH, isFeatureEnabled } from '@teambit/harmony.modules.feature-toggle';
 import type { Logger } from '@teambit/logger';
 import { type LockfileFile } from '@pnpm/lockfile.types';
 import fs from 'fs';
@@ -131,9 +130,12 @@ export class PnpmPackageManager implements PackageManager {
     const proxyConfig = await this.depResolver.getProxyConfig();
     const networkConfig = await this.depResolver.getNetworkConfig();
     const { config } = await this.readConfig(installOptions.packageManagerConfigRootDir);
+    // When dependenciesGraph is explicitly supplied (by the component writer on import, or
+    // by `bit install --restore`), honor it regardless of the DEPS_GRAPH feature toggle —
+    // the flag gates the *providers* that fetch graphs, so the presence of one here means
+    // the caller already decided this install should be seeded from stored graphs.
     if (
       installOptions.dependenciesGraph &&
-      isFeatureEnabled(DEPS_GRAPH) &&
       (installOptions.rootComponents || installOptions.rootComponentsForCapsules)
     ) {
       try {

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -12,7 +12,6 @@ import type {
   CalcDepsGraphOptions,
 } from '@teambit/dependency-resolver';
 import { Registries, Registry } from '@teambit/pkg.entities.registry';
-import { DEPS_GRAPH, isFeatureEnabled } from '@teambit/harmony.modules.feature-toggle';
 import type { Logger } from '@teambit/logger';
 import { type LockfileFile } from '@pnpm/lockfile.types';
 import { memoize, omit } from 'lodash';
@@ -151,9 +150,12 @@ export class PnpmPackageManager implements PackageManager {
     const proxyConfig = await this.depResolver.getProxyConfig();
     const networkConfig = await this.depResolver.getNetworkConfig();
     const { config } = await this.readConfig(installOptions.packageManagerConfigRootDir);
+    // When dependenciesGraph is explicitly supplied (by the component writer on import, or
+    // by `bit install --restore`), honor it regardless of the DEPS_GRAPH feature toggle —
+    // the flag gates the *providers* that fetch graphs, so the presence of one here means
+    // the caller already decided this install should be seeded from stored graphs.
     if (
       installOptions.dependenciesGraph &&
-      isFeatureEnabled(DEPS_GRAPH) &&
       (installOptions.rootComponents || installOptions.rootComponentsForCapsules)
     ) {
       try {

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -150,10 +150,6 @@ export class PnpmPackageManager implements PackageManager {
     const proxyConfig = await this.depResolver.getProxyConfig();
     const networkConfig = await this.depResolver.getNetworkConfig();
     const { config } = await this.readConfig(installOptions.packageManagerConfigRootDir);
-    // When dependenciesGraph is explicitly supplied (by the component writer on import, or
-    // by `bit install --restore`), honor it regardless of the DEPS_GRAPH feature toggle —
-    // the flag gates the *providers* that fetch graphs, so the presence of one here means
-    // the caller already decided this install should be seeded from stored graphs.
     if (
       installOptions.dependenciesGraph &&
       (installOptions.rootComponents || installOptions.rootComponentsForCapsules)

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -69,6 +69,7 @@ function loadNodeApi(): typeof NodeApi {
 
 export class PnpmPackageManager implements PackageManager {
   readonly name = 'pnpm';
+  readonly supportsDependencyGraphRestoration = true;
   readonly modulesManifestCache: Map<string, ModulesManifest> = new Map();
   private username: string;
 
@@ -164,8 +165,8 @@ export class PnpmPackageManager implements PackageManager {
           cacheDir: config.cacheDir,
         });
       } catch (error) {
-        // If the lockfile could not be created for some reason, it will be created later during installation.
         this.logger.error((error as Error).message);
+        if (installOptions.failOnDependenciesGraphError) throw error;
       }
     }
 

--- a/scopes/dependencies/yarn/yarn.package-manager.ts
+++ b/scopes/dependencies/yarn/yarn.package-manager.ts
@@ -44,6 +44,7 @@ import { createRootComponentsDir } from './create-root-components-dir';
 
 export class YarnPackageManager implements PackageManager {
   readonly name = 'yarn';
+  readonly supportsDependencyGraphRestoration = false;
 
   constructor(
     private depResolver: DependencyResolverMain,

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -2418,6 +2418,11 @@
       ],
       [
         "",
+        "restore",
+        "reconstruct the lockfile from each workspace component's stored dependency graph before installing"
+      ],
+      [
+        "",
         "allow-scripts [pkgNames]",
         "a comma separated list of package names that are allowed to run installation scripts"
       ],

--- a/scopes/harmony/cli-reference/cli-reference.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.mdx
@@ -1289,6 +1289,7 @@ automatically imports components, compiles components, links to node_modules, an
 | `--recurring-install`           |                  | automatically run install again if there are non loaded old envs in your workspace                     |
 | `--no-optional [noOptional]`    |                  | do not install optional dependencies (works with pnpm only)                                            |
 | `--lockfile-only`               |                  | dependencies are not written to node_modules. Only the lockfile is updated                             |
+| `--restore`                     |                  | reconstruct the lockfile from each workspace component's stored dependency graph before installing     |
 | `--allow-scripts [pkgNames]`    |                  | a comma separated list of package names that are allowed to run installation scripts                   |
 | `--disallow-scripts [pkgNames]` |                  | a comma separated list of package names that are NOT allowed to run installation scripts               |
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1487,8 +1487,11 @@ export class ScopeMain implements ComponentFactory {
     return scope;
   }
 
-  public getDependenciesGraphByComponentIds(componentIds: ComponentID[]): Promise<DependenciesGraph | undefined> {
-    return this.legacyScope.getDependenciesGraphByComponentIds(componentIds);
+  public getDependenciesGraphByComponentIds(
+    componentIds: ComponentID[],
+    options?: { ignoreFeatureToggle?: boolean }
+  ): Promise<DependenciesGraph | undefined> {
+    return this.legacyScope.getDependenciesGraphByComponentIds(componentIds, options);
   }
 }
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1530,8 +1530,11 @@ export class ScopeMain implements ComponentFactory {
     return scope;
   }
 
-  public getDependenciesGraphByComponentIds(componentIds: ComponentID[]): Promise<DependenciesGraph | undefined> {
-    return this.legacyScope.getDependenciesGraphByComponentIds(componentIds);
+  public getDependenciesGraphByComponentIds(
+    componentIds: ComponentID[],
+    options?: { ignoreFeatureToggle?: boolean }
+  ): Promise<DependenciesGraph | undefined> {
+    return this.legacyScope.getDependenciesGraphByComponentIds(componentIds, options);
   }
 }
 

--- a/scopes/workspace/install/exceptions/index.ts
+++ b/scopes/workspace/install/exceptions/index.ts
@@ -1,3 +1,4 @@
 export { DependencyTypeNotSupportedInPolicy } from './dependency-type-not-supported-in-policy';
 export { UnpublishedComponentDependency } from './unpublished-component-dependency';
 export type { UnpublishedSnapDependency } from './unpublished-component-dependency';
+export { RestoreNotSupportedByPackageManager } from './restore-not-supported-by-package-manager';

--- a/scopes/workspace/install/exceptions/restore-not-supported-by-package-manager.ts
+++ b/scopes/workspace/install/exceptions/restore-not-supported-by-package-manager.ts
@@ -1,0 +1,7 @@
+import { BitError } from '@teambit/bit-error';
+
+export class RestoreNotSupportedByPackageManager extends BitError {
+  constructor(packageManagerName: string) {
+    super(`the --restore option is not supported by package manager "${packageManagerName}"`);
+  }
+}

--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -22,6 +22,7 @@ type InstallCmdOptions = {
   noOptional: boolean;
   recurringInstall: boolean;
   lockfileOnly: boolean;
+  restore: boolean;
   allowScripts?: string;
   disallowScripts?: string;
 };
@@ -69,6 +70,11 @@ automatically imports components, compiles components, links to node_modules, an
     ],
     ['', 'no-optional [noOptional]', 'do not install optional dependencies (works with pnpm only)'],
     ['', 'lockfile-only', 'dependencies are not written to node_modules. Only the lockfile is updated'],
+    [
+      '',
+      'restore',
+      'reconstruct the lockfile from each workspace component\'s stored dependency graph before installing',
+    ],
     ['', 'allow-scripts [pkgNames]', 'a comma separated list of package names that are allowed to run installation scripts'],
     ['', 'disallow-scripts [pkgNames]', 'a comma separated list of package names that are NOT allowed to run installation scripts'],
   ] as CommandOptions;
@@ -134,6 +140,7 @@ automatically imports components, compiles components, links to node_modules, an
       updateAll: options.update,
       recurringInstall: options.recurringInstall,
       lockfileOnly: options.lockfileOnly,
+      restoreFromDependenciesGraph: options.restore,
       showExternalPackageManagerPrompt: true,
       allowScripts: this._parseAllowScriptsFlags(options.allowScripts, options.disallowScripts),
     };

--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -73,7 +73,7 @@ automatically imports components, compiles components, links to node_modules, an
     [
       '',
       'restore',
-      'reconstruct the lockfile from each workspace component\'s stored dependency graph before installing',
+      "reconstruct the lockfile from each workspace component's stored dependency graph before installing",
     ],
     [
       '',

--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -22,6 +22,7 @@ type InstallCmdOptions = {
   noOptional: boolean;
   recurringInstall: boolean;
   lockfileOnly: boolean;
+  restore: boolean;
   allowScripts?: string;
   disallowScripts?: string;
 };
@@ -69,6 +70,11 @@ automatically imports components, compiles components, links to node_modules, an
     ],
     ['', 'no-optional [noOptional]', 'do not install optional dependencies (works with pnpm only)'],
     ['', 'lockfile-only', 'dependencies are not written to node_modules. Only the lockfile is updated'],
+    [
+      '',
+      'restore',
+      'reconstruct the lockfile from each workspace component\'s stored dependency graph before installing',
+    ],
     [
       '',
       'allow-scripts [pkgNames]',
@@ -142,6 +148,7 @@ automatically imports components, compiles components, links to node_modules, an
       updateAll: options.update,
       recurringInstall: options.recurringInstall,
       lockfileOnly: options.lockfileOnly,
+      restoreFromDependenciesGraph: options.restore,
       showExternalPackageManagerPrompt: true,
       allowScripts: this._parseAllowScriptsFlags(options.allowScripts, options.disallowScripts),
     };

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -108,6 +108,13 @@ export type WorkspaceInstallOptions = {
   writeConfigFiles?: boolean;
   skipPrune?: boolean;
   dependenciesGraph?: DependenciesGraph;
+  /**
+   * When true, attempt to reconstruct the lockfile from each workspace component's
+   * stored dependency graph before running the package manager. Graphs are fetched for
+   * every component listed in the bitmap, merged, and handed to the package manager the
+   * same way `bit import` does for the components it writes.
+   */
+  restoreFromDependenciesGraph?: boolean;
   allowScripts?: Record<string, boolean>;
 };
 
@@ -392,11 +399,12 @@ export class InstallMain {
       }
     );
 
+    const dependenciesGraph = await this.resolveDependenciesGraph(options);
     const pmInstallOptions: PackageManagerInstallOptions = {
       ...calcManifestsOpts,
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
       dedupePeers: this.dependencyResolver.config.dedupePeers,
-      dependenciesGraph: options?.dependenciesGraph,
+      dependenciesGraph,
       includeOptionalDeps: options?.includeOptionalDeps,
       neverBuiltDependencies: this.dependencyResolver.config.neverBuiltDependencies,
       allowScripts: this.dependencyResolver.getAllowedScripts(),
@@ -514,6 +522,22 @@ export class InstallMain {
   private shouldClearCacheOnInstall(): boolean {
     const nonLoadedEnvs = this.envs.getFailedToLoadEnvs();
     return nonLoadedEnvs.length > 0;
+  }
+
+  private async resolveDependenciesGraph(
+    options?: ModulesInstallOptions
+  ): Promise<DependenciesGraph | undefined> {
+    if (options?.dependenciesGraph) return options.dependenciesGraph;
+    if (!options?.restoreFromDependenciesGraph) return undefined;
+    const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds());
+    if (!graph) {
+      this.logger.console(
+        chalk.yellow(
+          '--restore was requested but no workspace component has a stored dependency graph. Falling back to a regular install.'
+        )
+      );
+    }
+    return graph;
   }
 
   /**

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -399,7 +399,7 @@ export class InstallMain {
       }
     );
 
-    const dependenciesGraph = await this.resolveDependenciesGraph(options);
+    const dependenciesGraph = await this.resolveDependenciesGraph(options, { hasRootComponents });
     const pmInstallOptions: PackageManagerInstallOptions = {
       ...calcManifestsOpts,
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
@@ -525,10 +525,23 @@ export class InstallMain {
   }
 
   private async resolveDependenciesGraph(
-    options?: ModulesInstallOptions
+    options: ModulesInstallOptions | undefined,
+    context: { hasRootComponents: boolean }
   ): Promise<DependenciesGraph | undefined> {
     if (options?.dependenciesGraph) return options.dependenciesGraph;
     if (!options?.restoreFromDependenciesGraph) return undefined;
+    // The package manager only seeds the lockfile from a supplied graph when the workspace
+    // has `rootComponents` enabled (see PnpmPackageManager.install). Without that, --restore
+    // would silently no-op and re-resolve everything from manifest specifiers, so we bail
+    // out explicitly instead of letting the user think the graph was applied.
+    if (!context.hasRootComponents) {
+      this.logger.console(
+        chalk.yellow(
+          '--restore requires "rootComponents: true" in the dependency-resolver config; falling back to a regular install.'
+        )
+      );
+      return undefined;
+    }
     // --restore is an explicit opt-in, so bypass the DEPS_GRAPH feature toggle that would
     // otherwise make this return undefined on workspaces that haven't enabled the flag.
     const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds(), {

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -529,7 +529,11 @@ export class InstallMain {
   ): Promise<DependenciesGraph | undefined> {
     if (options?.dependenciesGraph) return options.dependenciesGraph;
     if (!options?.restoreFromDependenciesGraph) return undefined;
-    const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds());
+    // --restore is an explicit opt-in, so bypass the DEPS_GRAPH feature toggle that would
+    // otherwise make this return undefined on workspaces that haven't enabled the flag.
+    const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds(), {
+      ignoreFeatureToggle: true,
+    });
     if (!graph) {
       this.logger.console(
         chalk.yellow(

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -110,6 +110,7 @@ export type WorkspaceInstallOptions = {
   writeConfigFiles?: boolean;
   skipPrune?: boolean;
   dependenciesGraph?: DependenciesGraph;
+  restoreFromDependenciesGraph?: boolean;
   allowScripts?: Record<string, boolean>;
 };
 
@@ -394,11 +395,12 @@ export class InstallMain {
       }
     );
 
+    const dependenciesGraph = await this.resolveDependenciesGraph(options);
     const pmInstallOptions: PackageManagerInstallOptions = {
       ...calcManifestsOpts,
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
       dedupePeers: this.dependencyResolver.config.dedupePeers,
-      dependenciesGraph: options?.dependenciesGraph,
+      dependenciesGraph,
       includeOptionalDeps: options?.includeOptionalDeps,
       neverBuiltDependencies: this.dependencyResolver.config.neverBuiltDependencies,
       allowScripts: this.dependencyResolver.getAllowedScripts(),
@@ -537,6 +539,22 @@ export class InstallMain {
   private shouldClearCacheOnInstall(): boolean {
     const nonLoadedEnvs = this.envs.getFailedToLoadEnvs();
     return nonLoadedEnvs.length > 0;
+  }
+
+  private async resolveDependenciesGraph(
+    options?: ModulesInstallOptions
+  ): Promise<DependenciesGraph | undefined> {
+    if (options?.dependenciesGraph) return options.dependenciesGraph;
+    if (!options?.restoreFromDependenciesGraph) return undefined;
+    const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds());
+    if (!graph) {
+      this.logger.console(
+        chalk.yellow(
+          '--restore was requested but no workspace component has a stored dependency graph. Falling back to a regular install.'
+        )
+      );
+    }
+    return graph;
   }
 
   /**

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -52,7 +52,11 @@ import type {
   WorkspacePolicy,
   UpdatedComponent,
 } from '@teambit/dependency-resolver';
-import { DependencyResolverAspect, ComponentDependency, ensureHoistedDependencyResolution } from '@teambit/dependency-resolver';
+import {
+  DependencyResolverAspect,
+  ComponentDependency,
+  ensureHoistedDependencyResolution,
+} from '@teambit/dependency-resolver';
 import type { WorkspaceConfigFilesMain } from '@teambit/workspace-config-files';
 import { WorkspaceConfigFilesAspect } from '@teambit/workspace-config-files';
 import type { Logger, LoggerMain } from '@teambit/logger';
@@ -395,7 +399,7 @@ export class InstallMain {
       }
     );
 
-    const dependenciesGraph = await this.resolveDependenciesGraph(options);
+    const dependenciesGraph = await this.resolveDependenciesGraph(options, { hasRootComponents });
     const pmInstallOptions: PackageManagerInstallOptions = {
       ...calcManifestsOpts,
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
@@ -542,12 +546,19 @@ export class InstallMain {
   }
 
   private async resolveDependenciesGraph(
-    options?: ModulesInstallOptions
+    options: ModulesInstallOptions | undefined,
+    context: { hasRootComponents: boolean }
   ): Promise<DependenciesGraph | undefined> {
     if (options?.dependenciesGraph) return options.dependenciesGraph;
     if (!options?.restoreFromDependenciesGraph) return undefined;
-    // --restore is an explicit opt-in, so bypass the DEPS_GRAPH feature toggle that would
-    // otherwise make this return undefined on workspaces that haven't enabled the flag.
+    if (!context.hasRootComponents) {
+      this.logger.console(
+        chalk.yellow(
+          '--restore requires "rootComponents: true" in the dependency-resolver config; falling back to a regular install.'
+        )
+      );
+      return undefined;
+    }
     const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds(), {
       ignoreFeatureToggle: true,
     });

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -5,7 +5,7 @@ import { getRootComponentDir, linkPkgsToRootComponents } from '@teambit/workspac
 import type { CompilerMain } from '@teambit/compiler';
 import { CompilerAspect, CompilationInitiator } from '@teambit/compiler';
 import type { CLIMain, CommandList } from '@teambit/cli';
-import { CLIAspect, MainRuntime } from '@teambit/cli';
+import { CLIAspect, MainRuntime, formatWarningSummary } from '@teambit/cli';
 import chalk from 'chalk';
 import yesno from 'yesno';
 import type { Workspace } from '@teambit/workspace';
@@ -43,6 +43,7 @@ import type {
   WorkspaceDependencyLifecycleType,
   DependencyResolverMain,
   DependencyInstaller,
+  PackageManager,
   PackageManagerInstallOptions,
   WorkspacePolicyEntry,
   LinkingOptions,
@@ -72,7 +73,11 @@ import { BundlerAspect } from '@teambit/bundler';
 import type { UiMain } from '@teambit/ui';
 import { UIAspect } from '@teambit/ui';
 import { EXTERNAL_PM_POSTINSTALL_SCRIPT } from '@teambit/host-initializer';
-import { DependencyTypeNotSupportedInPolicy, UnpublishedComponentDependency } from './exceptions';
+import {
+  DependencyTypeNotSupportedInPolicy,
+  RestoreNotSupportedByPackageManager,
+  UnpublishedComponentDependency,
+} from './exceptions';
 import type { UnpublishedSnapDependency } from './exceptions';
 import { InstallAspect } from './install.aspect';
 import { pickOutdatedPkgs } from './pick-outdated-pkgs';
@@ -362,6 +367,7 @@ export class InstallMain {
       await this.dependencyResolver.persistConfig('update allowScripts configuration');
     }
     const pm = this.dependencyResolver.getPackageManager();
+    this.ensurePackageManagerSupportsRestore(options, pm);
     this.logger.console(
       `installing dependencies in workspace using ${pm?.name} (${chalk.cyan(
         this.dependencyResolver.packageManagerName
@@ -405,6 +411,7 @@ export class InstallMain {
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
       dedupePeers: this.dependencyResolver.config.dedupePeers,
       dependenciesGraph,
+      failOnDependenciesGraphError: options?.restoreFromDependenciesGraph,
       includeOptionalDeps: options?.includeOptionalDeps,
       neverBuiltDependencies: this.dependencyResolver.config.neverBuiltDependencies,
       allowScripts: this.dependencyResolver.getAllowedScripts(),
@@ -545,6 +552,15 @@ export class InstallMain {
     return nonLoadedEnvs.length > 0;
   }
 
+  private ensurePackageManagerSupportsRestore(
+    options: ModulesInstallOptions | undefined,
+    packageManager: PackageManager | undefined
+  ) {
+    if (options?.restoreFromDependenciesGraph && !packageManager?.supportsDependencyGraphRestoration) {
+      throw new RestoreNotSupportedByPackageManager(packageManager?.name ?? this.dependencyResolver.packageManagerName);
+    }
+  }
+
   private async resolveDependenciesGraph(
     options: ModulesInstallOptions | undefined,
     context: { hasRootComponents: boolean }
@@ -553,7 +569,7 @@ export class InstallMain {
     if (!options?.restoreFromDependenciesGraph) return undefined;
     if (!context.hasRootComponents) {
       this.logger.console(
-        chalk.yellow(
+        formatWarningSummary(
           '--restore requires "rootComponents: true" in the dependency-resolver config; falling back to a regular install.'
         )
       );
@@ -564,7 +580,7 @@ export class InstallMain {
     });
     if (!graph) {
       this.logger.console(
-        chalk.yellow(
+        formatWarningSummary(
           '--restore was requested but no workspace component has a stored dependency graph. Falling back to a regular install.'
         )
       );

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -546,7 +546,11 @@ export class InstallMain {
   ): Promise<DependenciesGraph | undefined> {
     if (options?.dependenciesGraph) return options.dependenciesGraph;
     if (!options?.restoreFromDependenciesGraph) return undefined;
-    const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds());
+    // --restore is an explicit opt-in, so bypass the DEPS_GRAPH feature toggle that would
+    // otherwise make this return undefined on workspaces that haven't enabled the flag.
+    const graph = await this.workspace.scope.getDependenciesGraphByComponentIds(this.workspace.listIds(), {
+      ignoreFeatureToggle: true,
+    });
     if (!graph) {
       this.logger.console(
         chalk.yellow(


### PR DESCRIPTION
## Summary

`bit install` does not normally use the per-component dependency graphs stored on each `Version` object. If a user deletes `pnpm-lock.yaml` and runs `bit install`, pnpm re-resolves every dep from manifest specifiers and drifts to whatever the registry now considers latest — losing the tag-time version pins the graph feature is supposed to guarantee.

`--restore` opts into the same code path `bit import` uses: fetch the dep graph for every component in the bitmap, merge them, and hand the merged graph to the package manager, which seeds `pnpm-lock.yaml` from it. If no workspace component has a stored graph, we fall back to a regular install with a warning.

`--restore` is an explicit user opt-in, so it bypasses the `DEPS_GRAPH` feature toggle. The flag's purpose is to gate the providers that *fetch and attach* graphs (tag-time generation; import-time auto-restore). Once a graph is explicitly supplied to the package manager, there's no reason to also gate the consumer.

## Changes

### `scopes/workspace/install/install.cmd.tsx`
New `--restore` flag, threaded through to `WorkspaceInstallOptions.restoreFromDependenciesGraph`.

### `scopes/workspace/install/install.main.runtime.ts`
- `WorkspaceInstallOptions` gets `restoreFromDependenciesGraph`.
- New `resolveDependenciesGraph` helper centralizes the choice between an explicit `options.dependenciesGraph`, the restore path (`workspace.scope.getDependenciesGraphByComponentIds(workspace.listIds(), { ignoreFeatureToggle: true })`), and no graph. Extracted as a method because inlining pushed `_installModules` over the complexity limit.

### `scopes/scope/scope/scope.main.runtime.ts` and `components/legacy/scope/scope.ts`
`getDependenciesGraphByComponentIds` takes an optional `{ ignoreFeatureToggle }` flag that skips the `DEPS_GRAPH` short-circuit. Used only from the `--restore` path today.

### `scopes/dependencies/pnpm/pnpm.package-manager.ts`
Removed the `isFeatureEnabled(DEPS_GRAPH)` check from the graph-to-lockfile branch. If `installOptions.dependenciesGraph` is set, the caller already decided to seed from it.

### `e2e/harmony/deps-graph.e2e.ts`
Two e2e scenarios:
1. `--restore` with the feature flag on: delete lockfile + node_modules after an import, bump the registry, run `bit install --restore`, and assert both components stay locked to their graph versions.
2. `--restore` with the feature flag **off**: tag with the flag on so the graphs are stored, then reset features before import + `--restore`, and assert the lockfile is still restored from the stored graph.

## Test plan
- [x] `npm run lint` clean.
- [x] Both new e2e scenarios pass locally against `bd` (dev-linked bit).
- [ ] CI green.