### PR TITLE
feat(scope-rename): auto-install dependencies after rename

### DIFF
--- a/scopes/component/renaming/rename.cmd.ts
+++ b/scopes/component/renaming/rename.cmd.ts
@@ -10,6 +10,7 @@ export type RenameOptions = {
   preserve?: boolean;
   ast?: boolean;
   deprecate?: boolean;
+  skipCompile?: boolean;
 };
 
 export class RenameCmd implements Command {

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -207,7 +207,12 @@ make sure this argument is the name only, without the scope-name. to change the 
   async renameScope(
     oldScope: string,
     newScope: string,
-    options: { refactor?: boolean; deprecate?: boolean; preserve?: boolean } = {}
+    options: {
+      refactor?: boolean;
+      deprecate?: boolean;
+      preserve?: boolean;
+      skipDependencyInstallation?: boolean;
+    } = {}
   ): Promise<RenameResult> {
     if (!this.workspace) throw new OutsideWorkspaceError();
     const allComponentsIds = this.workspace.listIds();
@@ -222,7 +227,11 @@ make sure this argument is the name only, without the scope-name. to change the 
       const targetId = ComponentID.fromObject({ name: compId.fullName }, newScope);
       return { sourceId: compId, targetId };
     });
-    return this.renameMultiple(multipleIds, options);
+    const result = await this.renameMultiple(multipleIds, options);
+    if (!options.skipDependencyInstallation) {
+      await this.installDeps();
+    }
+    return result;
   }
 
   /**
@@ -285,6 +294,16 @@ make sure this argument is the name only, without the scope-name. to change the 
   private async deleteLinkFromNodeModules(packageName: string) {
     await fs.remove(path.join(this.workspace.path, 'node_modules', packageName));
   }
+  private async installDeps() {
+    await this.install.install(undefined, {
+      dedupe: true,
+      import: false,
+      copyPeerToRuntimeOnRoot: true,
+      copyPeerToRuntimeOnComponents: false,
+      updateExisting: false,
+    });
+  }
+
   private async compileGracefully(ids: ComponentID[]) {
     try {
       await this.compiler.compileOnWorkspace(ids);

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -186,7 +186,9 @@ make sure this argument is the name only, without the scope-name. to change the 
 
     const targetComps = compact(renameData.map(({ targetComp }) => targetComp));
     await linkToNodeModulesByComponents(targetComps, this.workspace); // link the new-name to node-modules
-    await this.compileGracefully(targetComps.map((c) => c.id));
+    if (!options.skipCompile) {
+      await this.compileGracefully(targetComps.map((c) => c.id));
+    }
 
     return { refactoredIds, renameData };
   }
@@ -227,9 +229,14 @@ make sure this argument is the name only, without the scope-name. to change the 
       const targetId = ComponentID.fromObject({ name: compId.fullName }, newScope);
       return { sourceId: compId, targetId };
     });
-    const result = await this.renameMultiple(multipleIds, options);
-    if (!options.skipDependencyInstallation) {
-      await this.installDeps();
+    // defer compilation until after install, so newly-required deps are available.
+    const result = await this.renameMultiple(multipleIds, { ...options, skipCompile: true });
+    const targetIds = result.renameData.map(({ targetId }) => targetId);
+    if (!options.skipDependencyInstallation && targetIds.length) {
+      await this.installDepsGracefully();
+    }
+    if (targetIds.length) {
+      await this.compileGracefully(targetIds);
     }
     return result;
   }
@@ -294,14 +301,18 @@ make sure this argument is the name only, without the scope-name. to change the 
   private async deleteLinkFromNodeModules(packageName: string) {
     await fs.remove(path.join(this.workspace.path, 'node_modules', packageName));
   }
-  private async installDeps() {
-    await this.install.install(undefined, {
-      dedupe: true,
-      import: false,
-      copyPeerToRuntimeOnRoot: true,
-      copyPeerToRuntimeOnComponents: false,
-      updateExisting: false,
-    });
+  private async installDepsGracefully() {
+    try {
+      await this.install.install(undefined, {
+        dedupe: true,
+        import: false,
+        copyPeerToRuntimeOnRoot: true,
+        copyPeerToRuntimeOnComponents: false,
+        updateExisting: false,
+      });
+    } catch (err: any) {
+      this.logger.consoleFailure(`failed installing dependencies. error: ${err.message}. run "bit install" to retry.`);
+    }
   }
 
   private async compileGracefully(ids: ComponentID[]) {

--- a/scopes/component/renaming/renaming.spec.ts
+++ b/scopes/component/renaming/renaming.spec.ts
@@ -27,7 +27,9 @@ describe('Renaming Aspect', function () {
       workspace = harmony.get<Workspace>(WorkspaceAspect.id);
 
       await renaming.rename('comp1', 'ui/comp1');
-      await renaming.renameScope(workspaceData.remoteScopeName, 'another-scope-name');
+      await renaming.renameScope(workspaceData.remoteScopeName, 'another-scope-name', {
+        skipDependencyInstallation: true,
+      });
     });
     after(async () => {
       await destroyWorkspace(workspaceData);

--- a/scopes/component/renaming/scope-rename.cmd.ts
+++ b/scopes/component/renaming/scope-rename.cmd.ts
@@ -21,6 +21,7 @@ as a result of this change`;
       'update the import statements in all dependent components to the new package name (i.e. with the new scope name)',
     ],
     ['', 'deprecate', 'for exported components, instead of deleting the original components, deprecating them'],
+    ['x', 'skip-dependency-installation', 'do not install dependencies after the rename'],
   ] as CommandOptions;
   group = 'component-config';
 
@@ -28,9 +29,19 @@ as a result of this change`;
 
   async report(
     [oldName, newName]: [string, string],
-    { refactor, deprecate, preserve }: { refactor?: boolean; deprecate?: boolean; preserve?: boolean }
+    {
+      refactor,
+      deprecate,
+      preserve,
+      skipDependencyInstallation,
+    }: { refactor?: boolean; deprecate?: boolean; preserve?: boolean; skipDependencyInstallation?: boolean }
   ) {
-    const result = await this.renaming.renameScope(oldName, newName, { refactor, deprecate, preserve });
+    const result = await this.renaming.renameScope(oldName, newName, {
+      refactor,
+      deprecate,
+      preserve,
+      skipDependencyInstallation,
+    });
     const renameOutput = renameScopeOutput(result);
     return joinSections([formatSuccessSummary(`replaced "${oldName}" scope with "${newName}"`), renameOutput]);
   }

--- a/scopes/component/renaming/scope-rename.cmd.ts
+++ b/scopes/component/renaming/scope-rename.cmd.ts
@@ -24,6 +24,7 @@ as a result of this change`;
     ['x', 'skip-dependency-installation', 'do not install dependencies after the rename'],
   ] as CommandOptions;
   group = 'component-config';
+  loader = true;
 
   constructor(private renaming: RenamingMain) {}
 


### PR DESCRIPTION
After `bit scope rename`, components may need new dependencies (e.g. an env declaring `@mdx-js/mdx`) that aren't yet installed, leading to `bit status` warning about missing packages until the user manually runs `bit install`.

Now `bit scope rename` runs install automatically after the rename completes. Added `-x, --skip-dependency-installation` to opt-out (useful for users who don't use Bit for package installation).