### PR TITLE
fix(deps-graph): drop orphan @file: entries from saved/loaded graphs

### DIFF
--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -320,6 +320,54 @@ describe('convertLockfileToGraph simple case', () => {
   });
 });
 
+describe('convertLockfileToGraph with directory packages missing from componentIdByPkgName', () => {
+  it('should not persist orphan @file: pkgIds in the produced graph', () => {
+    // Reproduces how the broken graphs end up in the model: a directory-type
+    // package in the lockfile whose name is absent from componentIdByPkgName.
+    // buildPackages strips the directory resolution but leaves the "@file:"
+    // pkgId untouched, which downstream cannot resolve. The graph creator
+    // must drop these so the model never stores entries that future
+    // installs can't generate a valid lockfile from.
+    const lockfile: BitLockfileFile = {
+      bit: { depsRequiringBuild: [] },
+      importers: {
+        '.': {},
+        'comps/comp1': {
+          dependencies: {
+            foo: { version: '1.0.0', specifier: '^1.0.0' },
+            'orphan-comp': { version: 'file:packages/orphan-comp', specifier: '*' },
+          },
+        },
+      },
+      lockfileVersion: '9.0',
+      snapshots: {
+        'foo@1.0.0': {},
+        'orphan-comp@file:packages/orphan-comp': {
+          dependencies: { foo: '1.0.0' },
+        },
+      },
+      packages: {
+        'foo@1.0.0': { resolution: { integrity: 'sha512-aaa' } },
+        'orphan-comp@file:packages/orphan-comp': {
+          resolution: { directory: 'packages/orphan-comp', type: 'directory' },
+        },
+      },
+    };
+    const graph = convertLockfileToGraph(lockfile, {
+      pkgName: undefined,
+      componentRelativeDir: 'comps/comp1',
+      componentRootDir: undefined,
+      // Intentionally empty: simulates the bug where the workspace map
+      // didn't include the directory dep.
+      componentIdByPkgName: new Map(),
+    });
+    expect([...graph.packages.keys()]).to.eql(['foo@1.0.0']);
+    const rootEdge = graph.findRootEdge();
+    expect(rootEdge?.neighbours.map((n) => n.id)).to.eql(['foo@1.0.0']);
+    expect(graph.edges.find(({ id }) => id.includes('@file:'))).to.equal(undefined);
+  });
+});
+
 describe('convertLockfileToGraph benchmark', () => {
   function generateLargeLockfile(
     numPackages: number,
@@ -487,6 +535,68 @@ describe('convertLockfileToGraph benchmark', () => {
 });
 
 describe('convertGraphToLockfile on invalid graph', () => {
+  // Reproduces the CI failure where a saved deps graph leaks "@file:" entries
+  // because buildPackages couldn't map them to a workspace component. The
+  // directory resolution was deleted and getPkgsToResolve can't recover an
+  // integrity for "file:" versions (dp.parse puts them in nonSemverVersion,
+  // not version), so validation throws "doesn't have a 'resolution' field".
+  // At install time the orphan can't be salvaged: if its name matches a
+  // workspace project pnpm wires it through importers/link entries (so the
+  // packages entry would be wrong), and otherwise we have no published
+  // version to recover. Dropping it is the only safe outcome.
+  it('should drop orphan @file: packages when generating a lockfile', async () => {
+    const packages: PackagesMap = new Map([
+      [
+        '@teambit/dot-launch.apps.whats-new-app@file:dot-launch/apps/whats-new-app',
+        {} as any,
+      ],
+      ['foo@1.0.0', { resolution: { integrity: 'sha512-aaa' } } as any],
+    ]);
+    const edges: DependencyEdge[] = [
+      {
+        id: DependenciesGraph.ROOT_EDGE_ID,
+        neighbours: [
+          { id: 'foo@1.0.0', name: 'foo', specifier: '1.0.0', lifecycle: 'runtime' },
+          {
+            id: '@teambit/dot-launch.apps.whats-new-app@file:dot-launch/apps/whats-new-app',
+            name: '@teambit/dot-launch.apps.whats-new-app',
+            specifier: '*',
+            lifecycle: 'runtime',
+          },
+        ],
+      },
+      {
+        id: 'foo@1.0.0',
+        neighbours: [
+          {
+            id: '@teambit/dot-launch.apps.whats-new-app@file:dot-launch/apps/whats-new-app',
+            optional: false,
+          },
+        ],
+      },
+      {
+        id: '@teambit/dot-launch.apps.whats-new-app@file:dot-launch/apps/whats-new-app',
+        neighbours: [],
+      },
+    ];
+    const graph = new DependenciesGraph({ packages, edges });
+    const lockfile = await convertGraphToLockfile(new DependenciesGraph(graph), {
+      manifests: {
+        [path.resolve('comps/comp1')]: {
+          dependencies: { foo: '1.0.0' },
+        },
+      },
+      rootDir: process.cwd(),
+      resolve: () => ({ resolution: { integrity: '0000' } }) as any,
+    });
+    expect(Object.keys(lockfile.packages!)).to.eql(['foo@1.0.0']);
+    expect(Object.keys(lockfile.snapshots!)).to.eql(['foo@1.0.0']);
+    // The dangling snapshot neighbour pointing at the orphan must also be
+    // filtered out so pnpm doesn't try to resolve a dep that no longer exists.
+    expect(lockfile.snapshots!['foo@1.0.0']).to.eql({});
+  });
+
+
   it('should throw an error if resolution is missing', async () => {
     const packages: PackagesMap = new Map([['foo@1.0.0', {} as any]]);
     const edges: DependencyEdge[] = [

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
@@ -101,10 +101,12 @@ function _convertLockfileToGraph(
     directDependencies: DependencyNeighbour[];
   }
 ): DependenciesGraph {
-  return new DependenciesGraph({
+  const graph = new DependenciesGraph({
     edges: buildEdges(lockfile, { directDependencies, componentIdByPkgName }),
     packages: buildPackages(lockfile, { componentIdByPkgName }),
   });
+  dropOrphanFilePkgs(graph);
+  return graph;
 }
 
 function buildEdges(
@@ -245,6 +247,7 @@ export async function convertGraphToLockfile(
 ): Promise<BitLockfileFile> {
   const graphString = _graph.serialize();
   const graph = DependenciesGraph.deserialize(graphString)!;
+  dropOrphanFilePkgs(graph);
   const packages = {};
   const snapshots = {};
   const allEdgeIds = new Set(graph.edges.map(({ id }) => id));
@@ -398,6 +401,56 @@ function getPkgsToResolve(lockfile: BitLockfileFile, manifests: Record<string, P
 
 function depPathToRef(depPath: dp.DependencyPath): string {
   return `${depPath.version}${depPath.patchHash ?? ''}${depPath.peerDepGraphHash ?? ''}`;
+}
+
+function isFilePkgId(pkgId: string): boolean {
+  return dp.parse(pkgId).nonSemverVersion?.startsWith('file:') ?? false;
+}
+
+/**
+ * Strip orphan "@file:" entries from the graph (mutates in place).
+ *
+ * The "@file:" pkgIds in pnpm's lockfile are workspace components linked as
+ * directory deps. buildPackages is supposed to rewrite them to
+ * "name@<semverVersion>" via componentIdByPkgName, but if a name is missing
+ * from that map (older bit, partial isolation, a component renamed/removed
+ * between install and tag) the orphan leaks through with its resolution
+ * stripped (directory type). We can't recover an integrity for it later —
+ * getPkgsToResolve won't try because dp.parse shoves "file:..." into
+ * nonSemverVersion, leaving parsed.version undefined, and at install time
+ * the component is either a workspace project pnpm wires through importers
+ * (so it doesn't belong in the packages map) or no longer in the workspace
+ * at all. Either way the orphan entry is unusable, so drop it both at graph
+ * creation (don't persist broken graphs) and at lockfile generation
+ * (recover graphs already saved in the model).
+ */
+function dropOrphanFilePkgs(graph: DependenciesGraph): void {
+  const orphanPkgIds = new Set<string>();
+  for (const pkgId of graph.packages.keys()) {
+    if (isFilePkgId(pkgId)) {
+      orphanPkgIds.add(pkgId);
+    }
+  }
+  for (const edge of graph.edges) {
+    const pkgId = edge.attr?.pkgId ?? edge.id;
+    if (isFilePkgId(pkgId) || isFilePkgId(edge.id)) {
+      orphanPkgIds.add(pkgId);
+      orphanPkgIds.add(edge.id);
+    }
+  }
+  if (orphanPkgIds.size === 0) return;
+  for (const id of orphanPkgIds) {
+    graph.packages.delete(id);
+  }
+  graph.edges = graph.edges
+    .filter((edge) => !orphanPkgIds.has(edge.id) && !orphanPkgIds.has(edge.attr?.pkgId ?? edge.id))
+    .map((edge) => {
+      if (!edge.neighbours.some((n) => orphanPkgIds.has(n.id))) return edge;
+      return {
+        ...edge,
+        neighbours: edge.neighbours.filter((n) => !orphanPkgIds.has(n.id)),
+      };
+    });
 }
 
 function convertGraphPackageToLockfilePackage(pkgAttr: PackageAttributes) {


### PR DESCRIPTION
## Summary
- A directory-type package whose name is missing from `componentIdByPkgName` slips through `buildPackages` with its resolution stripped but its `@file:` pkgId intact. At install time `dp.parse` puts `file:...` into `nonSemverVersion`, so `getPkgsToResolve` skips it and validation throws `Failed to generate a valid lockfile. The "packages['<pkg>@file:...'] entry doesn't have a "resolution" field.`
- Drop these orphans both at graph creation (`_convertLockfileToGraph`) and at lockfile generation (`convertGraphToLockfile`). Creation-side prevents the model from accumulating new broken entries; generation-side recovers existing broken graphs already saved in the model.
- Salvaging via rewrite was considered: if the orphan name matches a workspace project at install time, pnpm wires it through `importers`/`link` entries (so an entry in `packages` would be wrong); otherwise we have no published version to recover. Drop is the only safe outcome in both cases.

## Test plan
- [x] `bd test scopes/dependencies/pnpm` — 12 passed (added 2 regression tests covering creation-side drop and generation-side drop)
- [x] `npm run lint` — 0 warnings, 0 errors