### PR TITLE
fix(config-merger): handle comp range when ws has a higher exact version

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -641,6 +641,14 @@ describe('bit checkout command', function () {
       const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
       expect(policy.dependencies['lodash.get']).to.equal('4.4.1');
     });
+
+    // reproduces a bug where the comp has a range and the ws has an exact version higher than
+    // that range's min. e.g. comp: ^4.4.2, ws: 5.0.0. Previously threw "unhandled case".
+    it('if the ws has an exact version higher than the comp range, it should not throw', () => {
+      expect(() => initWsWithVer('5.0.0')).to.not.throw();
+      const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+      expect(policy.dependencies['lodash.get']).to.equal('5.0.0');
+    });
   });
   describe('checkout reset with changes in component.json', () => {
     before(() => {

--- a/scopes/workspace/config-merger/config-merger.main.runtime.ts
+++ b/scopes/workspace/config-merger/config-merger.main.runtime.ts
@@ -428,6 +428,7 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
           return;
         }
         addNotUpdateToLogs(`the min version from comp ${compMinVer} is less than ${depInWsVer} from ws`);
+        return;
       }
       throw new Error(`unhandled case: comp: ${depInCompVer}, ws: ${depInWsVer}`);
     });


### PR DESCRIPTION
When merging workspace deps during checkout/import, the branch handling \`comp range + ws exact version\` was missing a \`return\` after logging the no-update reason, causing it to fall through and throw \`unhandled case: comp: <range>, ws: <version>\` whenever the ws version was higher than the comp range's min (e.g. comp \`^12.7.1\`, ws \`14.1.5\`).

Added the missing \`return\` and an e2e test for this case.