### PR TITLE
feat(api-server): require bearer-token authentication on local HTTP server

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -2,7 +2,9 @@ import type { CLIMain } from '@teambit/cli';
 import { CLIAspect, MainRuntime } from '@teambit/cli';
 import { Port } from '@teambit/toolbox.network.get-port';
 import fs from 'fs-extra';
-import type { ExpressMain } from '@teambit/express';
+import crypto from 'crypto';
+import express from 'express';
+import type { ExpressMain, Middleware, Request, Response, NextFunction } from '@teambit/express';
 import { ExpressAspect } from '@teambit/express';
 import type { Logger, LoggerMain } from '@teambit/logger';
 import { LoggerAspect } from '@teambit/logger';
@@ -62,6 +64,8 @@ import type { SchemaMain } from '@teambit/schema';
 import { SchemaAspect } from '@teambit/schema';
 
 export class ApiServerMain {
+  private serverToken?: string;
+
   constructor(
     private workspace: Workspace,
     private logger: Logger,
@@ -122,7 +126,18 @@ export class ApiServerMain {
 
     const port = options.port || (await this.getRandomPort());
 
-    const app = this.express.createApp();
+    // Generate a per-server auth token and persist it to a 0600 file before
+    // any HTTP request can be handled. Clients (e.g. the bit-vscode extension)
+    // read it from <workspace.scope.path>/server-token.txt and send it as
+    // `Authorization: Bearer <token>`. See createAuthMiddleware below.
+    this.writeServerToken();
+
+    // Create the app *before* express.createApp registers routes, so the auth
+    // middleware runs first — including before bodyParser, which means
+    // unauthenticated requests can't trigger large-body parsing.
+    const app = express();
+    app.use(this.createAuthMiddleware());
+    this.express.createApp(app);
 
     app.use(
       cors({
@@ -223,6 +238,56 @@ export class ApiServerMain {
   writeUsedPort(port: number) {
     const filePath = this.getServerPortFilePath();
     fs.writeFileSync(filePath, port.toString());
+  }
+
+  /**
+   * Generate a fresh per-server bearer token and persist it to a 0600 file.
+   * Clients (e.g. the bit-vscode extension) read this file and send the token
+   * as `Authorization: Bearer <token>` on every request.
+   *
+   * Backwards compatibility: clients that don't yet know about this file (older
+   * extension versions) won't send the header and will receive 401 with a
+   * message pointing them at the upgrade. Old bit-server versions don't write
+   * this file, so a new client checking for it gracefully falls back to no
+   * auth header — meaning a NEW extension keeps working against an OLD
+   * bit-server.
+   */
+  private writeServerToken() {
+    const token = crypto.randomBytes(32).toString('hex');
+    const filePath = this.getServerTokenFilePath();
+    fs.writeFileSync(filePath, token, { mode: 0o600 });
+    this.serverToken = token;
+  }
+
+  private getServerTokenFilePath() {
+    return join(this.workspace.scope.path, 'server-token.txt');
+  }
+
+  /**
+   * Authentication middleware: requires `Authorization: Bearer <serverToken>`
+   * on every request except OPTIONS preflight (handled by cors) and the
+   * unauthenticated `/api/_health` liveness probe.
+   *
+   * Runs before bodyParser so unauthenticated requests can't trigger
+   * large-body parsing.
+   */
+  private createAuthMiddleware(): Middleware {
+    return (req: Request, res: Response, next: NextFunction) => {
+      if (req.method === 'OPTIONS') return next();
+      if (req.url === '/api/_health') return next();
+
+      const expected = `Bearer ${this.serverToken}`;
+      if (!this.serverToken || req.headers.authorization !== expected) {
+        this.logger.debug(`api-server: rejected unauthenticated request to ${req.url}`);
+        res.status(401).jsonp({
+          error: 'unauthorized',
+          message:
+            'This bit-server requires authentication. Please upgrade your bit VS Code extension to the latest version.',
+        });
+        return;
+      }
+      return next();
+    };
   }
 
   /**

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -133,12 +133,11 @@ export class ApiServerMain {
     this.writeServerToken();
 
     // Create the app *before* express.createApp registers routes, so the auth
-    // middleware runs first — including before bodyParser, which means
-    // unauthenticated requests can't trigger large-body parsing.
+    // middleware runs before bodyParser — unauthenticated requests can't
+    // trigger large-body parsing. CORS is registered before auth so 401
+    // responses still carry CORS headers; otherwise browser-based clients
+    // (bit-vscode) see a misleading CORS failure instead of the JSON 401.
     const app = express();
-    app.use(this.createAuthMiddleware());
-    this.express.createApp(app);
-
     app.use(
       cors({
         origin(origin, callback) {
@@ -147,6 +146,8 @@ export class ApiServerMain {
         credentials: true,
       })
     );
+    app.use(this.createAuthMiddleware());
+    this.express.createApp(app);
     const proxyHeaders = {
       Authorization: `${DEFAULT_AUTH_TYPE} ${Http.getToken()}`,
       origin: '',
@@ -256,6 +257,10 @@ export class ApiServerMain {
     const token = crypto.randomBytes(32).toString('hex');
     const filePath = this.getServerTokenFilePath();
     fs.writeFileSync(filePath, token, { mode: 0o600 });
+    // Node's `mode` write option is only honored when the file is created.
+    // chmod explicitly so a pre-existing file with broader permissions gets
+    // tightened to 0600.
+    fs.chmodSync(filePath, 0o600);
     this.serverToken = token;
   }
 
@@ -274,11 +279,13 @@ export class ApiServerMain {
   private createAuthMiddleware(): Middleware {
     return (req: Request, res: Response, next: NextFunction) => {
       if (req.method === 'OPTIONS') return next();
-      if (req.url === '/api/_health') return next();
+      // Use req.path (not req.url) so query strings don't bypass the
+      // health-check exemption — e.g. /api/_health?cache-buster=1.
+      if (req.path === '/api/_health') return next();
 
-      const expected = `Bearer ${this.serverToken}`;
-      if (!this.serverToken || req.headers.authorization !== expected) {
-        this.logger.debug(`api-server: rejected unauthenticated request to ${req.url}`);
+      const provided = parseBearerToken(req.headers.authorization);
+      if (!this.serverToken || provided !== this.serverToken) {
+        this.logger.debug(`api-server: rejected unauthenticated request to ${req.path}`);
         res.status(401).jsonp({
           error: 'unauthorized',
           message:
@@ -494,5 +501,16 @@ export class ApiServerMain {
 }
 
 ApiServerAspect.addRuntime(ApiServerMain);
+
+/**
+ * Extract the token from an `Authorization: Bearer <token>` header.
+ * Lenient on scheme casing and surrounding whitespace so a slightly
+ * non-canonical client header doesn't get rejected.
+ */
+function parseBearerToken(header: string | undefined): string | undefined {
+  if (!header) return undefined;
+  const match = header.match(/^\s*Bearer\s+(\S+)\s*$/i);
+  return match?.[1];
+}
 
 export default ApiServerMain;

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -3,7 +3,7 @@ import { CLIAspect, MainRuntime } from '@teambit/cli';
 import { Port } from '@teambit/toolbox.network.get-port';
 import fs from 'fs-extra';
 import crypto from 'crypto';
-import express from 'express';
+import expressFactory from 'express';
 import type { ExpressMain, Middleware, Request, Response, NextFunction } from '@teambit/express';
 import { ExpressAspect } from '@teambit/express';
 import type { Logger, LoggerMain } from '@teambit/logger';
@@ -137,7 +137,7 @@ export class ApiServerMain {
     // trigger large-body parsing. CORS is registered before auth so 401
     // responses still carry CORS headers; otherwise browser-based clients
     // (bit-vscode) see a misleading CORS failure instead of the JSON 401.
-    const app = express();
+    const app = expressFactory();
     app.use(
       cors({
         origin(origin, callback) {

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -58,6 +58,7 @@ import { getPidByPort, getSocketPort } from './server-forever';
 const CMD_SERVER_PORT = 'cli-server-port';
 const CMD_SERVER_PORT_DELETE = 'cli-server-port-delete';
 const CMD_SERVER_SOCKET_PORT = 'cli-server-socket-port';
+const CMD_SERVER_TOKEN = 'cli-server-token';
 const SKIP_PORT_VALIDATION_ARG = '--skip-port-validation';
 
 class ServerPortFileNotFound extends Error {
@@ -112,6 +113,7 @@ export class ServerCommander {
     if (process.argv.includes(CMD_SERVER_PORT)) return this.printPortAndExit();
     if (process.argv.includes(CMD_SERVER_SOCKET_PORT)) return this.printSocketPortAndExit();
     if (process.argv.includes(CMD_SERVER_PORT_DELETE)) return this.deletePortAndExit();
+    if (process.argv.includes(CMD_SERVER_TOKEN)) return this.printServerTokenAndExit();
     printBitVersionIfAsked();
     const port = await this.getExistingUsedPort();
     const url = `http://localhost:${port}/api`;
@@ -135,12 +137,15 @@ export class ServerCommander {
     const endpoint = `cli-raw`;
     const pwd = process.cwd();
     const body = { command: args, pwd, envBitFeatures: process.env.BIT_FEATURES, ttyPath, isPty: shouldUsePTY };
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const token = this.getServerTokenIfExists();
+    if (token) headers.Authorization = `Bearer ${token}`;
     let res;
     try {
       res = await fetch(`${url}/${endpoint}`, {
         method: 'post',
         body: JSON.stringify(body),
-        headers: { 'Content-Type': 'application/json' },
+        headers,
       });
     } catch (err: any) {
       if (err.code === 'ECONNREFUSED') {
@@ -237,7 +242,9 @@ Please run the command "bit server-forever" first to start the server.`)
    * it didn't work well. It was printed only after the response came back from the server.
    */
   private initSSE(url: string) {
-    const eventSource = new EventSource(`${url}/sse-events`);
+    const token = this.getServerTokenIfExists();
+    const eventSourceOpts = token ? { headers: { Authorization: `Bearer ${token}` } } : undefined;
+    const eventSource = new EventSource(`${url}/sse-events`, eventSourceOpts);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     eventSource.onerror = (_error: any) => {
       // eslint-disable-next-line no-console
@@ -287,6 +294,56 @@ Please run the command "bit server-forever" first to start the server.`)
     } catch (err: any) {
       console.error(err.message); // eslint-disable-line no-console
       process.exit(1);
+    }
+  }
+
+  /**
+   * Print the per-server bearer token written by bit-server at startup, used
+   * by clients (e.g. the bit-vscode extension) to authenticate to the local
+   * HTTP API. Prints empty if no token file exists (older bit-server with no
+   * auth requirement).
+   */
+  private async printServerTokenAndExit() {
+    try {
+      const filePath = this.getServerTokenFilePath();
+      try {
+        const token = await fs.readFile(filePath, 'utf8');
+        process.stdout.write(token.trim());
+      } catch (err: any) {
+        if (err.code !== 'ENOENT') throw err;
+        // No token file — old bit-server, no auth required. Print empty.
+      }
+      process.exit(0);
+    } catch (err: any) {
+      if (err instanceof ScopeNotFound) {
+        process.exit(0);
+      }
+      console.error(err.message); // eslint-disable-line no-console
+      process.exit(1);
+    }
+  }
+
+  private getServerTokenFilePath() {
+    const scopePath = findScopePath(process.cwd());
+    if (!scopePath) {
+      throw new ScopeNotFound(process.cwd());
+    }
+    return join(scopePath, 'server-token.txt');
+  }
+
+  /**
+   * Read the server's bearer token, returning undefined if no token file
+   * exists (older bit-server with no auth requirement) or scope can't be
+   * resolved. Used by HTTP/SSE callers in this file to authenticate to the
+   * running bit-server.
+   */
+  private getServerTokenIfExists(): string | undefined {
+    try {
+      const filePath = this.getServerTokenFilePath();
+      const token = fs.readFileSync(filePath, 'utf8').trim();
+      return token || undefined;
+    } catch {
+      return undefined;
     }
   }
 

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -336,14 +336,25 @@ Please run the command "bit server-forever" first to start the server.`)
    * exists (older bit-server with no auth requirement) or scope can't be
    * resolved. Used by HTTP/SSE callers in this file to authenticate to the
    * running bit-server.
+   *
+   * Only ENOENT and ScopeNotFound are swallowed — other read errors
+   * (EACCES, EPERM, corrupted file, …) are surfaced so the user sees the
+   * real cause instead of a misleading 401/upgrade message from the server.
    */
   private getServerTokenIfExists(): string | undefined {
+    let filePath: string;
     try {
-      const filePath = this.getServerTokenFilePath();
+      filePath = this.getServerTokenFilePath();
+    } catch (err: any) {
+      if (err instanceof ScopeNotFound) return undefined;
+      throw err;
+    }
+    try {
       const token = fs.readFileSync(filePath, 'utf8').trim();
       return token || undefined;
-    } catch {
-      return undefined;
+    } catch (err: any) {
+      if (err.code === 'ENOENT') return undefined;
+      throw err;
     }
   }
 


### PR DESCRIPTION
Adds per-server bearer-token authentication to bit-server's local HTTP API.

- Generates a 256-bit random token at startup, persists to `<scope>/server-token.txt` (mode 0600).
- Requires `Authorization: Bearer <token>` on all routes except OPTIONS preflight and `/api/_health`. Auth runs before bodyParser, so unauthenticated requests don't trigger large-body parsing.
- New `bit cli-server-token` command exposes the token to clients (uses `findScopePath`, so handles both `.bit/scope` and `.git/bit/scope`).
- CLI's own fast-mode (`BIT_CLI_SERVER=true`) HTTP + SSE paths updated to read and send the token.
- Backwards compatible: old clients that don't read the token still work against an old bit-server (no file present). Old clients hitting a new bit-server get 401 with an "upgrade your bit VS Code extension" message.

Companion change to the bit-vscode extension is on the `teambit.vscode/security-server-token-auth` lane — the extension reads the token via `bit cli-server-token` and includes it on every fetch + the SSE EventSource.