### PR TITLE
feat(ci): log lane hash when creating temporary lane in ci pr

### DIFF
--- a/e2e/harmony/ci-commands.e2e.ts
+++ b/e2e/harmony/ci-commands.e2e.ts
@@ -143,7 +143,9 @@ describe('ci commands', function () {
       // e.g., "feature-temp-lane-test-a1b2c"
       // Strip chalk/ANSI codes before regex matching to avoid false negatives
       const cleanOutput = removeChalkCharacters(prOutput) as string;
-      expect(cleanOutput).to.match(/Creating temporary lane .+\/feature-temp-lane-test-[a-z0-9]{5}/);
+      expect(cleanOutput).to.match(
+        /Created temporary lane .+\/feature-temp-lane-test-[a-z0-9]{5} \(hash: [a-f0-9]{40}\)/
+      );
     });
     it('should rename the temp lane to the final name before export', () => {
       const cleanOutput = removeChalkCharacters(prOutput) as string;

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -390,15 +390,17 @@ export class CiMain {
 
     // Use unique temp lane name to avoid race conditions when multiple CI jobs run concurrently
     const tempLaneName = `${laneId.name}-${generateRandomStr(5)}`;
-    this.logger.console(chalk.blue(`Creating temporary lane ${laneId.scope}/${tempLaneName}`));
 
     let foundErr: Error | undefined;
     let renamedToFinalName = false;
     try {
-      await this.lanes.createLane(tempLaneName, {
+      const createLaneResult = await this.lanes.createLane(tempLaneName, {
         scope: laneId.scope,
         forkLaneNewScope: true,
       });
+      this.logger.console(
+        chalk.blue(`Created temporary lane ${laneId.scope}/${tempLaneName} (hash: ${createLaneResult.hash})`)
+      );
 
       const currentLane = await this.lanes.getCurrentLane();
 


### PR DESCRIPTION
Logs the temporary lane's hash right after creation in `bit ci pr`, so export failures can be debugged against a known lane identifier.

Replaces the prior "Creating temporary lane" log with a single post-creation line: `Created temporary lane <scope>/<name> (hash: <hash>)`.