### PR TITLE
feat(api-server): tighten local server defaults

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -243,6 +243,10 @@ export class ApiServerMain {
   writeUsedPort(port: number) {
     const filePath = this.getServerPortFilePath();
     fs.writeFileSync(filePath, port.toString(), { mode: 0o600 });
+    // Node's `mode` write option is only honored when the file is created.
+    // chmod explicitly so a pre-existing file with broader permissions gets
+    // tightened to 0600.
+    fs.chmodSync(filePath, 0o600);
   }
 
   /**

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -137,7 +137,10 @@ export class ApiServerMain {
     // trigger large-body parsing. CORS is registered before auth so 401
     // responses still carry CORS headers; otherwise browser-based clients
     // (bit-vscode) see a misleading CORS failure instead of the JSON 401.
+    // The host-check middleware runs first to reject DNS-rebinding attacks
+    // (where a malicious page resolves attacker.example to 127.0.0.1).
     const app = expressFactory();
+    app.use(this.createHostCheckMiddleware());
     app.use(
       cors({
         origin(origin, callback) {
@@ -215,12 +218,13 @@ export class ApiServerMain {
         pathFilter: '/',
         target: symphonyUrl,
         ws: true,
-        secure: false, // Disable SSL verification for proxy to remote server
         changeOrigin: true,
       })
     );
 
-    const server = await app.listen(port);
+    // Bind to loopback only — never accept connections from the LAN. Clients
+    // are expected to use 127.0.0.1 (or localhost, which resolves to it).
+    const server = await app.listen(port, '127.0.0.1');
 
     return new Promise((resolve, reject) => {
       server.on('error', (err) => {
@@ -238,7 +242,7 @@ export class ApiServerMain {
 
   writeUsedPort(port: number) {
     const filePath = this.getServerPortFilePath();
-    fs.writeFileSync(filePath, port.toString());
+    fs.writeFileSync(filePath, port.toString(), { mode: 0o600 });
   }
 
   /**
@@ -269,9 +273,44 @@ export class ApiServerMain {
   }
 
   /**
+   * Host-header check: only accept requests targeting a loopback hostname.
+   * Defends against DNS-rebinding attacks where a malicious page on
+   * `evil.example` flips DNS to 127.0.0.1 — the browser sends `Host:
+   * evil.example`, which we reject with 403 here.
+   *
+   * The server already listens on 127.0.0.1 only, so any request reaching us
+   * arrived via loopback. The remaining concern is the *named* origin the
+   * browser thinks it's talking to.
+   */
+  private createHostCheckMiddleware(): Middleware {
+    const allowed = new Set(['localhost', '127.0.0.1', '::1']);
+    return (req: Request, res: Response, next: NextFunction) => {
+      const hostHeader = req.headers.host || '';
+      // Parse hostname from "host:port". IPv6 may be bracketed: "[::1]:1234"
+      // → "::1"; IPv4 / hostname is plain: "127.0.0.1:1234" → "127.0.0.1".
+      const match = hostHeader.match(/^\[([^\]]+)\]|^([^:]+)/);
+      const host = match ? match[1] || match[2] : '';
+      if (!allowed.has(host)) {
+        this.logger.debug(`api-server: rejected non-loopback Host header: ${hostHeader}`);
+        res.status(403).end();
+        return;
+      }
+      return next();
+    };
+  }
+
+  /**
    * Authentication middleware: requires `Authorization: Bearer <serverToken>`
    * on every request except OPTIONS preflight (handled by cors) and the
    * unauthenticated `/api/_health` liveness probe.
+   *
+   * For GET requests — specifically WebSocket upgrades and browser-native
+   * EventSource (SSE) connections — the underlying APIs cannot set custom
+   * headers from JavaScript. The token is therefore also accepted as a
+   * `?token=` query parameter on GET requests. We strip it from `req.url`
+   * before downstream processing so it never reaches the upstream Bit
+   * Cloud proxy or our own logs. POST/PUT/DELETE always require the
+   * Authorization header — they can set it.
    *
    * Runs before bodyParser so unauthenticated requests can't trigger
    * large-body parsing.
@@ -284,7 +323,22 @@ export class ApiServerMain {
       if (req.path === '/api/_health') return next();
 
       const provided = parseBearerToken(req.headers.authorization);
-      if (!this.serverToken || provided !== this.serverToken) {
+      let authorized = !!this.serverToken && provided === this.serverToken;
+
+      if (!authorized && this.serverToken && req.method === 'GET') {
+        const queryIdx = req.url.indexOf('?');
+        if (queryIdx >= 0) {
+          const params = new URLSearchParams(req.url.slice(queryIdx + 1));
+          if (params.get('token') === this.serverToken) {
+            authorized = true;
+            params.delete('token');
+            const remaining = params.toString();
+            req.url = req.url.slice(0, queryIdx) + (remaining ? `?${remaining}` : '');
+          }
+        }
+      }
+
+      if (!authorized) {
         this.logger.debug(`api-server: rejected unauthenticated request to ${req.path}`);
         res.status(401).jsonp({
           error: 'unauthorized',
@@ -364,8 +418,8 @@ export class ApiServerMain {
 
   async getRandomPort() {
     const startingPort = 4000; // we prefer to have the ports between 4000 and 4999.
-    // get random number in the range of [startingPort, 4999].
-    const randomNumber = Math.floor(Math.random() * (4999 - startingPort + 1) + startingPort);
+    // randomInt(min, max) returns a uniformly random int in [min, max).
+    const randomNumber = crypto.randomInt(startingPort, 5000);
     const port = await Port.getPort(randomNumber, 65500);
     return port;
   }

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -304,13 +304,10 @@ export class ApiServerMain {
    * on every request except OPTIONS preflight (handled by cors) and the
    * unauthenticated `/api/_health` liveness probe.
    *
-   * For GET requests — specifically WebSocket upgrades and browser-native
-   * EventSource (SSE) connections — the underlying APIs cannot set custom
-   * headers from JavaScript. The token is therefore also accepted as a
-   * `?token=` query parameter on GET requests. We strip it from `req.url`
-   * before downstream processing so it never reaches the upstream Bit
-   * Cloud proxy or our own logs. POST/PUT/DELETE always require the
-   * Authorization header — they can set it.
+   * GET requests can also authenticate via a `?token=...` query parameter,
+   * since browser-native WebSocket and EventSource cannot set custom headers
+   * from JavaScript. The param is stripped from `req.url` before downstream
+   * handling so the proxy and logs never see it.
    *
    * Runs before bodyParser so unauthenticated requests can't trigger
    * large-body parsing.
@@ -418,7 +415,6 @@ export class ApiServerMain {
 
   async getRandomPort() {
     const startingPort = 4000; // we prefer to have the ports between 4000 and 4999.
-    // randomInt(min, max) returns a uniformly random int in [min, max).
     const randomNumber = crypto.randomInt(startingPort, 5000);
     const port = await Port.getPort(randomNumber, 65500);
     return port;

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -292,8 +292,9 @@ export class ApiServerMain {
       const hostHeader = req.headers.host || '';
       // Parse hostname from "host:port". IPv6 may be bracketed: "[::1]:1234"
       // → "::1"; IPv4 / hostname is plain: "127.0.0.1:1234" → "127.0.0.1".
+      // HTTP hostnames are case-insensitive, so normalize before checking.
       const match = hostHeader.match(/^\[([^\]]+)\]|^([^:]+)/);
-      const host = match ? match[1] || match[2] : '';
+      const host = match ? (match[1] || match[2]).toLowerCase() : '';
       if (!allowed.has(host)) {
         this.logger.debug(`api-server: rejected non-loopback Host header: ${hostHeader}`);
         res.status(403).end();

--- a/scopes/harmony/api-server/cli-raw.route.ts
+++ b/scopes/harmony/api-server/cli-raw.route.ts
@@ -72,20 +72,23 @@ export class CLIRawRoute implements Route {
       const originalStdoutWrite = process.stdout.write;
       const originalStderrWrite = process.stderr.write;
 
+      let fileHandle: number | undefined;
       if (ttyPath) {
-        const fileHandle = await fs.open(ttyPath, 'w');
+        fileHandle = await fs.open(ttyPath, 'w');
         if (!isatty(fileHandle)) {
           await fs.close(fileHandle);
+          fileHandle = undefined;
           throw new Error(`Invalid ttyPath parameter. Path is not a TTY.`);
         }
+        const ttyFd = fileHandle;
         // @ts-ignore monkey patch the process stdout write method
         process.stdout.write = (chunk, encoding, callback) => {
-          fs.writeSync(fileHandle, chunk.toString());
+          fs.writeSync(ttyFd, chunk.toString());
           return originalStdoutWrite.call(process.stdout, chunk, encoding, callback);
         };
         // @ts-ignore monkey patch the process stderr write method
         process.stderr.write = (chunk, encoding, callback) => {
-          fs.writeSync(fileHandle, chunk.toString());
+          fs.writeSync(ttyFd, chunk.toString());
           return originalStderrWrite.call(process.stdout, chunk, encoding, callback);
         };
       }
@@ -145,6 +148,13 @@ export class CLIRawRoute implements Route {
         if (ttyPath) {
           process.stdout.write = originalStdoutWrite;
           process.stderr.write = originalStderrWrite;
+          if (fileHandle !== undefined) {
+            try {
+              await fs.close(fileHandle);
+            } catch (err) {
+              this.logger.debug(`cli-raw: failed to close tty fd: ${(err as Error).message}`);
+            }
+          }
         }
         if (isSSE) {
           delete process.env.BIT_CLI_SERVER_NO_TTY;

--- a/scopes/harmony/api-server/cli-raw.route.ts
+++ b/scopes/harmony/api-server/cli-raw.route.ts
@@ -2,6 +2,7 @@ import type { CLIMain } from '@teambit/cli';
 import { CLIParser, YargsExitWorkaround } from '@teambit/cli';
 import fs from 'fs-extra';
 import path from 'path';
+import { isatty } from 'tty';
 import chalk from 'chalk';
 import type { Route, Request, Response } from '@teambit/express';
 import type { Logger } from '@teambit/logger';
@@ -9,6 +10,20 @@ import { logger as legacyLogger, getLevelFromArgv } from '@teambit/legacy.logger
 import { reloadFeatureToggle } from '@teambit/harmony.modules.feature-toggle';
 import { loader } from '@teambit/legacy.loader';
 import type { APIForIDE } from './api-for-ide';
+
+/**
+ * Strict allowlist of TTY device paths. Anything not matching is rejected
+ * before we attempt to open it. Combined with an `isatty` check on the
+ * opened fd, this blocks block devices, /proc files, and symlink-redirected
+ * targets.
+ *
+ *   /dev/tty            current process's controlling tty
+ *   /dev/ttyXXXNN       e.g. /dev/ttys000 (macOS), /dev/ttyS0 (Linux)
+ *   /dev/pts/N          pseudo-terminal slaves on Linux
+ *   /dev/ptmx           pseudo-terminal master
+ *   /dev/console        system console
+ */
+const TTY_PATH_RE = /^\/dev\/(tty[a-zA-Z0-9]*|pts\/\d+|ptmx|console)$/;
 
 /**
  * example usage:
@@ -43,13 +58,12 @@ export class CLIRawRoute implements Route {
         }
       }
 
-      // Validate ttyPath parameter to prevent path traversal
-      if (ttyPath) {
-        // ttyPath should be a legitimate terminal device path (e.g., /dev/ttys000, /dev/pts/0)
-        // Validate it's a device path and doesn't contain traversal sequences
-        if (ttyPath.includes('..') || !(ttyPath.startsWith('/dev/') || ttyPath.startsWith('/proc/'))) {
-          throw new Error(`Invalid ttyPath parameter. Must be a legitimate terminal device path.`);
-        }
+      // Validate ttyPath against a strict allowlist. The earlier check (string
+      // prefix /dev/ or /proc/) was too permissive — it allowed /dev/sda,
+      // /proc/sysrq-trigger, etc. After opening we also verify the fd is a
+      // TTY (catches symlinks pointing outside the allowlist).
+      if (ttyPath && !TTY_PATH_RE.test(ttyPath)) {
+        throw new Error(`Invalid ttyPath parameter. Must be a TTY device under /dev/.`);
       }
       // there are 3 methods to interact with bit-server: 1) SSE, 2) TTY, 3) PTY. See server-commander.ts for more info.
       const isSSE = !ttyPath && !isPty;
@@ -60,6 +74,10 @@ export class CLIRawRoute implements Route {
 
       if (ttyPath) {
         const fileHandle = await fs.open(ttyPath, 'w');
+        if (!isatty(fileHandle)) {
+          await fs.close(fileHandle);
+          throw new Error(`Invalid ttyPath parameter. Path is not a TTY.`);
+        }
         // @ts-ignore monkey patch the process stdout write method
         process.stdout.write = (chunk, encoding, callback) => {
           fs.writeSync(fileHandle, chunk.toString());

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -116,7 +116,7 @@ export class ServerCommander {
     if (process.argv.includes(CMD_SERVER_TOKEN)) return this.printServerTokenAndExit();
     printBitVersionIfAsked();
     const port = await this.getExistingUsedPort();
-    const url = `http://localhost:${port}/api`;
+    const url = `http://127.0.0.1:${port}/api`;
     const shouldUsePTY = process.env.BIT_CLI_SERVER_PTY === 'true';
 
     if (shouldUsePTY) {

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -17,6 +17,7 @@ import { z } from 'zod';
 import type { Logger, LoggerMain } from '@teambit/logger';
 import { LoggerAspect } from '@teambit/logger';
 import { Http } from '@teambit/scope.network';
+import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 import { CENTRAL_BIT_HUB_NAME, SYMPHONY_GRAPHQL } from '@teambit/legacy.constants';
 import fetch from 'node-fetch';
 import { McpSetupCmd } from './setup-cmd';
@@ -129,23 +130,20 @@ export class CliMcpServerMain {
   /**
    * Read the bearer token written by bit-server (1.13.166+) for authenticating
    * to the local HTTP API. Returns undefined for older bit-server versions
-   * that don't write a token file (no auth required).
+   * that don't write a token file (no auth required), or when the workspace
+   * has no scope yet. Other read errors (EACCES, etc.) surface so the user
+   * sees the real cause instead of a misleading 401.
    */
   private getBitServerToken(cwd: string): string | undefined {
+    const scopePath = findScopePath(cwd);
+    if (!scopePath) return undefined;
+    const filePath = path.join(scopePath, 'server-token.txt');
     try {
-      const result = childProcess.spawnSync(this.bitBin, ['cli-server-token'], {
-        cwd,
-        env: { ...process.env, BIT_CLI_SERVER: 'true' },
-        encoding: 'utf8',
-      });
-      if (result.error) throw result.error;
-      if (result.status !== 0) {
-        throw new Error(`Command failed with status ${result.status}: ${result.stderr}`);
-      }
-      return result.stdout.trim() || undefined;
+      const token = fs.readFileSync(filePath, 'utf8').trim();
+      return token || undefined;
     } catch (err: any) {
-      this.logger.error(`[MCP-DEBUG] error getting server token at ${cwd}. err: ${err.message}`);
-      return undefined;
+      if (err.code === 'ENOENT') return undefined;
+      throw err;
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -166,7 +166,7 @@ export class CliMcpServerMain {
                 const port = parseInt(portMatch[1], 10);
                 this.logger.debug(`[MCP-DEBUG] bit-server started on port ${port}`);
                 this.serverPort = port;
-                this.serverUrl = `http://localhost:${port}/api`;
+                this.serverUrl = `http://127.0.0.1:${port}/api`;
                 resolve(port);
               }
             }
@@ -258,14 +258,14 @@ export class CliMcpServerMain {
       if (!cwd) throw new Error('CWD is required to call bit-server API');
       this.serverPort = await this.getBitServerPort(cwd);
       if (this.serverPort) {
-        this.serverUrl = `http://localhost:${this.serverPort}/api`;
+        this.serverUrl = `http://127.0.0.1:${this.serverPort}/api`;
       } else {
         // No server running, try to start one
         this.logger.debug('[MCP-DEBUG] No bit-server found, attempting to start one');
         const startedPort = await this.startBitServer(cwd);
         if (startedPort) {
           this.serverPort = startedPort;
-          this.serverUrl = `http://localhost:${this.serverPort}/api`;
+          this.serverUrl = `http://127.0.0.1:${this.serverPort}/api`;
         }
       }
     }

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -45,6 +45,7 @@ export class CliMcpServerMain {
   private isConsumerProjectMode: boolean = false;
   private serverPort?: number;
   private serverUrl?: string;
+  private serverToken?: string;
   private serverProcess: childProcess.ChildProcess | null = null;
 
   // Whitelist of commands that are considered read-only/query operations
@@ -121,6 +122,29 @@ export class CliMcpServerMain {
       return parseInt(existingPort, 10);
     } catch (err: any) {
       this.logger.error(`[MCP-DEBUG] error getting existing port from bit server at ${cwd}. err: ${err.message}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Read the bearer token written by bit-server (1.13.166+) for authenticating
+   * to the local HTTP API. Returns undefined for older bit-server versions
+   * that don't write a token file (no auth required).
+   */
+  private getBitServerToken(cwd: string): string | undefined {
+    try {
+      const result = childProcess.spawnSync(this.bitBin, ['cli-server-token'], {
+        cwd,
+        env: { ...process.env, BIT_CLI_SERVER: 'true' },
+        encoding: 'utf8',
+      });
+      if (result.error) throw result.error;
+      if (result.status !== 0) {
+        throw new Error(`Command failed with status ${result.status}: ${result.stderr}`);
+      }
+      return result.stdout.trim() || undefined;
+    } catch (err: any) {
+      this.logger.error(`[MCP-DEBUG] error getting server token at ${cwd}. err: ${err.message}`);
       return undefined;
     }
   }
@@ -268,6 +292,9 @@ export class CliMcpServerMain {
           this.serverUrl = `http://127.0.0.1:${this.serverPort}/api`;
         }
       }
+      // bit-server 1.13.166+ requires a bearer token; older versions don't
+      // write the token file and getBitServerToken returns undefined.
+      if (this.serverPort) this.serverToken = this.getBitServerToken(cwd);
     }
 
     if (!this.serverUrl) {
@@ -306,12 +333,22 @@ export class CliMcpServerMain {
       url = `${this.serverUrl}/${route}`;
     }
 
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.serverToken) headers.Authorization = `Bearer ${this.serverToken}`;
+
     try {
       const response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify(body),
       });
+
+      if (response.status === 401 && !isReTrying) {
+        // Token may be stale (server restarted with a new one); refresh and retry once.
+        this.logger.debug('[MCP-DEBUG] 401 from bit-server, refreshing token and retrying');
+        this.serverToken = this.getBitServerToken(cwd);
+        return this.callBitServerAPIWithRoute(route, commandOrMethod, argsOrParams, flags, cwd, true, isIDERoute);
+      }
 
       if (!response.ok) {
         let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
@@ -330,6 +367,7 @@ export class CliMcpServerMain {
         // Server is no longer running, reset cached values and try to restart
         this.serverPort = undefined;
         this.serverUrl = undefined;
+        this.serverToken = undefined;
         this.logger.debug('[MCP-DEBUG] Connection refused, attempting to restart bit-server');
         return this.callBitServerAPIWithRoute(route, commandOrMethod, argsOrParams, flags, cwd, true, isIDERoute);
       }


### PR DESCRIPTION
A few small hardening / hygiene improvements on the local bit-server:

- Bind the local API to `127.0.0.1` only. Clients connect via localhost which resolves to it.
- Validate that incoming `Host` headers correspond to a loopback hostname (`localhost`, `127.0.0.1`, `::1`).
- Accept the auth token via a `?token=...` query parameter on GET requests, since browser-native WebSocket and EventSource APIs cannot set custom headers from JavaScript. The token is stripped from `req.url` before downstream handling.
- Enable TLS certificate verification on the upstream WebSocket proxy.
- Tighten `ttyPath` validation in `/api/cli-raw`: strict regex match plus an `isatty(fd)` check after open, ensuring the path resolves to an actual terminal device.
- Use `crypto.randomInt` for port selection.
- Write `server-port.txt` with mode `0600`.
- `server-commander`: connect via `127.0.0.1` to match the bind address.