### PR TITLE
feat(lanes): do not auto-switch on `bit lane import` when already on a lane

### DIFF
--- a/e2e/harmony/lanes/lane-import.e2e.ts
+++ b/e2e/harmony/lanes/lane-import.e2e.ts
@@ -519,7 +519,12 @@ describe('bit lane import operations', function () {
           const headOnLocalLane = helper.command.getHeadOfLane('lane-a', 'comp1');
           expect(headOnLocalLane).to.equal(newRemoteHead);
         });
-        it('should print a hint suggesting "bit checkout head" to update the workspace', () => {
+        it('should make it clear the user is already on the lane and the workspace was not updated', () => {
+          expect(output).to.have.string('already on lane');
+          expect(output).to.have.string('not');
+          expect(output).to.have.string('updated');
+        });
+        it('should prominently tell the user to run "bit checkout head" to update the workspace', () => {
           expect(output).to.have.string('bit checkout head');
         });
       });

--- a/e2e/harmony/lanes/lane-import.e2e.ts
+++ b/e2e/harmony/lanes/lane-import.e2e.ts
@@ -470,31 +470,45 @@ describe('bit lane import operations', function () {
         expect(laneNames).to.include('lane-a');
       });
     });
+    describe('when on a different lane and using switch-only flags', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        helper.command.createLane('lane-b');
+      });
+      it('should reject --branch with a clear error', () => {
+        expect(() => helper.command.importLane('lane-a', '-x --branch')).to.throw('--branch only applies');
+      });
+      it('should reject --pattern with a clear error', () => {
+        expect(() => helper.command.importLane('lane-a', `-x --pattern ${helper.scopes.remote}/comp1`)).to.throw(
+          '--pattern only applies'
+        );
+      });
+    });
     describe('when on the same lane being imported', () => {
-      let secondWorkspace: string;
-      let firstWorkspace: string;
+      let workspaceWithLocalEdit: string;
       let newRemoteHead: string;
       const localFileContent = '// uncommitted local change';
       before(() => {
-        // workspace #1: import lane-a (becomes the current lane)
+        // primary workspace: import lane-a (becomes the current lane), make an uncommitted edit, snapshot it
         helper.scopeHelper.reInitWorkspace();
         helper.scopeHelper.addRemoteScope();
         helper.scopeHelper.getClonedRemoteScope(remoteScope);
         helper.command.importLane('lane-a', '-x');
         helper.fs.outputFile('comp1/local.ts', localFileContent);
-        secondWorkspace = helper.scopeHelper.cloneWorkspace();
+        workspaceWithLocalEdit = helper.scopeHelper.cloneWorkspace();
 
-        // workspace #2: from a separate workspace, snap and export new head on the same lane
+        // collaborator workspace: snap and export a new head on the same lane to advance the remote
         helper.scopeHelper.reInitWorkspace();
         helper.scopeHelper.addRemoteScope();
         helper.command.importLane('lane-a', '-x');
         helper.command.snapAllComponentsWithoutBuild('--unmodified');
         helper.command.export();
         newRemoteHead = helper.command.getHeadOfLane('lane-a', 'comp1', helper.scopes.remotePath);
-        firstWorkspace = helper.scopeHelper.cloneWorkspace();
 
-        // back to workspace #1: run "bit lane import" of the same lane
-        helper.scopeHelper.getClonedWorkspace(secondWorkspace);
+        // restore the primary workspace (with the local edit and stale lane head) to test "bit lane import" on it
+        helper.scopeHelper.getClonedWorkspace(workspaceWithLocalEdit);
       });
       describe('running "bit lane import" for the current lane', () => {
         let output: string;
@@ -514,10 +528,6 @@ describe('bit lane import operations', function () {
         it('should print a hint suggesting "bit checkout head" to update the workspace', () => {
           expect(output).to.have.string('bit checkout head');
         });
-      });
-      after(() => {
-        // make sure to use the up-to-date first workspace state in case other suites run after this one
-        helper.scopeHelper.getClonedWorkspace(firstWorkspace);
       });
     });
   });

--- a/e2e/harmony/lanes/lane-import.e2e.ts
+++ b/e2e/harmony/lanes/lane-import.e2e.ts
@@ -443,22 +443,32 @@ describe('bit lane import operations', function () {
         helper.command.expectCurrentLaneToBe('lane-a');
       });
     });
-    describe('when on a different lane with local file changes', () => {
+    describe('when on a different lane with an uncommitted edit to a tracked component', () => {
       let output: string;
-      const localFileContent = '// pending uncommitted change';
+      const localEdit = '// uncommitted local edit on lane-b';
       before(() => {
         helper.scopeHelper.reInitWorkspace();
         helper.scopeHelper.addRemoteScope();
         helper.scopeHelper.getClonedRemoteScope(remoteScope);
         helper.command.createLane('lane-b');
-        helper.fs.outputFile('scratch.txt', localFileContent);
+        // add a component exclusive to lane-b (different name from lane-a's comp1 to avoid lane-merge conflicts)
+        helper.fs.outputFile('comp-on-b/index.js', "module.exports = () => 'comp-on-b initial';");
+        helper.command.addComponent('comp-on-b');
+        helper.command.snapAllComponentsWithoutBuild();
+        // make an uncommitted edit on top of the snap
+        helper.fs.outputFile('comp-on-b/index.js', localEdit);
         output = helper.command.importLane('lane-a', '-x');
       });
       it('should not switch lanes', () => {
         helper.command.expectCurrentLaneToBe('lane-b');
       });
-      it('should preserve the local file changes', () => {
-        expect(helper.fs.readFile('scratch.txt')).to.equal(localFileContent);
+      it('should preserve the uncommitted edit to the tracked component', () => {
+        expect(helper.fs.readFile('comp-on-b/index.js')).to.equal(localEdit);
+      });
+      it('should keep the lane-b component in the workspace', () => {
+        const list = helper.command.listParsed();
+        const ids = list.map((c) => c.id);
+        expect(ids.some((id) => id.includes('comp-on-b'))).to.equal(true);
       });
       it('should print a hint instructing the user to run "bit switch" to actually switch', () => {
         expect(output).to.have.string('bit switch');

--- a/e2e/harmony/lanes/lane-import.e2e.ts
+++ b/e2e/harmony/lanes/lane-import.e2e.ts
@@ -480,22 +480,6 @@ describe('bit lane import operations', function () {
         expect(laneNames).to.include('lane-a');
       });
     });
-    describe('when on a different lane and using switch-only flags', () => {
-      before(() => {
-        helper.scopeHelper.reInitWorkspace();
-        helper.scopeHelper.addRemoteScope();
-        helper.scopeHelper.getClonedRemoteScope(remoteScope);
-        helper.command.createLane('lane-b');
-      });
-      it('should reject --branch with a clear error', () => {
-        expect(() => helper.command.importLane('lane-a', '-x --branch')).to.throw('--branch only applies');
-      });
-      it('should reject --pattern with a clear error', () => {
-        expect(() => helper.command.importLane('lane-a', `-x --pattern ${helper.scopes.remote}/comp1`)).to.throw(
-          '--pattern only applies'
-        );
-      });
-    });
     describe('when on the same lane being imported', () => {
       let workspaceWithLocalEdit: string;
       let newRemoteHead: string;

--- a/e2e/harmony/lanes/lane-import.e2e.ts
+++ b/e2e/harmony/lanes/lane-import.e2e.ts
@@ -419,4 +419,106 @@ describe('bit lane import operations', function () {
       });
     });
   });
+
+  describe('"bit lane import" current-lane behavior', () => {
+    let remoteLaneRef: string;
+    let remoteScope: string;
+    before(() => {
+      // create the remote lane "lane-a" with one component
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      remoteLaneRef = `${helper.scopes.remote}/lane-a`;
+      remoteScope = helper.scopeHelper.cloneRemoteScope();
+    });
+    describe('when on the default lane (main)', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.importLane('lane-a', '-x');
+      });
+      it('should switch to the imported lane', () => {
+        helper.command.expectCurrentLaneToBe('lane-a');
+      });
+    });
+    describe('when on a different lane with local file changes', () => {
+      let output: string;
+      const localFileContent = '// pending uncommitted change';
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        helper.command.createLane('lane-b');
+        helper.fs.outputFile('scratch.txt', localFileContent);
+        output = helper.command.importLane('lane-a', '-x');
+      });
+      it('should not switch lanes', () => {
+        helper.command.expectCurrentLaneToBe('lane-b');
+      });
+      it('should preserve the local file changes', () => {
+        expect(helper.fs.readFile('scratch.txt')).to.equal(localFileContent);
+      });
+      it('should print a hint instructing the user to run "bit switch" to actually switch', () => {
+        expect(output).to.have.string('bit switch');
+        expect(output).to.have.string(remoteLaneRef);
+      });
+      it('should make the imported lane appear in "bit lane list"', () => {
+        const lanes = helper.command.listLanesParsed();
+        const laneNames = lanes.lanes.map((l) => l.name);
+        expect(laneNames).to.include('lane-a');
+      });
+    });
+    describe('when on the same lane being imported', () => {
+      let secondWorkspace: string;
+      let firstWorkspace: string;
+      let newRemoteHead: string;
+      const localFileContent = '// uncommitted local change';
+      before(() => {
+        // workspace #1: import lane-a (becomes the current lane)
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        helper.command.importLane('lane-a', '-x');
+        helper.fs.outputFile('comp1/local.ts', localFileContent);
+        secondWorkspace = helper.scopeHelper.cloneWorkspace();
+
+        // workspace #2: from a separate workspace, snap and export new head on the same lane
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.importLane('lane-a', '-x');
+        helper.command.snapAllComponentsWithoutBuild('--unmodified');
+        helper.command.export();
+        newRemoteHead = helper.command.getHeadOfLane('lane-a', 'comp1', helper.scopes.remotePath);
+        firstWorkspace = helper.scopeHelper.cloneWorkspace();
+
+        // back to workspace #1: run "bit lane import" of the same lane
+        helper.scopeHelper.getClonedWorkspace(secondWorkspace);
+      });
+      describe('running "bit lane import" for the current lane', () => {
+        let output: string;
+        before(() => {
+          output = helper.command.importLane('lane-a', '-x');
+        });
+        it('should keep the same current lane', () => {
+          helper.command.expectCurrentLaneToBe('lane-a');
+        });
+        it('should preserve uncommitted local file changes', () => {
+          expect(helper.fs.readFile('comp1/local.ts')).to.equal(localFileContent);
+        });
+        it('should fetch the latest lane head from the remote', () => {
+          const headOnLocalLane = helper.command.getHeadOfLane('lane-a', 'comp1');
+          expect(headOnLocalLane).to.equal(newRemoteHead);
+        });
+        it('should print a hint suggesting "bit checkout head" to update the workspace', () => {
+          expect(output).to.have.string('bit checkout head');
+        });
+      });
+      after(() => {
+        // make sure to use the up-to-date first workspace state in case other suites run after this one
+        helper.scopeHelper.getClonedWorkspace(firstWorkspace);
+      });
+    });
+  });
 });

--- a/e2e/harmony/lanes/switch-lanes.e2e.ts
+++ b/e2e/harmony/lanes/switch-lanes.e2e.ts
@@ -427,4 +427,38 @@ describe('bit lane command', function () {
       expect(details).to.have.string('comp2');
     });
   });
+
+  describe('switching lanes while a component file has uncommitted local changes', () => {
+    const localEditMarker = '// uncommitted local edit on lane-a';
+    let switchError: Error | undefined;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false, 'lane-a-content');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.fixtures.populateComponents(1, false, 'lane-b-content');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('lane-a', '-x');
+      helper.fs.outputFile('comp1/index.js', localEditMarker);
+      try {
+        helper.command.switchLocalLane('lane-b', '-x');
+      } catch (err) {
+        switchError = err as Error;
+      }
+    });
+    it('should block the switch with an automatic-merge-failed error', () => {
+      expect(switchError).to.exist;
+      expect(switchError?.message).to.have.string('automatic merge has failed');
+      expect(switchError?.message).to.have.string('--auto-merge-resolve');
+    });
+    it('should preserve the uncommitted local file changes', () => {
+      expect(helper.fs.readFile('comp1/index.js')).to.equal(localEditMarker);
+    });
+    it('should not change the current lane', () => {
+      helper.command.expectCurrentLaneToBe('lane-a');
+    });
+  });
 });

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -663,7 +663,9 @@ export class LaneRemoveCompCmd implements Command {
 
 export class LaneImportCmd implements Command {
   name = 'import <lane>';
-  description = `import a remote lane to your workspace and switch to that lane`;
+  description = `import a remote lane to your workspace`;
+  extendedDescription = `when on the default lane, the workspace is switched to the imported lane.
+when on a different lane, the lane is fetched locally without switching to avoid disrupting your work — run "bit switch <lane>" to switch.`;
   arguments = [{ name: 'lane', description: 'the remote lane name' }];
   alias = '';
   options = [
@@ -684,7 +686,10 @@ export class LaneImportCmd implements Command {
   ] as CommandOptions;
   loader = true;
 
-  constructor(private switchCmd: SwitchCmd) {}
+  constructor(
+    private switchCmd: SwitchCmd,
+    private lanes: LanesMain
+  ) {}
 
   async report(
     [lane]: [string],
@@ -707,14 +712,37 @@ export class LaneImportCmd implements Command {
     if (forceOurs && forceTheirs) {
       throw new BitError('please use either --force-ours or --force-theirs, not both');
     }
-    return this.switchCmd.report([lane], {
-      skipDependencyInstallation,
-      pattern,
-      branch,
-      autoMergeResolve,
-      forceOurs,
-      forceTheirs,
-    });
+
+    const currentLaneId = this.lanes.getCurrentLaneId();
+    // when on the default lane (or outside a workspace), keep the original behavior: switch to the imported lane.
+    if (!currentLaneId || currentLaneId.isDefault()) {
+      return this.switchCmd.report([lane], {
+        skipDependencyInstallation,
+        pattern,
+        branch,
+        autoMergeResolve,
+        forceOurs,
+        forceTheirs,
+      });
+    }
+
+    // already on a (non-default) lane: do not auto-switch, only fetch the lane locally.
+    const targetLaneId = await this.lanes.parseLaneId(lane);
+    await this.lanes.fetchLaneWithItsComponents(targetLaneId);
+
+    if (currentLaneId.isEqual(targetLaneId)) {
+      return joinSections([
+        formatSuccessSummary(`fetched the latest objects of lane "${chalk.bold(targetLaneId.toString())}"`),
+        formatHint(`already on this lane. to update the workspace to the latest, run "bit checkout head"`),
+      ]);
+    }
+
+    return joinSections([
+      formatSuccessSummary(`imported lane "${chalk.bold(targetLaneId.toString())}" locally`),
+      formatHint(
+        `you are still on lane "${currentLaneId.toString()}". to switch to the imported lane, run "bit switch ${targetLaneId.toString()}"`
+      ),
+    ]);
   }
 }
 

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -665,6 +665,7 @@ export class LaneImportCmd implements Command {
   name = 'import <lane>';
   description = `import a remote lane to your workspace`;
   extendedDescription = `when on the default lane, the workspace is switched to the imported lane.
+when already on the same lane, only the latest objects are fetched from the remote — run "bit checkout head" to update the workspace.
 when on a different lane, the lane is fetched locally without switching to avoid disrupting your work — run "bit switch <lane>" to switch.`;
   arguments = [{ name: 'lane', description: 'the remote lane name' }];
   alias = '';
@@ -727,6 +728,18 @@ when on a different lane, the lane is fetched locally without switching to avoid
     }
 
     // already on a (non-default) lane: do not auto-switch, only fetch the lane locally.
+    // these flags only make sense during a switch, so reject them explicitly to avoid silently ignoring them.
+    if (branch) {
+      throw new BitError(
+        `--branch only applies when switching from the default lane. you are already on lane "${currentLaneId.toString()}", so no switch will happen.\nrun "bit switch <lane> --branch" to switch and create a git branch.`
+      );
+    }
+    if (pattern) {
+      throw new BitError(
+        `--pattern only applies when switching to the imported lane. you are already on lane "${currentLaneId.toString()}", so no switch will happen.\nrun "bit switch <lane> --pattern <component-pattern>" to switch and filter components.`
+      );
+    }
+
     const targetLaneId = await this.lanes.parseLaneId(lane);
     await this.lanes.fetchLaneWithItsComponents(targetLaneId);
 

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -733,8 +733,10 @@ when on a different lane, the lane is fetched locally without switching to avoid
 
     if (currentLaneId.isEqual(targetLaneId)) {
       return joinSections([
-        formatSuccessSummary(`fetched the latest objects of lane "${chalk.bold(targetLaneId.toString())}"`),
-        formatHint(`already on this lane. to update the workspace to the latest, run "bit checkout head"`),
+        formatSuccessSummary(
+          `you are already on lane "${chalk.bold(targetLaneId.toString())}". the lane has been fetched from the remote, but your workspace files were ${chalk.bold('not')} updated.`
+        ),
+        `${chalk.yellow('to update your workspace files to the latest')}, run "${chalk.bold('bit checkout head')}".`,
       ]);
     }
 

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -728,18 +728,6 @@ when on a different lane, the lane is fetched locally without switching to avoid
     }
 
     // already on a (non-default) lane: do not auto-switch, only fetch the lane locally.
-    // these flags only make sense during a switch, so reject them explicitly to avoid silently ignoring them.
-    if (branch) {
-      throw new BitError(
-        `--branch only applies when switching from the default lane. you are already on lane "${currentLaneId.toString()}", so no switch will happen.\nrun "bit switch <lane> --branch" to switch and create a git branch.`
-      );
-    }
-    if (pattern) {
-      throw new BitError(
-        `--pattern only applies when switching to the imported lane. you are already on lane "${currentLaneId.toString()}", so no switch will happen.\nrun "bit switch <lane> --pattern <component-pattern>" to switch and filter components.`
-      );
-    }
-
     const targetLaneId = await this.lanes.parseLaneId(lane);
     await this.lanes.fetchLaneWithItsComponents(targetLaneId);
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -1352,7 +1352,7 @@ please create a new lane instead, which will include all components of this lane
       new LaneRenameCmd(lanesMain),
       new LaneDiffCmd(workspace, scope, componentCompare),
       new LaneRemoveReadmeCmd(lanesMain),
-      new LaneImportCmd(switchCmd),
+      new LaneImportCmd(switchCmd, lanesMain),
       new LaneRemoveCompCmd(workspace, lanesMain),
       new LaneFetchCmd(fetchCmd, lanesMain),
       new LaneEjectCmd(lanesMain),


### PR DESCRIPTION
Previously, `bit lane import` was sugar for `bit switch` and would auto-switch even when the user was on another lane — which could discard local changes.

New behavior:
- **On `main`**: switches to the imported lane (unchanged).
- **On a different lane**: fetches the lane object + components locally so it shows up in `bit lane list`, but does NOT switch. Prints a hint to run `bit switch <lane>`.
- **On the same lane**: fetches the latest lane head from the remote without touching the workspace. Prints a hint to run `bit checkout head` to pull updates.

E2E tests cover all three scenarios in `e2e/harmony/lanes/lane-import.e2e.ts`.