### PR TITLE
fix(lanes): sort 'lane history' output by date

### DIFF
--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -455,15 +455,14 @@ export class LaneHistoryCmd implements Command {
     await this.lanes.importLaneHistory(laneId);
     const laneHistory = await this.lanes.getLaneHistory(laneId);
     const history = laneHistory.getHistory();
-    const sortedIds = laneHistory.getHistoryIds();
 
     if (id) {
       const historyItem = history[id];
       if (!historyItem) throw new Error(`history id ${id} was not found`);
-      return { historyItem, id, history, sortedIds, singleItem: true };
+      return { historyItem, id, history, singleItem: true as const };
     }
 
-    return { history, sortedIds, singleItem: false };
+    return { history, sortedIds: laneHistory.getHistoryIds(), singleItem: false as const };
   }
 
   private getDateString(date: string) {
@@ -471,14 +470,16 @@ export class LaneHistoryCmd implements Command {
   }
 
   async report([laneName]: [string], { id }: { id?: string }): Promise<string> {
-    const { history, historyItem, sortedIds, singleItem } = await this.getHistoryData(laneName, id);
+    const data = await this.getHistoryData(laneName, id);
 
-    if (singleItem && historyItem) {
+    if (data.singleItem) {
+      const { historyItem } = data;
       const date = this.getDateString(historyItem.log.date);
       const message = historyItem.log.message;
       return `${id} ${date} ${historyItem.log.username} ${message}\n\n${historyItem.components.join('\n')}`;
     }
 
+    const { history, sortedIds } = data;
     const items = sortedIds.map((uuid) => {
       const item = history[uuid];
       const date = this.getDateString(item.log.date);
@@ -489,9 +490,10 @@ export class LaneHistoryCmd implements Command {
   }
 
   async json([laneName]: [string], { id }: { id?: string }) {
-    const { history, historyItem, id: historyId, sortedIds, singleItem } = await this.getHistoryData(laneName, id);
+    const data = await this.getHistoryData(laneName, id);
 
-    if (singleItem && historyItem) {
+    if (data.singleItem) {
+      const { historyItem, id: historyId } = data;
       return {
         id: historyId,
         date: historyItem.log.date,
@@ -501,6 +503,7 @@ export class LaneHistoryCmd implements Command {
       };
     }
 
+    const { history, sortedIds } = data;
     return sortedIds.map((uuid) => {
       const item = history[uuid];
       return {

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -455,14 +455,15 @@ export class LaneHistoryCmd implements Command {
     await this.lanes.importLaneHistory(laneId);
     const laneHistory = await this.lanes.getLaneHistory(laneId);
     const history = laneHistory.getHistory();
+    const sortedIds = laneHistory.getHistoryIds();
 
     if (id) {
       const historyItem = history[id];
       if (!historyItem) throw new Error(`history id ${id} was not found`);
-      return { historyItem, id, history, singleItem: true };
+      return { historyItem, id, history, sortedIds, singleItem: true };
     }
 
-    return { history, singleItem: false };
+    return { history, sortedIds, singleItem: false };
   }
 
   private getDateString(date: string) {
@@ -470,7 +471,7 @@ export class LaneHistoryCmd implements Command {
   }
 
   async report([laneName]: [string], { id }: { id?: string }): Promise<string> {
-    const { history, historyItem, singleItem } = await this.getHistoryData(laneName, id);
+    const { history, historyItem, sortedIds, singleItem } = await this.getHistoryData(laneName, id);
 
     if (singleItem && historyItem) {
       const date = this.getDateString(historyItem.log.date);
@@ -478,7 +479,7 @@ export class LaneHistoryCmd implements Command {
       return `${id} ${date} ${historyItem.log.username} ${message}\n\n${historyItem.components.join('\n')}`;
     }
 
-    const items = Object.keys(history).map((uuid) => {
+    const items = sortedIds.map((uuid) => {
       const item = history[uuid];
       const date = this.getDateString(item.log.date);
       const message = item.log.message;
@@ -488,7 +489,7 @@ export class LaneHistoryCmd implements Command {
   }
 
   async json([laneName]: [string], { id }: { id?: string }) {
-    const { history, historyItem, id: historyId, singleItem } = await this.getHistoryData(laneName, id);
+    const { history, historyItem, id: historyId, sortedIds, singleItem } = await this.getHistoryData(laneName, id);
 
     if (singleItem && historyItem) {
       return {
@@ -500,7 +501,7 @@ export class LaneHistoryCmd implements Command {
       };
     }
 
-    return Object.keys(history).map((uuid) => {
+    return sortedIds.map((uuid) => {
       const item = history[uuid];
       return {
         id: uuid,

--- a/scopes/scope/objects/models/lane-history.spec.ts
+++ b/scopes/scope/objects/models/lane-history.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import { LaneHistory } from './lane-history';
+
+const makeItem = (date: string) => ({
+  log: { date, username: 'tester' },
+  components: [],
+});
+
+describe('LaneHistory', () => {
+  describe('getHistoryIds', () => {
+    it('returns ids sorted by date even when insertion order is not chronological', () => {
+      // Reproduces the "local snap before importing remote history" scenario:
+      // a newer entry is inserted first, then older entries are merged in.
+      const laneHistory = LaneHistory.parse(
+        JSON.stringify({
+          name: 'tmp4',
+          scope: 'my-scope',
+          laneHash: 'abc',
+          history: {
+            'newer-local': makeItem('1746369091000'), // 5/4/2026, 12:51 PM
+            'older-remote-1': makeItem('1746127977000'), // 5/1/2026, 3:32 PM
+            'older-remote-2': makeItem('1746127986000'), // 5/1/2026, 3:33 PM
+            'between-remote': makeItem('1746358729000'), // 5/4/2026, 9:58 AM
+          },
+        })
+      );
+
+      expect(laneHistory.getHistoryIds()).to.deep.equal([
+        'older-remote-1',
+        'older-remote-2',
+        'between-remote',
+        'newer-local',
+      ]);
+    });
+  });
+});

--- a/scopes/scope/objects/models/lane-history.spec.ts
+++ b/scopes/scope/objects/models/lane-history.spec.ts
@@ -10,8 +10,6 @@ const makeItem = (date: string) => ({
 describe('LaneHistory', () => {
   describe('getHistoryIds', () => {
     it('returns ids sorted by date even when insertion order is not chronological', () => {
-      // Reproduces the "local snap before importing remote history" scenario:
-      // a newer entry is inserted first, then older entries are merged in.
       const laneHistory = LaneHistory.parse(
         JSON.stringify({
           name: 'tmp4',


### PR DESCRIPTION
`bit lane history` was iterating `Object.keys(history)` and relying on insertion order, which doesn't match chronological order — when a workspace snaps before importing remote history, the new local entry ends up first in the map and remote entries get appended after it during `merge()`, producing a clearly wrong display order.

Fixed by switching the cmd's `report` and `json` paths to use `LaneHistory.getHistoryIds()`, which already sorts by `log.date` and is what `lane history-diff` uses too.