### PR TITLE
feat(workspace): scope-trust list for aspect loading

### DIFF
--- a/e2e/harmony/scope-trust.e2e.ts
+++ b/e2e/harmony/scope-trust.e2e.ts
@@ -1,0 +1,107 @@
+/**
+ * Verifies the workspace's scope-trust gate around aspect loading.
+ *
+ * Setup: an env in scope A has a top-level statement that writes a marker
+ * file when an env-var is set. A consumer component uses that env. A second
+ * workspace whose `defaultScope` belongs to a different owner imports the
+ * consumer.
+ *
+ * Expectation: because scope A isn't on the second workspace's effective
+ * trust list (builtin + owner-of-defaultScope + configured), the aspect
+ * loader doesn't require the env, and the marker file is never written
+ * after the import.
+ */
+import { expect } from 'chai';
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/legacy.e2e-helper';
+
+const MARKER_ENV_VAR = 'BIT_SCOPE_TRUST_TEST_MARKER';
+
+(supportNpmCiRegistryTesting ? describe : describe.skip)(
+  'workspace scope-trust gate around aspect loading',
+  function () {
+    this.timeout(0);
+    let helper: Helper;
+    let npmCiRegistry: NpmCiRegistry;
+    let markerPath: string;
+    let originalMarkerEnv: string | undefined;
+
+    before(async () => {
+      // Stable absolute marker path; passed to spawned bit processes via the
+      // current process's env so the env module's top-level can write it.
+      markerPath = path.join(
+        os.tmpdir(),
+        `bit-scope-trust-marker-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`
+      );
+      fs.removeSync(markerPath);
+      originalMarkerEnv = process.env[MARKER_ENV_VAR];
+      process.env[MARKER_ENV_VAR] = markerPath;
+
+      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+
+      // Env whose module body writes the marker file when MARKER_ENV_VAR is set.
+      helper.env.setEmptyEnv();
+      helper.fs.outputFile(
+        'empty-env/empty-env.bit-env.ts',
+        `
+import * as fs from 'fs';
+const marker = process.env.${MARKER_ENV_VAR};
+if (marker) {
+  try { fs.writeFileSync(marker, 'env-module-loaded'); } catch (e) { /* best effort */ }
+}
+export class EmptyEnv {}
+export default new EmptyEnv();
+`
+      );
+
+      helper.fixtures.populateComponents(1, false);
+      helper.command.setEnv('comp1', 'empty-env');
+
+      npmCiRegistry = new NpmCiRegistry(helper);
+      await npmCiRegistry.init();
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+      helper.command.install();
+      helper.command.compile();
+      helper.command.tagAllComponents();
+      helper.command.export();
+
+      // Second workspace with a defaultScope under a different owner — without
+      // this, the owner-wildcard derived from defaultScope would auto-trust
+      // the publisher's scope and the assertion wouldn't reflect a real
+      // cross-owner import.
+      helper.scopeHelper.reInitWorkspace({ addRemoteScopeAsDefaultScope: false });
+      helper.workspaceJsonc.addKeyValToWorkspace('defaultScope', 'other-owner.app');
+      npmCiRegistry.setResolver();
+
+      // Clear the marker before the import so any later write is attributable
+      // to the consumer-side aspect load (publisher-side install/compile runs
+      // its own env code naturally — its scope is trusted in its own workspace).
+      fs.removeSync(markerPath);
+      expect(fs.existsSync(markerPath), 'marker should be absent before import').to.be.false;
+
+      try {
+        helper.command.importComponent('comp1');
+      } catch {
+        // Aspect load refused → import command may exit non-zero. The
+        // marker-file check below is the source of truth.
+      }
+    });
+
+    after(() => {
+      try {
+        fs.removeSync(markerPath);
+      } catch {}
+      if (originalMarkerEnv === undefined) delete process.env[MARKER_ENV_VAR];
+      else process.env[MARKER_ENV_VAR] = originalMarkerEnv;
+      npmCiRegistry?.destroy();
+      helper?.scopeHelper.destroy();
+    });
+
+    it('does not load the env from a scope outside the trust list', () => {
+      expect(fs.existsSync(markerPath), `env module loaded; marker at ${markerPath}`).to.be.false;
+    });
+  }
+);

--- a/e2e/harmony/scope-trust.e2e.ts
+++ b/e2e/harmony/scope-trust.e2e.ts
@@ -1,15 +1,14 @@
 /**
  * Verifies the workspace's scope-trust gate around aspect loading.
  *
+ * The gate is opt-in: it only runs when `trustedScopes` is present in
+ * workspace.jsonc. The deny test below opts in explicitly; the allow test
+ * lists the env's scope.
+ *
  * Setup: an env in scope A has a top-level statement that writes a marker
  * file when an env-var is set. A consumer component uses that env. A second
  * workspace whose `defaultScope` belongs to a different owner imports the
  * consumer.
- *
- * Expectation: because scope A isn't on the second workspace's effective
- * trust list (builtin + owner-of-defaultScope + configured), the aspect
- * loader doesn't require the env, and the marker file is never written
- * after the import.
  */
 import { expect } from 'chai';
 import os from 'os';
@@ -68,12 +67,13 @@ export default new EmptyEnv();
       helper.command.tagAllComponents();
       helper.command.export();
 
-      // Second workspace with a defaultScope under a different owner — without
-      // this, the owner-wildcard derived from defaultScope would auto-trust
-      // the publisher's scope and the assertion wouldn't reflect a real
-      // cross-owner import.
+      // Second workspace, opted in to scope-trust with an empty list. The
+      // defaultScope is under a different owner so the owner-wildcard doesn't
+      // auto-trust the publisher's scope; the empty list means only builtins
+      // are trusted, so the publisher's scope is rejected.
       helper.scopeHelper.reInitWorkspace({ addRemoteScopeAsDefaultScope: false });
       helper.workspaceJsonc.addKeyValToWorkspace('defaultScope', 'other-owner.app');
+      helper.workspaceJsonc.addKeyValToWorkspace('trustedScopes', []);
       npmCiRegistry.setResolver();
 
       // Clear the marker before the import so any later write is attributable
@@ -102,6 +102,106 @@ export default new EmptyEnv();
 
     it('does not load the env from a scope outside the trust list', () => {
       expect(fs.existsSync(markerPath), `env module loaded; marker at ${markerPath}`).to.be.false;
+    });
+  }
+);
+
+(supportNpmCiRegistryTesting ? describe : describe.skip)(
+  'workspace scope-trust gate: trusted env in a different scope than the consumer',
+  function () {
+    this.timeout(0);
+    let helper: Helper;
+    let npmCiRegistry: NpmCiRegistry;
+    let markerPath: string;
+    let originalMarkerEnv: string | undefined;
+    let envScopeName: string;
+    let importOutput: string;
+
+    before(async () => {
+      markerPath = path.join(
+        os.tmpdir(),
+        `bit-scope-trust-marker-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`
+      );
+      fs.removeSync(markerPath);
+      originalMarkerEnv = process.env[MARKER_ENV_VAR];
+      process.env[MARKER_ENV_VAR] = markerPath;
+
+      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      // The publisher's default remote will hold the env. envScopeName is the
+      // exact scope name the victim will trust explicitly via `bit scope trust`.
+      envScopeName = helper.scopes.remote;
+
+      // A second remote holds the consumer component. The victim does NOT
+      // trust this scope. The import should still succeed because only the
+      // env's scope is checked at aspect-load.
+      const compRemote = helper.scopeHelper.getNewBareScope('-comp-remote');
+      // Register compRemote in the publisher workspace and cross-link the two
+      // remotes so each can resolve dependencies from the other.
+      helper.scopeHelper.addRemoteScope(compRemote.scopePath);
+      helper.scopeHelper.addRemoteScope(compRemote.scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, compRemote.scopePath);
+
+      helper.env.setEmptyEnv();
+      helper.fs.outputFile(
+        'empty-env/empty-env.bit-env.ts',
+        `
+import * as fs from 'fs';
+const marker = process.env.${MARKER_ENV_VAR};
+if (marker) {
+  try { fs.writeFileSync(marker, 'env-module-loaded'); } catch (e) { /* best effort */ }
+}
+export class EmptyEnv {}
+export default new EmptyEnv();
+`
+      );
+
+      helper.fixtures.populateComponents(1, false);
+      helper.command.setEnv('comp1', 'empty-env');
+      // Retarget the consumer (comp1) to the second remote scope so its scope
+      // differs from the env's scope.
+      helper.command.setScope(compRemote.scopeName, 'comp1');
+
+      npmCiRegistry = new NpmCiRegistry(helper);
+      await npmCiRegistry.init();
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+      helper.command.install();
+      helper.command.compile();
+      helper.command.tagAllComponents();
+      helper.command.export();
+
+      // Victim workspace under a different owner (so neither scope is auto-
+      // trusted via the owner-of-defaultScope wildcard). Trust ONLY the env's
+      // scope explicitly. The consumer's scope remains untrusted.
+      helper.scopeHelper.reInitWorkspace({ addRemoteScopeAsDefaultScope: false });
+      helper.workspaceJsonc.addKeyValToWorkspace('defaultScope', 'other-owner.app');
+      helper.workspaceJsonc.addKeyValToWorkspace('trustedScopes', [envScopeName]);
+      helper.scopeHelper.addRemoteScope(compRemote.scopePath);
+      npmCiRegistry.setResolver({ [compRemote.scopeName]: compRemote.scopePath });
+
+      fs.removeSync(markerPath);
+      expect(fs.existsSync(markerPath), 'marker should be absent before import').to.be.false;
+
+      importOutput = helper.command.import(`${compRemote.scopeName}/comp1`);
+    });
+
+    after(() => {
+      try {
+        fs.removeSync(markerPath);
+      } catch {}
+      if (originalMarkerEnv === undefined) delete process.env[MARKER_ENV_VAR];
+      else process.env[MARKER_ENV_VAR] = originalMarkerEnv;
+      npmCiRegistry?.destroy();
+      helper?.scopeHelper.destroy();
+    });
+
+    it('imports successfully (no error about untrusted scopes)', () => {
+      expect(importOutput).to.match(/successfully imported/i);
+      expect(importOutput).to.not.match(/isn't on the workspace's trusted list/i);
+    });
+
+    it('loads the env from the trusted scope', () => {
+      expect(fs.existsSync(markerPath), `env module did not load; expected marker at ${markerPath}`).to.be.true;
     });
   }
 );

--- a/e2e/harmony/scope-trust.e2e.ts
+++ b/e2e/harmony/scope-trust.e2e.ts
@@ -18,6 +18,16 @@ import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/leg
 
 const MARKER_ENV_VAR = 'BIT_SCOPE_TRUST_TEST_MARKER';
 
+const ENV_WITH_MARKER_SOURCE = `
+import * as fs from 'fs';
+const marker = process.env.${MARKER_ENV_VAR};
+if (marker) {
+  try { fs.writeFileSync(marker, 'env-module-loaded'); } catch (e) { /* best effort */ }
+}
+export class EmptyEnv {}
+export default new EmptyEnv();
+`;
+
 (supportNpmCiRegistryTesting ? describe : describe.skip)(
   'workspace scope-trust gate around aspect loading',
   function () {
@@ -44,18 +54,7 @@ const MARKER_ENV_VAR = 'BIT_SCOPE_TRUST_TEST_MARKER';
 
       // Env whose module body writes the marker file when MARKER_ENV_VAR is set.
       helper.env.setEmptyEnv();
-      helper.fs.outputFile(
-        'empty-env/empty-env.bit-env.ts',
-        `
-import * as fs from 'fs';
-const marker = process.env.${MARKER_ENV_VAR};
-if (marker) {
-  try { fs.writeFileSync(marker, 'env-module-loaded'); } catch (e) { /* best effort */ }
-}
-export class EmptyEnv {}
-export default new EmptyEnv();
-`
-      );
+      helper.fs.outputFile('empty-env/empty-env.bit-env.ts', ENV_WITH_MARKER_SOURCE);
 
       helper.fixtures.populateComponents(1, false);
       helper.command.setEnv('comp1', 'empty-env');
@@ -151,18 +150,7 @@ export default new EmptyEnv();
       helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, compRemote.scopePath);
 
       helper.env.setEmptyEnv();
-      helper.fs.outputFile(
-        'empty-env/empty-env.bit-env.ts',
-        `
-import * as fs from 'fs';
-const marker = process.env.${MARKER_ENV_VAR};
-if (marker) {
-  try { fs.writeFileSync(marker, 'env-module-loaded'); } catch (e) { /* best effort */ }
-}
-export class EmptyEnv {}
-export default new EmptyEnv();
-`
-      );
+      helper.fs.outputFile('empty-env/empty-env.bit-env.ts', ENV_WITH_MARKER_SOURCE);
 
       helper.fixtures.populateComponents(1, false);
       helper.command.setEnv('comp1', 'empty-env');

--- a/e2e/harmony/scope-trust.e2e.ts
+++ b/e2e/harmony/scope-trust.e2e.ts
@@ -26,6 +26,7 @@ const MARKER_ENV_VAR = 'BIT_SCOPE_TRUST_TEST_MARKER';
     let npmCiRegistry: NpmCiRegistry;
     let markerPath: string;
     let originalMarkerEnv: string | undefined;
+    let importErrorOutput: string;
 
     before(async () => {
       // Stable absolute marker path; passed to spawned bit processes via the
@@ -82,11 +83,14 @@ export default new EmptyEnv();
       fs.removeSync(markerPath);
       expect(fs.existsSync(markerPath), 'marker should be absent before import').to.be.false;
 
+      // The aspect-load gate refuses; the import surfaces the refusal
+      // message. Capture both stdout and any thrown error so we can assert
+      // on the message (avoids a false positive if the import had failed for
+      // an unrelated reason like a network/registry hiccup).
       try {
-        helper.command.importComponent('comp1');
-      } catch {
-        // Aspect load refused → import command may exit non-zero. The
-        // marker-file check below is the source of truth.
+        importErrorOutput = helper.command.importComponent('comp1');
+      } catch (err: any) {
+        importErrorOutput = `${err?.stdout || ''}\n${err?.stderr || ''}\n${err?.message || ''}`;
       }
     });
 
@@ -102,6 +106,10 @@ export default new EmptyEnv();
 
     it('does not load the env from a scope outside the trust list', () => {
       expect(fs.existsSync(markerPath), `env module loaded; marker at ${markerPath}`).to.be.false;
+    });
+
+    it("surfaces a refusal message naming the scope that isn't on the trust list", () => {
+      expect(importErrorOutput).to.match(/isn't on the workspace's trusted list/i);
     });
   }
 );

--- a/e2e/performance/filesystem-read.e2e.ts
+++ b/e2e/performance/filesystem-read.e2e.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const MAX_FILES_READ = 1057;
+const MAX_FILES_READ = 1062;
 const MAX_FILES_READ_STATUS = 1500;
 
 /**

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -214,7 +214,11 @@ needed-for: ${neededFor || '<unknown>'}`);
       return new RequireableComponent(
         capsule.component,
         async () => {
-          // eslint-disable-next-line global-require, import/no-dynamic-require
+          // Honor the workspace's scope-trust hook if registered. Absent in
+          // pure scope (remote-server) contexts.
+          const guard = this.scope.getAspectLoadGuard();
+          if (guard) await guard(capsule.component.id);
+
           const plugins = this.aspectLoader.getPlugins(capsule.component, capsule.path);
           if (plugins.has()) {
             await this.compileIfNoDist(capsule, capsule.component);
@@ -227,7 +231,6 @@ needed-for: ${neededFor || '<unknown>'}`);
           const runtimePath = scopeRuntime || mainRuntime;
           // eslint-disable-next-line global-require, import/no-dynamic-require
           if (runtimePath) require(runtimePath);
-          // eslint-disable-next-line global-require, import/no-dynamic-require
           return aspect;
         },
         capsule

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -202,6 +202,21 @@ export class ScopeMain implements ComponentFactory {
   localAspects: string[] = [];
 
   /**
+   * Optional hook called immediately before an aspect is `require()`d from a
+   * scope-aspects capsule. Throws to refuse the load. The workspace aspect
+   * registers this to enforce the per-workspace scope-trust list.
+   */
+  private aspectLoadGuard?: (componentId: ComponentID) => Promise<void>;
+
+  setAspectLoadGuard(guard: (componentId: ComponentID) => Promise<void>): void {
+    this.aspectLoadGuard = guard;
+  }
+
+  getAspectLoadGuard(): ((componentId: ComponentID) => Promise<void>) | undefined {
+    return this.aspectLoadGuard;
+  }
+
+  /**
    * name of the scope
    */
   get name(): string {

--- a/scopes/workspace/workspace/scope-trust/index.ts
+++ b/scopes/workspace/workspace/scope-trust/index.ts
@@ -1,3 +1,3 @@
 export { ScopeTrust } from './scope-trust';
 export type { TrustedScopesGroups } from './scope-trust';
-export { ScopeTrustCmd, ScopeUntrustCmd } from './scope-trust.cmd';
+export { ScopeTrustCmd } from './scope-trust.cmd';

--- a/scopes/workspace/workspace/scope-trust/index.ts
+++ b/scopes/workspace/workspace/scope-trust/index.ts
@@ -1,3 +1,2 @@
 export { ScopeTrust } from './scope-trust';
-export type { TrustedScopesGroups } from './scope-trust';
 export { ScopeTrustCmd } from './scope-trust.cmd';

--- a/scopes/workspace/workspace/scope-trust/index.ts
+++ b/scopes/workspace/workspace/scope-trust/index.ts
@@ -1,0 +1,3 @@
+export { ScopeTrust } from './scope-trust';
+export type { TrustedScopesGroups } from './scope-trust';
+export { ScopeTrustCmd, ScopeUntrustCmd } from './scope-trust.cmd';

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -13,7 +13,7 @@ export class ScopeTrustCmd implements Command {
   arguments = [
     {
       name: 'action',
-      description: `one of: ${ACTIONS.join(' | ')}. defaults to "list".`,
+      description: `one of: ${ACTIONS.join(', ')}. defaults to "list".`,
     },
     {
       name: 'pattern',
@@ -30,12 +30,12 @@ export class ScopeTrustCmd implements Command {
   loadAspects = false;
   extendedDescription = `scope-trust is opt-in. when off (the default), aspects from any scope load without a check. when on, aspects from a scope outside the trust list trigger a prompt (interactive shells) or an error (non-interactive).
 
-  bit scope trust              # same as "list"
-  bit scope trust list         # show status; if on, print the effective trust list
-  bit scope trust enable       # turn on (writes "trustedScopes": [] to workspace.jsonc)
-  bit scope trust disable      # turn off (removes "trustedScopes" from workspace.jsonc)
-  bit scope trust add <p>      # add a pattern (auto-enables if needed)
-  bit scope trust remove <p>   # remove a pattern (does NOT disable when list is empty)
+  bit scope trust                    # same as "list"
+  bit scope trust list               # show status; if on, print the effective trust list
+  bit scope trust enable             # turn on (writes "trustedScopes": [] to workspace.jsonc)
+  bit scope trust disable            # turn off (removes "trustedScopes" from workspace.jsonc)
+  bit scope trust add PATTERN        # add a pattern (auto-enables if needed)
+  bit scope trust remove PATTERN     # remove a pattern (does NOT disable when list is empty)
 
 once on, the effective trust set is: builtin (teambit.*, bitdev.*) + the owner of defaultScope + entries listed under "trustedScopes". patterns are exact ("acme.frontend") or owner wildcard ("acme.*").`;
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -1,41 +1,82 @@
 import type { Command } from '@teambit/cli';
 import { formatSuccessSummary } from '@teambit/cli';
+import { BitError } from '@teambit/bit-error';
 import chalk from 'chalk';
 import type { ScopeTrust } from './scope-trust';
 
+const ACTIONS = ['list', 'enable', 'disable', 'add', 'remove'] as const;
+type Action = (typeof ACTIONS)[number];
+
 export class ScopeTrustCmd implements Command {
-  name = 'trust [scope-pattern]';
-  description = 'add a scope to the workspace trust list, or list trusted scopes when called without args';
+  name = 'trust [action] [pattern]';
+  description = "manage which scopes are trusted to load aspects (envs, etc.) into the workspace's process";
   arguments = [
     {
-      name: 'scope-pattern',
-      description: 'scope name (e.g. "acme.frontend") or owner wildcard (e.g. "acme.*")',
+      name: 'action',
+      description: `one of: ${ACTIONS.join(' | ')}. defaults to "list".`,
+    },
+    {
+      name: 'pattern',
+      description: 'scope pattern (required for "add" and "remove")',
     },
   ];
   options = [];
   group = 'component-config';
-  extendedDescription = `trusted scopes can ship aspects (envs, generators) whose code is \`require()\`d locally during \`bit import\` / \`bit compile\`. by default the workspace trusts:
-- builtin: teambit.*, bitdev.*
-- the owner of the workspace's defaultScope (e.g. defaultScope "acme.frontend" trusts "acme.*")
-- anything explicitly listed under "trustedScopes" in workspace.jsonc
+  extendedDescription = `scope-trust is opt-in. when off (the default), aspects from any scope load without a check. when on, aspects from a scope outside the trust list trigger a prompt (interactive shells) or an error (non-interactive).
 
-run \`bit scope trust\` (no args) to inspect the effective list. run \`bit scope untrust <pattern>\` to remove an entry.`;
+  bit scope trust              # same as "list"
+  bit scope trust list         # show status; if on, print the effective trust list
+  bit scope trust enable       # turn on (writes "trustedScopes": [] to workspace.jsonc)
+  bit scope trust disable      # turn off (removes "trustedScopes" from workspace.jsonc)
+  bit scope trust add <p>      # add a pattern (auto-enables if needed)
+  bit scope trust remove <p>   # remove a pattern (does NOT disable when list is empty)
+
+once on, the effective trust set is: builtin (teambit.*, bitdev.*) + the owner of defaultScope + entries listed under "trustedScopes". patterns are exact ("acme.frontend") or owner wildcard ("acme.*").`;
 
   constructor(private scopeTrust: ScopeTrust) {}
 
   async report(args: string[]): Promise<string> {
-    const scopePattern = args[0];
-    if (!scopePattern) {
-      return this.formatList();
+    const [rawAction, pattern] = args;
+    const action = (rawAction || 'list') as Action;
+    if (!ACTIONS.includes(action)) {
+      throw new BitError(`unknown action "${rawAction}". valid actions: ${ACTIONS.join(', ')}.`);
     }
-    await this.scopeTrust.addTrustedScope(scopePattern);
-    return formatSuccessSummary(`added ${chalk.bold(scopePattern)} to trustedScopes in workspace.jsonc`);
+    switch (action) {
+      case 'list':
+        return this.formatList();
+      case 'enable':
+        await this.scopeTrust.enable();
+        return formatSuccessSummary('scope-trust enabled (added trustedScopes: [] to workspace.jsonc)');
+      case 'disable':
+        await this.scopeTrust.disable();
+        return formatSuccessSummary('scope-trust disabled (removed trustedScopes from workspace.jsonc)');
+      case 'add':
+        if (!pattern) throw new BitError('"add" requires a pattern. example: bit scope trust add acme.frontend');
+        await this.scopeTrust.addTrustedScope(pattern);
+        return formatSuccessSummary(`added ${chalk.bold(pattern)} to trustedScopes in workspace.jsonc`);
+      case 'remove':
+        if (!pattern) throw new BitError('"remove" requires a pattern. example: bit scope trust remove acme.frontend');
+        await this.scopeTrust.removeTrustedScope(pattern);
+        return formatSuccessSummary(`removed ${chalk.bold(pattern)} from trustedScopes in workspace.jsonc`);
+      default:
+        throw new BitError(`unknown action "${action}". valid actions: ${ACTIONS.join(', ')}.`);
+    }
   }
 
   private formatList(): string {
+    if (!this.scopeTrust.isOptedIn()) {
+      return [
+        chalk.bold('scope-trust is off for this workspace.'),
+        'aspects from any scope load without a check.',
+        '',
+        'to turn on, run:',
+        '  bit scope trust enable           (no scopes added; only builtins + owner-of-defaultScope auto-trusted)',
+        '  bit scope trust add <pattern>    (turns on and adds the first scope)',
+      ].join('\n');
+    }
     const groups = this.scopeTrust.getEffectiveTrustedPatterns();
     const lines: string[] = [];
-    lines.push(chalk.bold('Trusted scopes (aspects from these scopes load without a prompt):'));
+    lines.push(chalk.bold('scope-trust is on. aspects from these scopes load without a prompt:'));
     lines.push('');
     lines.push(chalk.dim('builtin:'));
     groups.builtin.forEach((p) => lines.push(`  ${p}`));
@@ -47,27 +88,10 @@ run \`bit scope trust\` (no args) to inspect the effective list. run \`bit scope
     lines.push('');
     lines.push(chalk.dim('configured in workspace.jsonc:'));
     if (!groups.configured.length) {
-      lines.push(`  ${chalk.dim('(none — use `bit scope trust <pattern>` to add)')}`);
+      lines.push(`  ${chalk.dim('(none — use "bit scope trust add <pattern>" to add)')}`);
     } else {
       groups.configured.forEach((p) => lines.push(`  ${p}`));
     }
     return lines.join('\n');
-  }
-}
-
-export class ScopeUntrustCmd implements Command {
-  name = 'untrust <scope-pattern>';
-  description = 'remove a scope pattern from the workspace trust list (workspace.jsonc)';
-  arguments = [{ name: 'scope-pattern', description: 'pattern to remove (must match what was added)' }];
-  options = [];
-  group = 'component-config';
-  extendedDescription = `removes <scope-pattern> from "trustedScopes" under teambit.workspace/workspace in workspace.jsonc. builtin and owner-wildcard entries cannot be removed (they are computed at runtime).`;
-
-  constructor(private scopeTrust: ScopeTrust) {}
-
-  async report(args: string[]): Promise<string> {
-    const scopePattern = args[0];
-    await this.scopeTrust.removeTrustedScope(scopePattern);
-    return formatSuccessSummary(`removed ${chalk.bold(scopePattern)} from trustedScopes in workspace.jsonc`);
   }
 }

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -1,0 +1,73 @@
+import type { Command } from '@teambit/cli';
+import { formatSuccessSummary } from '@teambit/cli';
+import chalk from 'chalk';
+import type { ScopeTrust } from './scope-trust';
+
+export class ScopeTrustCmd implements Command {
+  name = 'trust [scope-pattern]';
+  description = 'add a scope to the workspace trust list, or list trusted scopes when called without args';
+  arguments = [
+    {
+      name: 'scope-pattern',
+      description: 'scope name (e.g. "acme.frontend") or owner wildcard (e.g. "acme.*")',
+    },
+  ];
+  options = [];
+  group = 'component-config';
+  extendedDescription = `trusted scopes can ship aspects (envs, generators) whose code is \`require()\`d locally during \`bit import\` / \`bit compile\`. by default the workspace trusts:
+- builtin: teambit.*, bitdev.*
+- the owner of the workspace's defaultScope (e.g. defaultScope "acme.frontend" trusts "acme.*")
+- anything explicitly listed under "trustedScopes" in workspace.jsonc
+
+run \`bit scope trust\` (no args) to inspect the effective list. run \`bit scope untrust <pattern>\` to remove an entry.`;
+
+  constructor(private scopeTrust: ScopeTrust) {}
+
+  async report(args: string[]): Promise<string> {
+    const scopePattern = args[0];
+    if (!scopePattern) {
+      return this.formatList();
+    }
+    await this.scopeTrust.addTrustedScope(scopePattern);
+    return formatSuccessSummary(`added ${chalk.bold(scopePattern)} to trustedScopes in workspace.jsonc`);
+  }
+
+  private formatList(): string {
+    const groups = this.scopeTrust.getEffectiveTrustedPatterns();
+    const lines: string[] = [];
+    lines.push(chalk.bold('Trusted scopes (aspects from these scopes load without a prompt):'));
+    lines.push('');
+    lines.push(chalk.dim('builtin:'));
+    groups.builtin.forEach((p) => lines.push(`  ${p}`));
+    if (groups.owner.length) {
+      lines.push('');
+      lines.push(chalk.dim('inferred from workspace defaultScope:'));
+      groups.owner.forEach((p) => lines.push(`  ${p}`));
+    }
+    lines.push('');
+    lines.push(chalk.dim('configured in workspace.jsonc:'));
+    if (!groups.configured.length) {
+      lines.push(`  ${chalk.dim('(none — use `bit scope trust <pattern>` to add)')}`);
+    } else {
+      groups.configured.forEach((p) => lines.push(`  ${p}`));
+    }
+    return lines.join('\n');
+  }
+}
+
+export class ScopeUntrustCmd implements Command {
+  name = 'untrust <scope-pattern>';
+  description = 'remove a scope pattern from the workspace trust list (workspace.jsonc)';
+  arguments = [{ name: 'scope-pattern', description: 'pattern to remove (must match what was added)' }];
+  options = [];
+  group = 'component-config';
+  extendedDescription = `removes <scope-pattern> from "trustedScopes" under teambit.workspace/workspace in workspace.jsonc. builtin and owner-wildcard entries cannot be removed (they are computed at runtime).`;
+
+  constructor(private scopeTrust: ScopeTrust) {}
+
+  async report(args: string[]): Promise<string> {
+    const scopePattern = args[0];
+    await this.scopeTrust.removeTrustedScope(scopePattern);
+    return formatSuccessSummary(`removed ${chalk.bold(scopePattern)} from trustedScopes in workspace.jsonc`);
+  }
+}

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -1,5 +1,5 @@
 import type { Command } from '@teambit/cli';
-import { formatSuccessSummary } from '@teambit/cli';
+import { formatHint, formatItem, formatSection, formatSuccessSummary, formatTitle, joinSections } from '@teambit/cli';
 import { BitError } from '@teambit/bit-error';
 import chalk from 'chalk';
 import type { ScopeTrust } from './scope-trust';
@@ -57,47 +57,51 @@ once on, the effective trust set is: builtin (teambit.*, bitdev.*) + the owner o
         await this.scopeTrust.disable();
         return formatSuccessSummary('scope-trust disabled (removed trustedScopes from workspace.jsonc)');
       case 'add':
-        if (!pattern) throw new BitError('"add" requires a pattern. example: bit scope trust add acme.frontend');
-        await this.scopeTrust.addTrustedScope(pattern);
+        await this.scopeTrust.addTrustedScope(requirePattern(action, pattern));
         return formatSuccessSummary(`added ${chalk.bold(pattern)} to trustedScopes in workspace.jsonc`);
       case 'remove':
-        if (!pattern) throw new BitError('"remove" requires a pattern. example: bit scope trust remove acme.frontend');
-        await this.scopeTrust.removeTrustedScope(pattern);
+        await this.scopeTrust.removeTrustedScope(requirePattern(action, pattern));
         return formatSuccessSummary(`removed ${chalk.bold(pattern)} from trustedScopes in workspace.jsonc`);
-      default:
-        throw new BitError(`unknown action "${action}". valid actions: ${ACTIONS.join(', ')}.`);
     }
   }
 
   private formatList(): string {
     if (!this.scopeTrust.isOptedIn()) {
-      return [
-        chalk.bold('scope-trust is off for this workspace.'),
+      return joinSections([
+        formatTitle('scope-trust is off for this workspace.'),
         'aspects from any scope load without a check.',
-        '',
-        'to turn on, run:',
-        '  bit scope trust enable           (no scopes added; only builtins + owner-of-defaultScope auto-trusted)',
-        '  bit scope trust add <pattern>    (turns on and adds the first scope)',
-      ].join('\n');
+        formatHint(
+          'to turn on:\n  bit scope trust enable        (no scopes added; only builtins + owner-of-defaultScope auto-trusted)\n  bit scope trust add <pattern> (turns on and adds the first scope)'
+        ),
+      ]);
     }
     const groups = this.scopeTrust.getEffectiveTrustedPatterns();
-    const lines: string[] = [];
-    lines.push(chalk.bold('scope-trust is on. aspects from these scopes load without a prompt:'));
-    lines.push('');
-    lines.push(chalk.dim('builtin:'));
-    groups.builtin.forEach((p) => lines.push(`  ${p}`));
-    if (groups.owner.length) {
-      lines.push('');
-      lines.push(chalk.dim('inferred from workspace defaultScope:'));
-      groups.owner.forEach((p) => lines.push(`  ${p}`));
-    }
-    lines.push('');
-    lines.push(chalk.dim('configured in workspace.jsonc:'));
-    if (!groups.configured.length) {
-      lines.push(`  ${chalk.dim('(none — use "bit scope trust add <pattern>" to add)')}`);
-    } else {
-      groups.configured.forEach((p) => lines.push(`  ${p}`));
-    }
-    return lines.join('\n');
+    return joinSections([
+      formatTitle('scope-trust is on. aspects from these scopes load without a prompt:'),
+      formatSection(
+        'builtin',
+        '',
+        groups.builtin.map((p) => formatItem(p))
+      ),
+      formatSection(
+        'inferred from workspace defaultScope',
+        '',
+        groups.owner.map((p) => formatItem(p))
+      ),
+      groups.configured.length
+        ? formatSection(
+            'configured in workspace.jsonc',
+            '',
+            groups.configured.map((p) => formatItem(p))
+          )
+        : formatHint('no scopes configured in workspace.jsonc. add one with `bit scope trust add <pattern>`.'),
+    ]);
   }
+}
+
+function requirePattern(action: Action, pattern: string | undefined): string {
+  if (!pattern) {
+    throw new BitError(`"${action}" requires a pattern. example: bit scope trust ${action} acme.frontend`);
+  }
+  return pattern;
 }

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -22,6 +22,12 @@ export class ScopeTrustCmd implements Command {
   ];
   options = [];
   group = 'component-config';
+  // Don't load aspects for this command. If the workspace already references
+  // an aspect from a scope that the trust list doesn't allow, the pre-command
+  // aspect-load step would itself trip the gate, leaving the user with no way
+  // to run `bit scope trust` to fix it. Skipping aspect-load keeps the command
+  // usable as a recovery path.
+  loadAspects = false;
   extendedDescription = `scope-trust is opt-in. when off (the default), aspects from any scope load without a check. when on, aspects from a scope outside the trust list trigger a prompt (interactive shells) or an error (non-interactive).
 
   bit scope trust              # same as "list"

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -37,7 +37,7 @@ export class ScopeTrustCmd implements Command {
   bit scope trust add PATTERN        # add a pattern (auto-enables if needed)
   bit scope trust remove PATTERN     # remove a pattern (does NOT disable when list is empty)
 
-once on, the effective trust set is: builtin (teambit.*, bitdev.*) + the owner of defaultScope + entries listed under "trustedScopes". patterns are exact ("acme.frontend") or owner wildcard ("acme.*").`;
+once on, the effective trust set is: builtin scopes (teambit.*, bitdev.*, and a few others — run "bit scope trust list" to see) + the owner of defaultScope + entries listed under "trustedScopes". patterns are exact ("acme.frontend") or owner wildcard ("acme.*").`;
 
   constructor(private scopeTrust: ScopeTrust) {}
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.cmd.ts
@@ -56,12 +56,16 @@ once on, the effective trust set is: builtin scopes (teambit.*, bitdev.*, and a 
       case 'disable':
         await this.scopeTrust.disable();
         return formatSuccessSummary('scope-trust disabled (removed trustedScopes from workspace.jsonc)');
-      case 'add':
-        await this.scopeTrust.addTrustedScope(requirePattern(action, pattern));
-        return formatSuccessSummary(`added ${chalk.bold(pattern)} to trustedScopes in workspace.jsonc`);
-      case 'remove':
-        await this.scopeTrust.removeTrustedScope(requirePattern(action, pattern));
-        return formatSuccessSummary(`removed ${chalk.bold(pattern)} from trustedScopes in workspace.jsonc`);
+      case 'add': {
+        const p = requirePattern(action, pattern);
+        await this.scopeTrust.addTrustedScope(p);
+        return formatSuccessSummary(`added ${chalk.bold(p)} to trustedScopes in workspace.jsonc`);
+      }
+      case 'remove': {
+        const p = requirePattern(action, pattern);
+        await this.scopeTrust.removeTrustedScope(p);
+        return formatSuccessSummary(`removed ${chalk.bold(p)} from trustedScopes in workspace.jsonc`);
+      }
     }
   }
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -106,12 +106,15 @@ export class ScopeTrust {
     const wsConfig = this.workspace.getWorkspaceConfig();
     const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
     if (Object.prototype.hasOwnProperty.call(existingExt, 'trustedScopes')) return;
-    const updated = { ...existingExt, trustedScopes: [] };
-    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    wsConfig.setExtension(WORKSPACE_ASPECT_ID, { trustedScopes: [] }, { mergeIntoExisting: true, ignoreVersion: true });
     await wsConfig.write({ reasonForChange: 'enable scope-trust' });
   }
 
-  /** Opt the workspace out by removing the `trustedScopes` key (idempotent). */
+  /**
+   * Opt the workspace out by removing the `trustedScopes` key (idempotent).
+   * Uses `overrideExisting` because key deletion isn't expressible via
+   * mergeIntoExisting; comments on other keys may be reformatted as a result.
+   */
   async disable(): Promise<void> {
     const wsConfig = this.workspace.getWorkspaceConfig();
     const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
@@ -126,15 +129,20 @@ export class ScopeTrust {
   async addTrustedScope(pattern: string): Promise<void> {
     if (!ScopeTrust.isValidPattern(pattern)) {
       throw new BitError(
-        `invalid scope pattern: "${pattern}". use an exact scope name (e.g. "acme.frontend") or an owner wildcard (e.g. "acme.*").`
+        `invalid scope pattern: "${pattern}". use an exact scope name (e.g. "acme.frontend" or "my-scope") or an owner wildcard (e.g. "acme.*").`
       );
     }
     const wsConfig = this.workspace.getWorkspaceConfig();
     const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
     const existingList: string[] = Array.isArray(existingExt.trustedScopes) ? existingExt.trustedScopes : [];
     if (existingList.includes(pattern)) return; // idempotent
-    const updated = { ...existingExt, trustedScopes: [...existingList, pattern] };
-    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    // mergeIntoExisting: only the trustedScopes key is rewritten; comments
+    // and other keys in workspace.jsonc are preserved.
+    wsConfig.setExtension(
+      WORKSPACE_ASPECT_ID,
+      { trustedScopes: [...existingList, pattern] },
+      { mergeIntoExisting: true, ignoreVersion: true }
+    );
     await wsConfig.write({ reasonForChange: `add trusted scope ${pattern}` });
   }
 
@@ -147,8 +155,11 @@ export class ScopeTrust {
     const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
     const existingList: string[] = Array.isArray(existingExt.trustedScopes) ? existingExt.trustedScopes : [];
     if (!existingList.includes(pattern)) return; // idempotent
-    const updated = { ...existingExt, trustedScopes: existingList.filter((p) => p !== pattern) };
-    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    wsConfig.setExtension(
+      WORKSPACE_ASPECT_ID,
+      { trustedScopes: existingList.filter((p) => p !== pattern) },
+      { mergeIntoExisting: true, ignoreVersion: true }
+    );
     await wsConfig.write({ reasonForChange: `remove trusted scope ${pattern}` });
   }
 
@@ -186,9 +197,16 @@ export class ScopeTrust {
 
   private deniedThisRun = new Set<string>();
 
+  /**
+   * Returns the trust pattern derived from the workspace's `defaultScope`:
+   * - `acme.frontend` → `acme.*` (owner wildcard)
+   * - `my-scope` (legacy dotless) → `my-scope` (exact match)
+   * - empty / unset → undefined
+   */
   private getOwnerWildcardFromDefaultScope(): string | undefined {
     const defaultScope = this.workspace.defaultScope;
     if (!defaultScope) return undefined;
+    if (!defaultScope.includes('.')) return defaultScope;
     const owner = defaultScope.split('.')[0];
     if (!owner) return undefined;
     return `${owner}.*`;
@@ -219,8 +237,8 @@ export class ScopeTrust {
       const owner = pattern.slice(0, -2);
       return /^[a-zA-Z0-9_-]+$/.test(owner);
     }
-    // exact: owner.name
-    return /^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_./-]+$/.test(pattern);
+    // exact: either dotless ("my-scope") or owner.name ("acme.frontend").
+    return /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_./-]+)?$/.test(pattern);
   }
 }
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -218,7 +218,7 @@ export class ScopeTrust {
         type: 'toggle',
         name: 'trust',
         message:
-          `Component ${componentId.toString()} uses an env from scope "${scopeName}", which isn't on your workspace's trusted list.\n` +
+          `Aspect ${componentId.toString()} comes from scope "${scopeName}", which isn't on your workspace's trusted list.\n` +
           `Trust "${scopeName}" and add it to workspace.jsonc?`,
         enabled: 'Yes',
         disabled: 'No',
@@ -238,7 +238,9 @@ export class ScopeTrust {
       return /^[a-zA-Z0-9_-]+$/.test(owner);
     }
     // exact: either dotless ("my-scope") or owner.name ("acme.frontend").
-    return /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_./-]+)?$/.test(pattern);
+    // Slash isn't allowed — scope names don't contain `/` (it separates scope
+    // from component name in component IDs).
+    return /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)?$/.test(pattern);
   }
 }
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -1,12 +1,15 @@
 import type { ComponentID } from '@teambit/component-id';
 import type { Logger } from '@teambit/logger';
 import { BitError } from '@teambit/bit-error';
+import { isValidScopeName } from '@teambit/legacy-bit-id';
 import { prompt } from 'enquirer';
 import type { Workspace } from '../workspace';
 
 const BUILTIN_TRUSTED_PATTERNS = ['teambit.*', 'bitdev.*'];
 
 const WORKSPACE_ASPECT_ID = 'teambit.workspace/workspace';
+
+const TRUSTED_SCOPES_KEY = 'trustedScopes';
 
 export type TrustedScopesGroups = {
   /** patterns built into Bit (`teambit.*`, `bitdev.*`) */
@@ -24,8 +27,8 @@ export type TrustedScopesGroups = {
  *
  * Once opted in, a scope is trusted if it matches any pattern in:
  * - the builtin set (`teambit.*`, `bitdev.*`),
- * - the owner wildcard derived from the workspace's `defaultScope`
- *   (e.g. `acme.frontend` → `acme.*`),
+ * - the pattern derived from the workspace's `defaultScope`
+ *   (e.g. `acme.frontend` → `acme.*`; legacy dotless `my-scope` → `my-scope`),
  * - the `trustedScopes` array configured in workspace.jsonc.
  *
  * Patterns are exact (`acme.frontend`) or owner wildcard (`acme.*`).
@@ -34,6 +37,8 @@ export type TrustedScopesGroups = {
  * aspect-loader path so untrusted aspects never reach `require()`.
  */
 export class ScopeTrust {
+  private deniedThisRun = new Set<string>();
+
   constructor(
     private workspace: Workspace,
     private logger: Logger
@@ -45,12 +50,7 @@ export class ScopeTrust {
    * gate is a no-op.
    */
   isOptedIn(): boolean {
-    try {
-      const ext = this.workspace.getWorkspaceConfig().extension(WORKSPACE_ASPECT_ID, true) || {};
-      return Object.prototype.hasOwnProperty.call(ext, 'trustedScopes');
-    } catch {
-      return false;
-    }
+    return Object.prototype.hasOwnProperty.call(this.readExt(), TRUSTED_SCOPES_KEY);
   }
 
   /**
@@ -58,22 +58,14 @@ export class ScopeTrust {
    * checks and the `bit scope trust list` UX.
    */
   getEffectiveTrustedPatterns(): TrustedScopesGroups {
-    const configured = this.readConfiguredPatterns();
-    const owner = this.getOwnerWildcardFromDefaultScope();
+    const ext = this.readExt();
+    const configured = Array.isArray(ext[TRUSTED_SCOPES_KEY]) ? (ext[TRUSTED_SCOPES_KEY] as string[]).slice() : [];
+    const owner = this.getInferredOwnerPattern();
     return {
       builtin: BUILTIN_TRUSTED_PATTERNS.slice(),
       owner: owner ? [owner] : [],
       configured,
     };
-  }
-
-  private readConfiguredPatterns(): string[] {
-    try {
-      const ext = this.workspace.getWorkspaceConfig().extension(WORKSPACE_ASPECT_ID, true) || {};
-      return Array.isArray(ext.trustedScopes) ? ext.trustedScopes.slice() : [];
-    } catch {
-      return [];
-    }
   }
 
   /**
@@ -103,24 +95,20 @@ export class ScopeTrust {
 
   /** Opt the workspace in by writing `trustedScopes: []` (idempotent). */
   async enable(): Promise<void> {
-    const wsConfig = this.workspace.getWorkspaceConfig();
-    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
-    if (Object.prototype.hasOwnProperty.call(existingExt, 'trustedScopes')) return;
-    wsConfig.setExtension(WORKSPACE_ASPECT_ID, { trustedScopes: [] }, { mergeIntoExisting: true, ignoreVersion: true });
-    await wsConfig.write({ reasonForChange: 'enable scope-trust' });
+    if (this.isOptedIn()) return;
+    await this.writeExtPatch({ [TRUSTED_SCOPES_KEY]: [] }, 'enable scope-trust');
   }
 
   /**
    * Opt the workspace out by removing the `trustedScopes` key (idempotent).
    * Uses `overrideExisting` because key deletion isn't expressible via
-   * mergeIntoExisting; comments on other keys may be reformatted as a result.
+   * `mergeIntoExisting`; comments on other keys may be reformatted as a result.
    */
   async disable(): Promise<void> {
+    if (!this.isOptedIn()) return;
+    const updated = { ...this.readExt() };
+    delete updated[TRUSTED_SCOPES_KEY];
     const wsConfig = this.workspace.getWorkspaceConfig();
-    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
-    if (!Object.prototype.hasOwnProperty.call(existingExt, 'trustedScopes')) return;
-    const updated = { ...existingExt };
-    delete updated.trustedScopes;
     wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
     await wsConfig.write({ reasonForChange: 'disable scope-trust' });
   }
@@ -132,18 +120,10 @@ export class ScopeTrust {
         `invalid scope pattern: "${pattern}". use an exact scope name (e.g. "acme.frontend" or "my-scope") or an owner wildcard (e.g. "acme.*").`
       );
     }
-    const wsConfig = this.workspace.getWorkspaceConfig();
-    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
-    const existingList: string[] = Array.isArray(existingExt.trustedScopes) ? existingExt.trustedScopes : [];
-    if (existingList.includes(pattern)) return; // idempotent
-    // mergeIntoExisting: only the trustedScopes key is rewritten; comments
-    // and other keys in workspace.jsonc are preserved.
-    wsConfig.setExtension(
-      WORKSPACE_ASPECT_ID,
-      { trustedScopes: [...existingList, pattern] },
-      { mergeIntoExisting: true, ignoreVersion: true }
+    await this.mutateConfiguredList(
+      (list) => (list.includes(pattern) ? null : [...list, pattern]),
+      `add trusted scope ${pattern}`
     );
-    await wsConfig.write({ reasonForChange: `add trusted scope ${pattern}` });
   }
 
   /**
@@ -151,16 +131,10 @@ export class ScopeTrust {
    * the list becomes empty — use `disable()` to fully turn the gate off.
    */
   async removeTrustedScope(pattern: string): Promise<void> {
-    const wsConfig = this.workspace.getWorkspaceConfig();
-    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
-    const existingList: string[] = Array.isArray(existingExt.trustedScopes) ? existingExt.trustedScopes : [];
-    if (!existingList.includes(pattern)) return; // idempotent
-    wsConfig.setExtension(
-      WORKSPACE_ASPECT_ID,
-      { trustedScopes: existingList.filter((p) => p !== pattern) },
-      { mergeIntoExisting: true, ignoreVersion: true }
+    await this.mutateConfiguredList(
+      (list) => (list.includes(pattern) ? list.filter((p) => p !== pattern) : null),
+      `remove trusted scope ${pattern}`
     );
-    await wsConfig.write({ reasonForChange: `remove trusted scope ${pattern}` });
   }
 
   /**
@@ -174,28 +148,56 @@ export class ScopeTrust {
       const scopeName = componentId.scope;
       if (this.isScopeTrusted(scopeName)) return;
 
-      // Don't prompt twice for the same untrusted scope in a single run.
-      // The user's answer is persisted to workspace.jsonc on accept.
-      if (this.deniedThisRun.has(scopeName)) {
+      const deny = (): never => {
         throw makeUntrustedError(scopeName, componentId);
-      }
+      };
+
+      // The user's answer is persisted to workspace.jsonc on accept; remember
+      // a denial so we don't re-prompt for the same scope in this run.
+      if (this.deniedThisRun.has(scopeName)) deny();
 
       const isInteractive = Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
-      if (!isInteractive) {
-        throw makeUntrustedError(scopeName, componentId);
-      }
+      if (!isInteractive) deny();
 
       const accepted = await this.promptForTrust(scopeName, componentId);
       if (!accepted) {
         this.deniedThisRun.add(scopeName);
-        throw makeUntrustedError(scopeName, componentId);
+        deny();
       }
       await this.addTrustedScope(scopeName);
       this.logger.consoleSuccess(`added "${scopeName}" to trustedScopes in workspace.jsonc`);
     };
   }
 
-  private deniedThisRun = new Set<string>();
+  private readExt(): Record<string, unknown> {
+    try {
+      return (this.workspace.getWorkspaceConfig().extension(WORKSPACE_ASPECT_ID, true) || {}) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Apply `mutator` to the current `trustedScopes` list. If the mutator
+   * returns `null`, treat the call as a no-op (idempotent fast path).
+   * Uses `mergeIntoExisting` so other keys' comments are preserved.
+   */
+  private async mutateConfiguredList(mutator: (list: string[]) => string[] | null, reason: string): Promise<void> {
+    const ext = this.readExt();
+    const current: string[] = Array.isArray(ext[TRUSTED_SCOPES_KEY]) ? (ext[TRUSTED_SCOPES_KEY] as string[]) : [];
+    const next = mutator(current);
+    if (next === null) return;
+    await this.writeExtPatch({ [TRUSTED_SCOPES_KEY]: next }, reason);
+  }
+
+  private async writeExtPatch(patch: Record<string, unknown>, reason: string): Promise<void> {
+    const wsConfig = this.workspace.getWorkspaceConfig();
+    wsConfig.setExtension(WORKSPACE_ASPECT_ID, patch, { mergeIntoExisting: true, ignoreVersion: true });
+    await wsConfig.write({ reasonForChange: reason });
+  }
 
   /**
    * Returns the trust pattern derived from the workspace's `defaultScope`:
@@ -203,7 +205,7 @@ export class ScopeTrust {
    * - `my-scope` (legacy dotless) → `my-scope` (exact match)
    * - empty / unset → undefined
    */
-  private getOwnerWildcardFromDefaultScope(): string | undefined {
+  private getInferredOwnerPattern(): string | undefined {
     const defaultScope = this.workspace.defaultScope;
     if (!defaultScope) return undefined;
     if (!defaultScope.includes('.')) return defaultScope;
@@ -223,7 +225,9 @@ export class ScopeTrust {
         enabled: 'Yes',
         disabled: 'No',
         initial: false,
-      } as any)) as { trust: boolean };
+        // The `toggle` prompt's option type isn't exported by enquirer's main
+        // typings; cast just the literal so the rest of the call stays typed.
+      } as Parameters<typeof prompt>[0])) as { trust: boolean };
       return Boolean(response.trust);
     } catch {
       // user cancelled the prompt (Ctrl+C etc.)
@@ -233,14 +237,11 @@ export class ScopeTrust {
 
   static isValidPattern(pattern: string): boolean {
     if (!pattern || typeof pattern !== 'string') return false;
-    if (pattern.endsWith('.*')) {
-      const owner = pattern.slice(0, -2);
-      return /^[a-zA-Z0-9_-]+$/.test(owner);
-    }
-    // exact: either dotless ("my-scope") or owner.name ("acme.frontend").
-    // Slash isn't allowed — scope names don't contain `/` (it separates scope
-    // from component name in component IDs).
-    return /^[a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)?$/.test(pattern);
+    // owner wildcard ("acme.*"): the prefix without the trailing ".*" must be
+    // a valid scope-owner segment. The owner alone ("acme") is itself a valid
+    // dotless scope name, so reuse the canonical scope-name validator.
+    const candidate = pattern.endsWith('.*') ? pattern.slice(0, -2) : pattern;
+    return isValidScopeName(candidate);
   }
 }
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -18,10 +18,11 @@ export type TrustedScopesGroups = {
 };
 
 /**
- * Workspace-level scope-trust policy. Determines which scopes' aspects
- * (envs, generators, etc.) may be loaded into the host process.
+ * Workspace-level scope-trust policy. Opt-in: when the `trustedScopes` key is
+ * present in workspace.jsonc (even as an empty array), the aspect-load gate
+ * is active. When the key is absent, no gate runs and any aspect loads.
  *
- * A scope is trusted if it matches any pattern in:
+ * Once opted in, a scope is trusted if it matches any pattern in:
  * - the builtin set (`teambit.*`, `bitdev.*`),
  * - the owner wildcard derived from the workspace's `defaultScope`
  *   (e.g. `acme.frontend` → `acme.*`),
@@ -39,8 +40,22 @@ export class ScopeTrust {
   ) {}
 
   /**
+   * `true` when the workspace has opted in (the `trustedScopes` key is present
+   * in workspace.jsonc, even as an empty array). When `false`, the aspect-load
+   * gate is a no-op.
+   */
+  isOptedIn(): boolean {
+    try {
+      const ext = this.workspace.getWorkspaceConfig().extension(WORKSPACE_ASPECT_ID, true) || {};
+      return Object.prototype.hasOwnProperty.call(ext, 'trustedScopes');
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Effective trust list, broken down by source. Useful for both internal
-   * checks and the `bit scope trust` listing UX.
+   * checks and the `bit scope trust list` UX.
    */
   getEffectiveTrustedPatterns(): TrustedScopesGroups {
     const configured = this.readConfiguredPatterns();
@@ -86,11 +101,32 @@ export class ScopeTrust {
     return false;
   }
 
-  /** Add `pattern` to `trustedScopes` in workspace.jsonc and persist. */
+  /** Opt the workspace in by writing `trustedScopes: []` (idempotent). */
+  async enable(): Promise<void> {
+    const wsConfig = this.workspace.getWorkspaceConfig();
+    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
+    if (Object.prototype.hasOwnProperty.call(existingExt, 'trustedScopes')) return;
+    const updated = { ...existingExt, trustedScopes: [] };
+    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    await wsConfig.write({ reasonForChange: 'enable scope-trust' });
+  }
+
+  /** Opt the workspace out by removing the `trustedScopes` key (idempotent). */
+  async disable(): Promise<void> {
+    const wsConfig = this.workspace.getWorkspaceConfig();
+    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
+    if (!Object.prototype.hasOwnProperty.call(existingExt, 'trustedScopes')) return;
+    const updated = { ...existingExt };
+    delete updated.trustedScopes;
+    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    await wsConfig.write({ reasonForChange: 'disable scope-trust' });
+  }
+
+  /** Add `pattern` to `trustedScopes` (auto-enables if not yet). */
   async addTrustedScope(pattern: string): Promise<void> {
     if (!ScopeTrust.isValidPattern(pattern)) {
       throw new BitError(
-        `invalid scope pattern: "${pattern}". Use an exact scope name (e.g. "acme.frontend") or an owner wildcard (e.g. "acme.*").`
+        `invalid scope pattern: "${pattern}". use an exact scope name (e.g. "acme.frontend") or an owner wildcard (e.g. "acme.*").`
       );
     }
     const wsConfig = this.workspace.getWorkspaceConfig();
@@ -102,7 +138,10 @@ export class ScopeTrust {
     await wsConfig.write({ reasonForChange: `add trusted scope ${pattern}` });
   }
 
-  /** Remove `pattern` from `trustedScopes` in workspace.jsonc and persist. */
+  /**
+   * Remove `pattern` from `trustedScopes`. Leaves the key in place even if
+   * the list becomes empty — use `disable()` to fully turn the gate off.
+   */
   async removeTrustedScope(pattern: string): Promise<void> {
     const wsConfig = this.workspace.getWorkspaceConfig();
     const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
@@ -114,12 +153,13 @@ export class ScopeTrust {
   }
 
   /**
-   * Build the guard that scope-aspects-loader calls before each `require()`.
-   * Throws to refuse the load. Throws with TOFU-prompt outcome on TTY,
-   * otherwise with a clear instructional error.
+   * Build the aspect-load guard. No-op when not opted in. When opted in:
+   * untrusted scopes get a TTY prompt to extend the trust list, or in
+   * non-TTY contexts an instructional error.
    */
   createGuard(): (componentId: ComponentID) => Promise<void> {
     return async (componentId: ComponentID) => {
+      if (!this.isOptedIn()) return;
       const scopeName = componentId.scope;
       if (this.isScopeTrusted(scopeName)) return;
 
@@ -189,7 +229,7 @@ function makeUntrustedError(scopeName: string, componentId: ComponentID): BitErr
     `cannot load aspect ${componentId.toString()}: scope "${scopeName}" isn't on the workspace's trusted list.\n` +
       `\n` +
       `to trust this scope, run:\n` +
-      `  bit scope trust ${scopeName}\n` +
+      `  bit scope trust add ${scopeName}\n` +
       `or add it to "trustedScopes" under "${WORKSPACE_ASPECT_ID}" in workspace.jsonc.`
   );
 }

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -1,0 +1,195 @@
+import type { ComponentID } from '@teambit/component-id';
+import type { Logger } from '@teambit/logger';
+import { BitError } from '@teambit/bit-error';
+import { prompt } from 'enquirer';
+import type { Workspace } from '../workspace';
+
+const BUILTIN_TRUSTED_PATTERNS = ['teambit.*', 'bitdev.*'];
+
+const WORKSPACE_ASPECT_ID = 'teambit.workspace/workspace';
+
+export type TrustedScopesGroups = {
+  /** patterns built into Bit (`teambit.*`, `bitdev.*`) */
+  builtin: string[];
+  /** owner wildcard inferred from `defaultScope` (e.g. `acme.frontend` → `acme.*`) */
+  owner: string[];
+  /** patterns explicitly configured in `workspace.jsonc` under `trustedScopes` */
+  configured: string[];
+};
+
+/**
+ * Workspace-level scope-trust policy. Determines which scopes' aspects
+ * (envs, generators, etc.) may be loaded into the host process.
+ *
+ * A scope is trusted if it matches any pattern in:
+ * - the builtin set (`teambit.*`, `bitdev.*`),
+ * - the owner wildcard derived from the workspace's `defaultScope`
+ *   (e.g. `acme.frontend` → `acme.*`),
+ * - the `trustedScopes` array configured in workspace.jsonc.
+ *
+ * Patterns are exact (`acme.frontend`) or owner wildcard (`acme.*`).
+ *
+ * Wired into `ScopeMain` via `setAspectLoadGuard`; the guard runs in the
+ * aspect-loader path so untrusted aspects never reach `require()`.
+ */
+export class ScopeTrust {
+  constructor(
+    private workspace: Workspace,
+    private logger: Logger
+  ) {}
+
+  /**
+   * Effective trust list, broken down by source. Useful for both internal
+   * checks and the `bit scope trust` listing UX.
+   */
+  getEffectiveTrustedPatterns(): TrustedScopesGroups {
+    const configured = this.readConfiguredPatterns();
+    const owner = this.getOwnerWildcardFromDefaultScope();
+    return {
+      builtin: BUILTIN_TRUSTED_PATTERNS.slice(),
+      owner: owner ? [owner] : [],
+      configured,
+    };
+  }
+
+  private readConfiguredPatterns(): string[] {
+    try {
+      const ext = this.workspace.getWorkspaceConfig().extension(WORKSPACE_ASPECT_ID, true) || {};
+      return Array.isArray(ext.trustedScopes) ? ext.trustedScopes.slice() : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * True iff `scopeName` matches any pattern in the effective trust list.
+   * `scopeName` is expected to be the bare scope (e.g. `acme.frontend`).
+   */
+  isScopeTrusted(scopeName: string): boolean {
+    if (!scopeName) return false;
+    const groups = this.getEffectiveTrustedPatterns();
+    const all = [...groups.builtin, ...groups.owner, ...groups.configured];
+    return all.some((pattern) => ScopeTrust.matchesPattern(scopeName, pattern));
+  }
+
+  /**
+   * Pattern matcher. Two forms:
+   * - exact: `acme.frontend` matches only `acme.frontend`.
+   * - owner wildcard: `acme.*` matches `acme.<anything>`.
+   */
+  static matchesPattern(scopeName: string, pattern: string): boolean {
+    if (pattern === scopeName) return true;
+    if (pattern.endsWith('.*')) {
+      const owner = pattern.slice(0, -2);
+      return scopeName.startsWith(`${owner}.`);
+    }
+    return false;
+  }
+
+  /** Add `pattern` to `trustedScopes` in workspace.jsonc and persist. */
+  async addTrustedScope(pattern: string): Promise<void> {
+    if (!ScopeTrust.isValidPattern(pattern)) {
+      throw new BitError(
+        `invalid scope pattern: "${pattern}". Use an exact scope name (e.g. "acme.frontend") or an owner wildcard (e.g. "acme.*").`
+      );
+    }
+    const wsConfig = this.workspace.getWorkspaceConfig();
+    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
+    const existingList: string[] = Array.isArray(existingExt.trustedScopes) ? existingExt.trustedScopes : [];
+    if (existingList.includes(pattern)) return; // idempotent
+    const updated = { ...existingExt, trustedScopes: [...existingList, pattern] };
+    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    await wsConfig.write({ reasonForChange: `add trusted scope ${pattern}` });
+  }
+
+  /** Remove `pattern` from `trustedScopes` in workspace.jsonc and persist. */
+  async removeTrustedScope(pattern: string): Promise<void> {
+    const wsConfig = this.workspace.getWorkspaceConfig();
+    const existingExt = wsConfig.extension(WORKSPACE_ASPECT_ID, true) || {};
+    const existingList: string[] = Array.isArray(existingExt.trustedScopes) ? existingExt.trustedScopes : [];
+    if (!existingList.includes(pattern)) return; // idempotent
+    const updated = { ...existingExt, trustedScopes: existingList.filter((p) => p !== pattern) };
+    wsConfig.setExtension(WORKSPACE_ASPECT_ID, updated, { overrideExisting: true, ignoreVersion: true });
+    await wsConfig.write({ reasonForChange: `remove trusted scope ${pattern}` });
+  }
+
+  /**
+   * Build the guard that scope-aspects-loader calls before each `require()`.
+   * Throws to refuse the load. Throws with TOFU-prompt outcome on TTY,
+   * otherwise with a clear instructional error.
+   */
+  createGuard(): (componentId: ComponentID) => Promise<void> {
+    return async (componentId: ComponentID) => {
+      const scopeName = componentId.scope;
+      if (this.isScopeTrusted(scopeName)) return;
+
+      // Don't prompt twice for the same untrusted scope in a single run.
+      // The user's answer is persisted to workspace.jsonc on accept.
+      if (this.deniedThisRun.has(scopeName)) {
+        throw makeUntrustedError(scopeName, componentId);
+      }
+
+      const isInteractive = Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
+      if (!isInteractive) {
+        throw makeUntrustedError(scopeName, componentId);
+      }
+
+      const accepted = await this.promptForTrust(scopeName, componentId);
+      if (!accepted) {
+        this.deniedThisRun.add(scopeName);
+        throw makeUntrustedError(scopeName, componentId);
+      }
+      await this.addTrustedScope(scopeName);
+      this.logger.consoleSuccess(`added "${scopeName}" to trustedScopes in workspace.jsonc`);
+    };
+  }
+
+  private deniedThisRun = new Set<string>();
+
+  private getOwnerWildcardFromDefaultScope(): string | undefined {
+    const defaultScope = this.workspace.defaultScope;
+    if (!defaultScope) return undefined;
+    const owner = defaultScope.split('.')[0];
+    if (!owner) return undefined;
+    return `${owner}.*`;
+  }
+
+  private async promptForTrust(scopeName: string, componentId: ComponentID): Promise<boolean> {
+    try {
+      const response = (await prompt({
+        type: 'toggle',
+        name: 'trust',
+        message:
+          `Component ${componentId.toString()} uses an env from scope "${scopeName}", which isn't on your workspace's trusted list.\n` +
+          `Trust "${scopeName}" and add it to workspace.jsonc?`,
+        enabled: 'Yes',
+        disabled: 'No',
+        initial: false,
+      } as any)) as { trust: boolean };
+      return Boolean(response.trust);
+    } catch {
+      // user cancelled the prompt (Ctrl+C etc.)
+      return false;
+    }
+  }
+
+  static isValidPattern(pattern: string): boolean {
+    if (!pattern || typeof pattern !== 'string') return false;
+    if (pattern.endsWith('.*')) {
+      const owner = pattern.slice(0, -2);
+      return /^[a-zA-Z0-9_-]+$/.test(owner);
+    }
+    // exact: owner.name
+    return /^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_./-]+$/.test(pattern);
+  }
+}
+
+function makeUntrustedError(scopeName: string, componentId: ComponentID): BitError {
+  return new BitError(
+    `cannot load aspect ${componentId.toString()}: scope "${scopeName}" isn't on the workspace's trusted list.\n` +
+      `\n` +
+      `to trust this scope, run:\n` +
+      `  bit scope trust ${scopeName}\n` +
+      `or add it to "trustedScopes" under "${WORKSPACE_ASPECT_ID}" in workspace.jsonc.`
+  );
+}

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -237,11 +237,15 @@ export class ScopeTrust {
 
   static isValidPattern(pattern: string): boolean {
     if (!pattern || typeof pattern !== 'string') return false;
-    // owner wildcard ("acme.*"): the prefix without the trailing ".*" must be
-    // a valid scope-owner segment. The owner alone ("acme") is itself a valid
-    // dotless scope name, so reuse the canonical scope-name validator.
-    const candidate = pattern.endsWith('.*') ? pattern.slice(0, -2) : pattern;
-    return isValidScopeName(candidate);
+    if (pattern.endsWith('.*')) {
+      const owner = pattern.slice(0, -2);
+      // wildcard must be a single owner segment ("acme.*"), not nested
+      // ("acme.frontend.*") — the matcher only consults scope owners.
+      if (owner.includes('.')) return false;
+      return isValidScopeName(owner);
+    }
+    // exact match: "acme.frontend" or dotless legacy "my-scope".
+    return isValidScopeName(pattern);
   }
 }
 

--- a/scopes/workspace/workspace/scope-trust/scope-trust.ts
+++ b/scopes/workspace/workspace/scope-trust/scope-trust.ts
@@ -5,14 +5,14 @@ import { isValidScopeName } from '@teambit/legacy-bit-id';
 import { prompt } from 'enquirer';
 import type { Workspace } from '../workspace';
 
-const BUILTIN_TRUSTED_PATTERNS = ['teambit.*', 'bitdev.*'];
+const BUILTIN_TRUSTED_PATTERNS = ['teambit.*', 'bitdev.*', 'learn-bit-react.*', 'bitdesign.*', 'frontend.*'];
 
 const WORKSPACE_ASPECT_ID = 'teambit.workspace/workspace';
 
 const TRUSTED_SCOPES_KEY = 'trustedScopes';
 
 export type TrustedScopesGroups = {
-  /** patterns built into Bit (`teambit.*`, `bitdev.*`) */
+  /** patterns built into Bit (e.g. `teambit.*`, `bitdev.*`) */
   builtin: string[];
   /** owner wildcard inferred from `defaultScope` (e.g. `acme.frontend` → `acme.*`) */
   owner: string[];
@@ -26,7 +26,7 @@ export type TrustedScopesGroups = {
  * is active. When the key is absent, no gate runs and any aspect loads.
  *
  * Once opted in, a scope is trusted if it matches any pattern in:
- * - the builtin set (`teambit.*`, `bitdev.*`),
+ * - the builtin set (e.g. `teambit.*`, `bitdev.*`; see `BUILTIN_TRUSTED_PATTERNS`),
  * - the pattern derived from the workspace's `defaultScope`
  *   (e.g. `acme.frontend` → `acme.*`; legacy dotless `my-scope` → `my-scope`),
  * - the `trustedScopes` array configured in workspace.jsonc.

--- a/scopes/workspace/workspace/types.ts
+++ b/scopes/workspace/workspace/types.ts
@@ -93,6 +93,17 @@ export interface WorkspaceExtConfig {
   ignoredFiles?: string[];
 
   /**
+   * Scope-name patterns that the workspace trusts when loading aspects (envs,
+   * generators, etc.) imported from those scopes. The effective trust set is:
+   * builtin (`teambit.*`, `bitdev.*`) + the owner of `defaultScope` (e.g.
+   * `acme.frontend` → `acme.*`) + entries listed here.
+   *
+   * Patterns: exact (`acme.frontend`) or owner wildcard (`acme.*`).
+   * Manage via `bit scope trust` / `bit scope untrust`.
+   */
+  trustedScopes?: string[];
+
+  /**
    * If set to `true`, Bit auto-syncs the local `.bitmap` to the latest scope HEAD versions
    * whenever the git HEAD has moved since the last sync (sentinel-driven, runs once per
    * `git pull`). Designed for repos with strict branch-protection rules: combined with

--- a/scopes/workspace/workspace/types.ts
+++ b/scopes/workspace/workspace/types.ts
@@ -99,7 +99,7 @@ export interface WorkspaceExtConfig {
    * `acme.frontend` → `acme.*`) + entries listed here.
    *
    * Patterns: exact (`acme.frontend`) or owner wildcard (`acme.*`).
-   * Manage via `bit scope trust` / `bit scope untrust`.
+   * Manage via `bit scope trust [enable|disable|add|remove] [pattern]`.
    */
   trustedScopes?: string[];
 

--- a/scopes/workspace/workspace/types.ts
+++ b/scopes/workspace/workspace/types.ts
@@ -95,8 +95,8 @@ export interface WorkspaceExtConfig {
   /**
    * Scope-name patterns that the workspace trusts when loading aspects (envs,
    * generators, etc.) imported from those scopes. The effective trust set is:
-   * builtin (`teambit.*`, `bitdev.*`) + the owner of `defaultScope` (e.g.
-   * `acme.frontend` → `acme.*`) + entries listed here.
+   * a builtin set (e.g. `teambit.*`, `bitdev.*`) + the owner of `defaultScope`
+   * (e.g. `acme.frontend` → `acme.*`) + entries listed here.
    *
    * Patterns: exact (`acme.frontend`) or owner wildcard (`acme.*`).
    * Manage via `bit scope trust [enable|disable|add|remove] [pattern]`.

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -490,6 +490,11 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
       const component = aspectDef.component;
       if (!component) return undefined;
       const requireFunc = async () => {
+        // Honor the workspace's scope-trust hook (registered on ScopeMain).
+        // Workspace and scope-aspects-loader take parallel require paths.
+        const guard = this.scope.getAspectLoadGuard();
+        if (guard) await guard(component.id);
+
         const plugins = this.aspectLoader.getPlugins(component, localPath);
         if (plugins.has()) {
           return plugins.load(MainRuntime.name);

--- a/scopes/workspace/workspace/workspace.main.runtime.ts
+++ b/scopes/workspace/workspace/workspace.main.runtime.ts
@@ -47,6 +47,7 @@ import { EnvsUnsetCmd } from './envs-subcommands/envs-unset.cmd';
 import { PatternCommand } from './pattern.cmd';
 import { EnvsReplaceCmd } from './envs-subcommands/envs-replace.cmd';
 import { ScopeSetCmd } from './scope-subcommands/scope-set.cmd';
+import { ScopeTrust, ScopeTrustCmd, ScopeUntrustCmd } from './scope-trust';
 import { UseCmd } from './use.cmd';
 import { EnvsUpdateCmd } from './envs-subcommands/envs-update.cmd';
 import { UnuseCmd } from './unuse.cmd';
@@ -333,6 +334,13 @@ export class WorkspaceMain {
     // add sub-command "set" to scope command.
     const scopeCommand = cli.getCommand('scope');
     scopeCommand?.commands?.push(new ScopeSetCmd(workspace));
+
+    // Workspace scope-trust: aspect-load hook wired into ScopeMain, plus the
+    // bit scope trust / bit scope untrust subcommands.
+    const scopeTrust = new ScopeTrust(workspace, logger);
+    scope.setAspectLoadGuard(scopeTrust.createGuard());
+    scopeCommand?.commands?.push(new ScopeTrustCmd(scopeTrust));
+    scopeCommand?.commands?.push(new ScopeUntrustCmd(scopeTrust));
 
     return workspace;
   }

--- a/scopes/workspace/workspace/workspace.main.runtime.ts
+++ b/scopes/workspace/workspace/workspace.main.runtime.ts
@@ -47,7 +47,7 @@ import { EnvsUnsetCmd } from './envs-subcommands/envs-unset.cmd';
 import { PatternCommand } from './pattern.cmd';
 import { EnvsReplaceCmd } from './envs-subcommands/envs-replace.cmd';
 import { ScopeSetCmd } from './scope-subcommands/scope-set.cmd';
-import { ScopeTrust, ScopeTrustCmd, ScopeUntrustCmd } from './scope-trust';
+import { ScopeTrust, ScopeTrustCmd } from './scope-trust';
 import { UseCmd } from './use.cmd';
 import { EnvsUpdateCmd } from './envs-subcommands/envs-update.cmd';
 import { UnuseCmd } from './unuse.cmd';
@@ -336,11 +336,10 @@ export class WorkspaceMain {
     scopeCommand?.commands?.push(new ScopeSetCmd(workspace));
 
     // Workspace scope-trust: aspect-load hook wired into ScopeMain, plus the
-    // bit scope trust / bit scope untrust subcommands.
+    // bit scope trust subcommand. Opt-in via workspace.jsonc.
     const scopeTrust = new ScopeTrust(workspace, logger);
     scope.setAspectLoadGuard(scopeTrust.createGuard());
     scopeCommand?.commands?.push(new ScopeTrustCmd(scopeTrust));
-    scopeCommand?.commands?.push(new ScopeUntrustCmd(scopeTrust));
 
     return workspace;
   }


### PR DESCRIPTION
**Opt-in workspace policy.** When the workspace declares `trustedScopes` in workspace.jsonc, Bit checks the scope of every aspect (env, generator, etc.) before loading it. Without that key, behavior is unchanged — anything loads.

Once enabled, the effective trust set is:

- builtin: `teambit.*`, `bitdev.*`, `learn-bit-react.*`, `bitdesign.*`, `frontend.*` (the bit.cloud orgs that ship official + community-blessed components most users already pull from)
- the owner of `defaultScope` (e.g. `acme.frontend` → `acme.*`)
- entries listed under `trustedScopes` in workspace.jsonc

If an aspect's scope isn't on that list, an interactive shell prompts the user to add it; non-interactive contexts (CI) get an error pointing at `bit scope trust add <scope>` or workspace.jsonc.

## Surface

- `trustedScopes?: string[]` on `teambit.workspace/workspace`
- `bit scope trust [action] [pattern]` — single command with action positional
  - `list` (default) — status; if on, the effective list
  - `enable` — opt-in (writes `trustedScopes: []`)
  - `disable` — opt-out (removes the key)
  - `add <pattern>` — add pattern (auto-enables)
  - `remove <pattern>` — remove pattern (does NOT auto-disable on empty)
- aspect-load hook on `ScopeMain`; both `scope-aspects-loader` and `workspace-aspects-loader` honor it before `require()`-ing aspects