### PR TITLE
fix(lanes): wrap <lane> in backticks in lane import extended description

### DIFF
--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -670,7 +670,7 @@ export class LaneImportCmd implements Command {
   description = `import a remote lane to your workspace`;
   extendedDescription = `when on the default lane, the workspace is switched to the imported lane.
 when already on the same lane, only the latest objects are fetched from the remote — run "bit checkout head" to update the workspace.
-when on a different lane, the lane is fetched locally without switching to avoid disrupting your work — run "bit switch <lane>" to switch.`;
+when on a different lane, the lane is fetched locally without switching to avoid disrupting your work — run \`bit switch <lane>\` to switch.`;
   arguments = [{ name: 'lane', description: 'the remote lane name' }];
   alias = '';
   options = [


### PR DESCRIPTION
prevents MDX parser from treating <lane> as an unclosed JSX tag when cli-reference.mdx is regenerated in CI.