### PR TITLE
fix(typescript): avoid OOM in check-types by batching tsserver open/close

### DIFF
--- a/scopes/typescript/ts-server/ts-server-client.ts
+++ b/scopes/typescript/ts-server/ts-server-client.ts
@@ -18,6 +18,12 @@ export type TsserverClientOpts = {
   checkTypes?: CheckTypes; // whether errors/warnings are monitored and printed to the console.
   printTypeErrors?: boolean; // whether print typescript errors to the console.
   aggregateDiagnosticData?: boolean; // whether to aggregate diagnostic data instead of printing them to the console.
+  /**
+   * if false, files passed to the constructor are NOT opened during init().
+   * useful when the caller wants to control opening (e.g. batched open/close in `getDiagnostic`).
+   * default: true (backward compatible).
+   */
+  openFilesOnInit?: boolean;
 };
 
 export type DiagnosticData = {
@@ -68,13 +74,11 @@ export class TsserverClient {
           this.logger.error('TsserverClient.init failed', err);
         });
 
-      if (this.files.length) {
+      const shouldOpenFiles = this.options.openFilesOnInit !== false;
+      if (this.files.length && shouldOpenFiles) {
         const openPromises = this.files.map((file) => this.open(file));
         await Promise.all(openPromises.map((promise) => promise.catch((error) => error)));
         const failedFiles = openPromises.filter((promise) => promise instanceof Error);
-        if (failedFiles.length > 0) {
-          this.logger.error('TsserverClient.init failed to open files:', failedFiles);
-        }
         if (failedFiles.length > 0) {
           this.logger.error('TsserverClient.init failed to open files:', failedFiles);
         }
@@ -145,7 +149,9 @@ export class TsserverClient {
    * were found or not.
    *
    * @param files files to check
-   * @param batchSize if provided, files will be processed in batches to avoid overwhelming tsserver
+   * @param batchSize if provided, files will be processed in batches. when files were not pre-opened
+   *                  via init(), each batch is opened, checked, then closed — keeping tsserver memory
+   *                  bounded by the batch size to avoid OOM in large workspaces.
    */
   async getDiagnostic(files = this.files, batchSize?: number): Promise<any> {
     this.lastDiagnostics = [];
@@ -154,11 +160,41 @@ export class TsserverClient {
       return this.tsServer?.request(CommandTypes.Geterr, { delay: 0, files });
     }
 
-    // Process files in batches
+    const filesArePreOpened = files === this.files || files.every((f) => this.files.includes(f));
+    const total = files.length;
     for (let i = 0; i < files.length; i += batchSize) {
       const batch = files.slice(i, i + batchSize);
+      const upTo = Math.min(i + batchSize, total);
+      this.logger.setStatusLine(`type-checking files ${i + 1}-${upTo} of ${total}`);
+      if (!filesArePreOpened) {
+        await this.openFiles(batch);
+      }
       await this.tsServer?.request(CommandTypes.Geterr, { delay: 0, files: batch });
+      if (!filesArePreOpened) {
+        await this.closeFiles(batch);
+      }
     }
+    this.logger.clearStatusLine();
+  }
+
+  /**
+   * open multiple files in a single round-trip. useful when batching to bound tsserver memory.
+   */
+  async openFiles(files: string[]): Promise<void> {
+    if (!files.length) return;
+    await this.tsServer?.request(CommandTypes.UpdateOpen, {
+      openFiles: files.map((file) => ({ file, projectRootPath: this.projectPath })),
+    });
+  }
+
+  /**
+   * close multiple files in a single round-trip.
+   */
+  async closeFiles(files: string[]): Promise<void> {
+    if (!files.length) return;
+    await this.tsServer?.request(CommandTypes.UpdateOpen, {
+      closedFiles: files,
+    });
   }
 
   /**

--- a/scopes/typescript/ts-server/ts-server-client.ts
+++ b/scopes/typescript/ts-server/ts-server-client.ts
@@ -36,6 +36,7 @@ export class TsserverClient {
   private tsServer: ProcessBasedTsServer | null;
   public lastDiagnostics: ts.server.protocol.DiagnosticEventBody[] = [];
   private serverRunning = false;
+  private filesPreOpenedOnInit = false;
   public diagnosticData: DiagnosticData[] = [];
   constructor(
     /**
@@ -76,12 +77,14 @@ export class TsserverClient {
 
       const shouldOpenFiles = this.options.openFilesOnInit !== false;
       if (this.files.length && shouldOpenFiles) {
-        const openPromises = this.files.map((file) => this.open(file));
-        await Promise.all(openPromises.map((promise) => promise.catch((error) => error)));
-        const failedFiles = openPromises.filter((promise) => promise instanceof Error);
+        const openResults = await Promise.all(
+          this.files.map((file) => this.open(file).catch((error: unknown) => error))
+        );
+        const failedFiles = openResults.filter((result) => result instanceof Error);
         if (failedFiles.length > 0) {
           this.logger.error('TsserverClient.init failed to open files:', failedFiles);
         }
+        this.filesPreOpenedOnInit = true;
         this.checkTypesIfNeeded();
       }
       this.logger.debug('TsserverClient.init completed');
@@ -160,21 +163,27 @@ export class TsserverClient {
       return this.tsServer?.request(CommandTypes.Geterr, { delay: 0, files });
     }
 
-    const filesArePreOpened = files === this.files || files.every((f) => this.files.includes(f));
+    const filesArePreOpened = this.filesPreOpenedOnInit && files.every((f) => this.files.includes(f));
     const total = files.length;
-    for (let i = 0; i < files.length; i += batchSize) {
-      const batch = files.slice(i, i + batchSize);
-      const upTo = Math.min(i + batchSize, total);
-      this.logger.setStatusLine(`type-checking files ${i + 1}-${upTo} of ${total}`);
-      if (!filesArePreOpened) {
-        await this.openFiles(batch);
+    try {
+      for (let i = 0; i < files.length; i += batchSize) {
+        const batch = files.slice(i, i + batchSize);
+        const upTo = Math.min(i + batchSize, total);
+        this.logger.setStatusLine(`type-checking files ${i + 1}-${upTo} of ${total}`);
+        if (!filesArePreOpened) {
+          await this.openFiles(batch);
+        }
+        try {
+          await this.tsServer?.request(CommandTypes.Geterr, { delay: 0, files: batch });
+        } finally {
+          if (!filesArePreOpened) {
+            await this.closeFiles(batch).catch((err) => this.logger.error('failed to close batch', err));
+          }
+        }
       }
-      await this.tsServer?.request(CommandTypes.Geterr, { delay: 0, files: batch });
-      if (!filesArePreOpened) {
-        await this.closeFiles(batch);
-      }
+    } finally {
+      this.logger.clearStatusLine();
     }
-    this.logger.clearStatusLine();
   }
 
   /**

--- a/scopes/typescript/typescript/cmds/check-types.cmd.ts
+++ b/scopes/typescript/typescript/cmds/check-types.cmd.ts
@@ -91,31 +91,34 @@ otherwise, only new and modified components will be checked`);
     unmodified: boolean
   ): Promise<{ tsserver: ReturnType<TypescriptMain['getTsserverClient']>; componentsCount: number }> {
     if (!this.workspace) throw new OutsideWorkspaceError();
-    this.logger.setStatusLine('check-types: loading components...');
-    // If pattern is provided, don't pass the unmodified flag - the pattern should take precedence
-    const components = await this.workspace.getComponentsByUserInput(pattern ? false : unmodified, pattern);
-    if (!components.length) {
+    try {
+      this.logger.setStatusLine('check-types: loading components...');
+      // If pattern is provided, don't pass the unmodified flag - the pattern should take precedence
+      const components = await this.workspace.getComponentsByUserInput(pattern ? false : unmodified, pattern);
+      if (!components.length) {
+        return { tsserver: undefined, componentsCount: 0 };
+      }
+      const files = this.typescript.getSupportedFilesForTsserver(components);
+      this.logger.setStatusLine(
+        `check-types: starting tsserver for ${components.length} component(s), ${files.length} file(s)...`
+      );
+      await this.typescript.initTsserverClientFromWorkspace(
+        {
+          aggregateDiagnosticData: isJson,
+          printTypeErrors: !isJson,
+          // skip pre-opening so getDiagnostic can open/close per batch — keeps tsserver memory bounded
+          // by one batch's worth of files instead of the whole workspace.
+          openFilesOnInit: false,
+        },
+        files
+      );
+      const tsserver = this.typescript.getTsserverClient();
+      if (!tsserver) throw new Error(`unable to start tsserver`);
+      const BATCH_SIZE = 50;
+      await tsserver.getDiagnostic(files, files.length > BATCH_SIZE ? BATCH_SIZE : undefined);
+      return { tsserver, componentsCount: components.length };
+    } finally {
       this.logger.clearStatusLine();
-      return { tsserver: undefined, componentsCount: 0 };
     }
-    const files = this.typescript.getSupportedFilesForTsserver(components);
-    this.logger.setStatusLine(
-      `check-types: starting tsserver for ${components.length} component(s), ${files.length} file(s)...`
-    );
-    await this.typescript.initTsserverClientFromWorkspace(
-      {
-        aggregateDiagnosticData: isJson,
-        printTypeErrors: !isJson,
-        // skip pre-opening so getDiagnostic can open/close per batch — keeps tsserver memory bounded
-        // by one batch's worth of files instead of the whole workspace.
-        openFilesOnInit: false,
-      },
-      files
-    );
-    const tsserver = this.typescript.getTsserverClient();
-    if (!tsserver) throw new Error(`unable to start tsserver`);
-    const BATCH_SIZE = 50;
-    await tsserver.getDiagnostic(files, files.length > BATCH_SIZE ? BATCH_SIZE : undefined);
-    return { tsserver, componentsCount: components.length };
   }
 }

--- a/scopes/typescript/typescript/cmds/check-types.cmd.ts
+++ b/scopes/typescript/typescript/cmds/check-types.cmd.ts
@@ -91,22 +91,29 @@ otherwise, only new and modified components will be checked`);
     unmodified: boolean
   ): Promise<{ tsserver: ReturnType<TypescriptMain['getTsserverClient']>; componentsCount: number }> {
     if (!this.workspace) throw new OutsideWorkspaceError();
+    this.logger.setStatusLine('check-types: loading components...');
     // If pattern is provided, don't pass the unmodified flag - the pattern should take precedence
     const components = await this.workspace.getComponentsByUserInput(pattern ? false : unmodified, pattern);
     if (!components.length) {
+      this.logger.clearStatusLine();
       return { tsserver: undefined, componentsCount: 0 };
     }
     const files = this.typescript.getSupportedFilesForTsserver(components);
+    this.logger.setStatusLine(
+      `check-types: starting tsserver for ${components.length} component(s), ${files.length} file(s)...`
+    );
     await this.typescript.initTsserverClientFromWorkspace(
       {
         aggregateDiagnosticData: isJson,
         printTypeErrors: !isJson,
+        // skip pre-opening so getDiagnostic can open/close per batch — keeps tsserver memory bounded
+        // by one batch's worth of files instead of the whole workspace.
+        openFilesOnInit: false,
       },
       files
     );
     const tsserver = this.typescript.getTsserverClient();
     if (!tsserver) throw new Error(`unable to start tsserver`);
-    // Use batching for large file sets to avoid overwhelming tsserver
     const BATCH_SIZE = 50;
     await tsserver.getDiagnostic(files, files.length > BATCH_SIZE ? BATCH_SIZE : undefined);
     return { tsserver, componentsCount: components.length };


### PR DESCRIPTION
`bit check-types` opened every `.ts/.tsx` file in the workspace upfront via `Promise.all`, so tsserver loaded the closest tsconfig project for each file and held them all in memory. The existing `BATCH_SIZE=50` only batched the `geterr` call — by then everything was already loaded, so it never bounded memory and large workspaces would hang or OOM.

Now files are opened and closed in batches inside `getDiagnostic` (one `updateOpen` round-trip per batch), so tsserver only holds one batch's worth of files at a time. Added a status line so the run shows progress instead of looking hung.

No new flags or memory tuning — defaults are unchanged.