### PR TITLE
refactor(workspace): drop hardcoded core-aspect-env special case

### DIFF
--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -301,28 +301,15 @@ export class WorkspaceComponentLoader {
     const groupsToHandle = [
       // Always load first core envs
       { ids: groupedByIsCoreEnvs.true || [], core: true, aspects: true, seeders: true, envs: true },
-      // { ids: groupedByIsEnvOfWsComps.true || [], core: false, aspects: true, seeders: false, envs: true },
+      // The recursive env-DAG sort in `groupEnvsByDepLayer` places envs at the
+      // bottom of the chain (e.g. `core-aspect-env`/`core-aspect-env-jest`) in the
+      // earliest layer naturally. The hardcoded `core-aspect-env` prepending that
+      // used to live here is redundant under the recursive sort — see D-001.
       ...layeredEnvsGroups,
       { ids: extsNotFromTheList || [], core: false, aspects: true, seeders: false, envs: false },
       ...layeredExtGroups,
       { ids: groupedByIsExtOfAnother.false || [], core: false, aspects: false, seeders: true, envs: false },
     ];
-
-    // This is a special use case mostly for the bit core repo
-    const envsOfCoreAspectEnv = ['teambit.harmony/envs/core-aspect-env', 'teambit.harmony/envs/core-aspect-env-jest'];
-    const coreAspectEnvGroup = { ids: [], core: true, aspects: true, seeders: true, envs: true };
-    layeredEnvsGroups.forEach((group) => {
-      const filteredIds = group.ids.filter((id) => envsOfCoreAspectEnv.includes(id.toStringWithoutVersion()));
-      if (filteredIds.length) {
-        // @ts-ignore
-        coreAspectEnvGroup.ids.push(...filteredIds);
-      }
-    });
-    if (coreAspectEnvGroup.ids.length) {
-      // enter first in the list
-      groupsToHandle.unshift(coreAspectEnvGroup);
-    }
-    // END of bit repo special use case
 
     const groupsByWsScope = groupsToHandle.map((group) => {
       if (!group.ids?.length) return undefined;


### PR DESCRIPTION
Builds on #10350.

Removes the hardcoded prepend in \`buildLoadGroups\` that always loaded \`teambit.harmony/envs/core-aspect-env\` and \`teambit.harmony/envs/core-aspect-env-jest\` first. With the recursive env-DAG sort from #10350, those envs naturally land in the deepest layer of the topological sort and load early. The hardcode was a workaround for the previous one-level sort.

## Verification

- **Smoke-tested on bit7 itself** (the 311-component workspace the special case was originally written for): \`bit7 status\` runs cleanly. This is the most important signal — the special case was specifically a \"bit core repo\" workaround per the inline comment.
- 21 contract tests pass.
- Harness e2e on a 2-component workspace produces zero diffs.

## Stack

- #10349 (base) — diff harness + RFC + spike + first seam
  - #10350 — recursive env-DAG sort
    - **this PR** — drop the special case