### PR TITLE
fix(install): skip linking into .bit_roots when rootComponents is disabled

### DIFF
--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -70,13 +70,20 @@ export default class NodeModuleLinker {
       this.workspace.clearAllComponentsCache();
     }
 
-    await linkPkgsToRootComponents(
-      {
-        rootComponentsPath: this.workspace.rootComponentsPath,
-        workspacePath,
-      },
-      this.components.map((comp) => componentIdToPackageName(comp.state._consumer))
-    );
+    // Only update `.bit_roots` when root components are actually in use. Otherwise
+    // we'd be hard-linking into a stale tree left over from a previous install where
+    // rootComponents was enabled — pnpm no longer manages that subtree, so its layout
+    // can be inconsistent and `mkdir` may throw ENOTDIR/ENOENT through a broken
+    // ancestor inside `.bit_roots/<env>/node_modules/...`.
+    if (this.workspace.hasRootComponents()) {
+      await linkPkgsToRootComponents(
+        {
+          rootComponentsPath: this.workspace.rootComponentsPath,
+          workspacePath,
+        },
+        this.components.map((comp) => componentIdToPackageName(comp.state._consumer))
+      );
+    }
     return linksResults;
   }
   async getLinks(): Promise<DataToPersist> {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -309,6 +309,14 @@ export class Workspace implements ComponentFactory {
     return path.join(baseDir, BIT_ROOTS_DIR);
   }
 
+  /**
+   * Whether the workspace is configured to use root components (the `.bit_roots`
+   * per-env install layout under `node_modules`).
+   */
+  hasRootComponents(): boolean {
+    return this.dependencyResolver.hasRootComponents();
+  }
+
   /** get the `node_modules` folder of this workspace */
   private get modulesPath() {
     return path.join(this.path, 'node_modules');

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -310,8 +310,9 @@ export class Workspace implements ComponentFactory {
   }
 
   /**
-   * Whether the workspace is configured to use root components (the `.bit_roots`
-   * per-env install layout under `node_modules`).
+   * Whether the workspace is configured to use root components — the per-env install
+   * layout written to `rootComponentsPath` (defaults to `node_modules/.bit_roots`,
+   * relocatable via `dependencyResolver.rootComponentsDirectory`).
    */
   hasRootComponents(): boolean {
     return this.dependencyResolver.hasRootComponents();


### PR DESCRIPTION
## Summary

The post-install path runs through `linkCodemods` → `linkToNodeModulesByIds` → `NodeModuleLinker.link()`, and that ended with an **unconditional** call to `linkPkgsToRootComponents` at `node-modules-linker.ts:73`. The sibling call site in `install.main.runtime.ts` (`_linkAllComponentsToBitRoots`, line 1272) is already gated on `dependencyResolver.hasRootComponents()` — this aligns the linker with that.

### When this matters

A user toggles `rootComponents` from `true` to `false` and runs `bit install`:

1. Prior install (with `rootComponents: true`) populated `node_modules/.bit_roots/<env>/node_modules/...`.
2. New install (with `rootComponents: false`): pnpm no longer treats `.bit_roots/<env>` as a workspace project, and `_updateRootDirs` is skipped, so that subtree is no longer managed by anyone. Its internal layout can drift — e.g. ancestors of `<env>/node_modules/<pkg>` may have been reshaped, leaving a regular file or a broken link where a directory used to be.
3. `NodeModuleLinker.link()` then tries to hard-link the workspace's `node_modules/<pkg>` into that stale tree, and `mkdir(... { recursive: true })` throws `ENOTDIR` (or `ENOENT` through a broken symlink). The whole install aborts.

Concrete report from a user:
```
✔ done running package installation using pnpm (completed in 5s)
✔ running post install subscribers
ENOTDIR: not a directory, mkdir '/home/user/hope-mobile/node_modules/.bit_roots/bitdev.react-native_react-native-env@2.0.0/node_modules/@teambit/hope.hope-mobile'
```

### Changes

- `Workspace.hasRootComponents()` — small public method that delegates to the private `dependencyResolver.hasRootComponents()`. The linker (and any other consumer of `Workspace`) can now check this without reaching into the private resolver.
- `NodeModuleLinker.link()` — gates the `linkPkgsToRootComponents` call on `workspace.hasRootComponents()`. When root components are off, the stale `.bit_roots` tree is left strictly alone.

### Notes

- The defensive recovery in #10355 turns the underlying ENOTDIR into a recoverable warning when it does happen. This PR is the upstream fix that prevents bit from touching `.bit_roots` in the first place when it shouldn't. The two are complementary — happy to land in either order.
- This PR does not clean up an existing `.bit_roots` when the user toggles to `false`. The stale tree is wasted disk but no longer actively harmful once we stop writing to it. If you want bit to also remove it on toggle, that's a separate change worth thinking through (someone may have tooling that reads from there independently).

## Test plan

- [x] `npm run lint` — same 38 pre-existing TS errors as master (all in unrelated `@pnpm/*` imports), no new errors in the changed files
- [ ] e2e test — the existing `e2e/harmony/root-components.e2e.ts` is the natural home for a "toggle off and reinstall" scenario but I held off on adding one in this draft; let me know if you want it bundled in.
