### PR TITLE
fix(config-store): write the global config with 0600 permissions

### DIFF
--- a/components/config-store/global-config.ts
+++ b/components/config-store/global-config.ts
@@ -3,6 +3,11 @@ import * as path from 'path';
 
 import { GLOBAL_CONFIG, GLOBAL_CONFIG_FILE } from '@teambit/legacy.constants';
 
+// Owner-only perms for the global config file. It can hold the user's
+// bit-cloud token and other secrets, so match the AWS/gcloud baseline
+// of 0600 instead of relying on the umask default (often 0644).
+const CONFIG_FILE_MODE = 0o600;
+
 export function getGlobalConfigPath() {
   return path.join(GLOBAL_CONFIG, GLOBAL_CONFIG_FILE);
 }
@@ -16,12 +21,19 @@ export class GlobalConfig extends Map<string, string> {
     return JSON.stringify(this.toPlainObject(), null, 2);
   }
 
-  write() {
-    return fs.outputFile(getGlobalConfigPath(), this.toJson());
+  async write() {
+    const configPath = getGlobalConfigPath();
+    await fs.outputFile(configPath, this.toJson(), { mode: CONFIG_FILE_MODE });
+    // Node's `mode` write option is only honored when the file is created,
+    // so chmod explicitly to tighten any pre-existing file written under
+    // the default umask.
+    await fs.chmod(configPath, CONFIG_FILE_MODE);
   }
 
   writeSync() {
-    return fs.outputFileSync(getGlobalConfigPath(), this.toJson());
+    const configPath = getGlobalConfigPath();
+    fs.outputFileSync(configPath, this.toJson(), { mode: CONFIG_FILE_MODE });
+    fs.chmodSync(configPath, CONFIG_FILE_MODE);
   }
 
   static loadSync(): GlobalConfig {


### PR DESCRIPTION
The global config holds the user's `user.token` but is written without a `mode` option, so it inherits the default umask (often `0644`). Tighten to `0600` (matches AWS CLI / gcloud / kubectl / gh).

Same shape as `server-port.txt` hardening from #10344 — pass `mode: 0o600` on write *and* explicitly `chmod` after, since Node only honors the `mode` option on file creation.