### PR TITLE
fix(deps-graph): drop back-edges from circular workspace deps

### DIFF
--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -344,6 +344,11 @@ describe('convertLockfileToGraph with a circular workspace dependency back to th
             comp2: { version: 'file:comps/comp2', specifier: '*' },
           },
         },
+        'comps/comp2': {
+          dependencies: {
+            comp1: { version: 'file:comps/comp1', specifier: '*' },
+          },
+        },
       },
       lockfileVersion: '9.0',
       snapshots: {

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -320,6 +320,72 @@ describe('convertLockfileToGraph simple case', () => {
   });
 });
 
+describe('convertLockfileToGraph with a circular workspace dependency back to the component being processed', () => {
+  // Reproduces the "No matching version found for <workspace-comp>@0.0.0-<hash>"
+  // failure: comp1 (the component being processed) is removed from snapshots
+  // and packages, but a circular workspace dep (comp2 depends back on comp1)
+  // leaves an edge whose neighbour references comp1@<version> with no
+  // corresponding packages entry. When the graph is later converted back to a
+  // lockfile, convertGraphToLockfile materialises that dangling neighbour as
+  // an empty packages entry and getPkgsToResolve treats it as a missing
+  // package, asking the registry for a snap-version that was never published.
+  it('should drop edges that reference the component being processed', () => {
+    const lockfile: BitLockfileFile = {
+      bit: { depsRequiringBuild: [] },
+      importers: {
+        '.': {},
+        'node_modules/.bit_roots/env': {
+          dependencies: {
+            comp1: { version: 'file:comps/comp1', specifier: '*' },
+          },
+        },
+        'comps/comp1': {
+          dependencies: {
+            comp2: { version: 'file:comps/comp2', specifier: '*' },
+          },
+        },
+      },
+      lockfileVersion: '9.0',
+      snapshots: {
+        'comp1@file:comps/comp1': {
+          dependencies: {
+            comp2: 'file:comps/comp2',
+          },
+        },
+        'comp2@file:comps/comp2': {
+          dependencies: {
+            comp1: 'file:comps/comp1',
+          },
+        },
+      },
+      packages: {
+        'comp1@file:comps/comp1': {
+          resolution: { directory: 'comps/comp1', type: 'directory' },
+        },
+        'comp2@file:comps/comp2': {
+          resolution: { directory: 'comps/comp2', type: 'directory' },
+        },
+      },
+    };
+    const graph = convertLockfileToGraph(lockfile, {
+      pkgName: 'comp1',
+      componentRelativeDir: 'comps/comp1',
+      componentRootDir: 'node_modules/.bit_roots/env',
+      componentIdByPkgName: new Map([
+        ['comp1', ComponentID.fromString('my-scope/comp1@1.0.0')],
+        ['comp2', ComponentID.fromString('my-scope/comp2@1.0.0')],
+      ]),
+    });
+    // The graph must never reference comp1 — it is the component being
+    // snapped, so it does not belong in its own deps graph.
+    const referencingComp1 = graph.edges.filter((edge) =>
+      edge.neighbours.some((n) => n.id === 'comp1@1.0.0')
+    );
+    expect(referencingComp1).to.eql([]);
+    expect(graph.packages.has('comp1@1.0.0')).to.equal(false);
+  });
+});
+
 describe('convertLockfileToGraph with directory packages missing from componentIdByPkgName', () => {
   it('should not persist orphan @file: pkgIds in the produced graph', () => {
     // Reproduces how the broken graphs end up in the model: a directory-type

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -389,6 +389,66 @@ describe('convertLockfileToGraph with a circular workspace dependency back to th
     expect(referencingComp1).to.eql([]);
     expect(graph.packages.has('comp1@1.0.0')).to.equal(false);
   });
+
+  // Same bug, but the cycle closes through an intermediate workspace
+  // component (comp1 → comp2 → comp3 → comp1). The back-edge in the
+  // lockfile lives on comp3's snapshot, not comp2's. Scrubbing only
+  // direct dependents of comp1 would miss it; the fix iterates every
+  // remaining snapshot so chain-length doesn't matter.
+  it('should drop edges that reference the component via a multi-hop chain', () => {
+    const lockfile: BitLockfileFile = {
+      bit: { depsRequiringBuild: [] },
+      importers: {
+        '.': {},
+        'node_modules/.bit_roots/env': {
+          dependencies: {
+            comp1: { version: 'file:comps/comp1', specifier: '*' },
+          },
+        },
+        'comps/comp1': {
+          dependencies: {
+            comp2: { version: 'file:comps/comp2', specifier: '*' },
+          },
+        },
+        'comps/comp2': {
+          dependencies: {
+            comp3: { version: 'file:comps/comp3', specifier: '*' },
+          },
+        },
+        'comps/comp3': {
+          dependencies: {
+            comp1: { version: 'file:comps/comp1', specifier: '*' },
+          },
+        },
+      },
+      lockfileVersion: '9.0',
+      snapshots: {
+        'comp1@file:comps/comp1': { dependencies: { comp2: 'file:comps/comp2' } },
+        'comp2@file:comps/comp2': { dependencies: { comp3: 'file:comps/comp3' } },
+        'comp3@file:comps/comp3': { dependencies: { comp1: 'file:comps/comp1' } },
+      },
+      packages: {
+        'comp1@file:comps/comp1': { resolution: { directory: 'comps/comp1', type: 'directory' } },
+        'comp2@file:comps/comp2': { resolution: { directory: 'comps/comp2', type: 'directory' } },
+        'comp3@file:comps/comp3': { resolution: { directory: 'comps/comp3', type: 'directory' } },
+      },
+    };
+    const graph = convertLockfileToGraph(lockfile, {
+      pkgName: 'comp1',
+      componentRelativeDir: 'comps/comp1',
+      componentRootDir: 'node_modules/.bit_roots/env',
+      componentIdByPkgName: new Map([
+        ['comp1', ComponentID.fromString('my-scope/comp1@1.0.0')],
+        ['comp2', ComponentID.fromString('my-scope/comp2@1.0.0')],
+        ['comp3', ComponentID.fromString('my-scope/comp3@1.0.0')],
+      ]),
+    });
+    const referencingComp1 = graph.edges.filter((edge) =>
+      edge.neighbours.some((n) => n.id === 'comp1@1.0.0')
+    );
+    expect(referencingComp1).to.eql([]);
+    expect(graph.packages.has('comp1@1.0.0')).to.equal(false);
+  });
 });
 
 describe('convertLockfileToGraph with directory packages missing from componentIdByPkgName', () => {

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
@@ -88,6 +88,23 @@ export function convertLockfileToGraph(
   }
   delete lockfile.snapshots![lockedPkgDepPath];
   delete lockfile.packages![dp.removeSuffix(lockedPkgDepPath)];
+  // Scrub back-edges from a circular workspace dep (another workspace
+  // component depending on the one we're processing). Otherwise the
+  // back-edge survives buildEdges but its target — the just-deleted
+  // pkgId — has no entry in buildPackages, leaving a dangling neighbour.
+  // convertGraphToLockfile would later materialise that neighbour as an
+  // empty packages entry and ask the registry for the workspace
+  // snap-version, which may never have been published.
+  const lockedFileVersion = lockfile.importers![componentRootDir].dependencies![pkgName].version;
+  for (const snapshot of Object.values(lockfile.snapshots ?? {})) {
+    for (const depType of ['dependencies', 'optionalDependencies'] as const) {
+      const deps = snapshot[depType];
+      if (deps?.[pkgName] === lockedFileVersion) {
+        delete deps[pkgName];
+        if (Object.keys(deps).length === 0) delete snapshot[depType];
+      }
+    }
+  }
   return _convertLockfileToGraph(lockfile, { componentIdByPkgName, directDependencies });
 }
 


### PR DESCRIPTION
## Summary

- Fixes the `NoMatchingVersionError: No matching version found for <workspace-comp>@0.0.0-<hash>` that surfaces during install when a snapped component has a circular workspace dep.
- When a component is snapped, `convertLockfileToGraph` deletes the component's own snapshot/package entry, but back-references to it from other snapshots survived. Those neighbours then pointed at a pkgId with no `packages` entry. `convertGraphToLockfile` later materialised the dangling neighbour as an empty `packages` entry and `getPkgsToResolve` asked the registry for a workspace snap-version that may never have been published.
- Now we scrub the back-references in `convertLockfileToGraph`: any other snapshot whose `dependencies`/`optionalDependencies` keys the processed `pkgName` with the same file: ref we just deleted has that entry removed. Published-version refs (to a different version of the same component) are preserved.

## Test plan

- [x] New unit test in `lockfile-deps-graph-converter.spec.ts` reproduces a 2-component cycle (comp1 ↔ comp2) and asserts the resulting graph has no edge referencing comp1@1.0.0 and no comp1@1.0.0 in `graph.packages`. Fails on master, passes with the fix.
- [x] All 11 tests in the spec pass (`mocha lockfile-deps-graph-converter.spec.ts`).
- [x] `npx oxlint` clean on both changed files.