### PR TITLE
fix(artifacts): several fixes for `bit artifacts --out-dir`

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -51,8 +51,19 @@ export class ArtifactExtractor {
     const host = this.componentMain.getHost();
     const ids = await host.idsByPattern(this.pattern);
     const scope = this.componentMain.getHost(ScopeAspect.id) as ScopeMain;
-    // import in case the components are with build status "pending"
-    await scope.legacyScope.scopeImporter.importWithoutDeps(ComponentIdList.fromArray(ids), { reason: 'artifact' });
+    // re-import the version objects so we pick up any builder data added by the remote build pipeline
+    // after the local snap was created. importMany with reFetchUnBuiltVersion treats versions whose
+    // buildStatus isn't "succeed"/"skipped" as stale and re-fetches them from the remote (including
+    // from the current lane's scope, in case the snap lives on a lane).
+    const currentLane = await scope.legacyScope.getCurrentLaneObject();
+    await scope.legacyScope.scopeImporter.importMany({
+      ids: ComponentIdList.fromArray(ids),
+      reFetchUnBuiltVersion: true,
+      preferDependencyGraph: true,
+      throwForSeederNotFound: false,
+      lane: currentLane || undefined,
+      reason: 'to refresh build artifacts',
+    });
     const components = await host.getMany(ids);
     const artifactListPerId: ArtifactListPerId[] = components.map((component) => {
       return {

--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -53,13 +53,12 @@ export class ArtifactExtractor {
     const scope = this.componentMain.getHost(ScopeAspect.id) as ScopeMain;
     // re-import the version objects so we pick up any builder data added by the remote build
     // pipeline after the local snap was created (the local Version may have been stored with
-    // empty BuilderAspect data — the hash excludes extension data, so it isn't replaced on a
-    // normal cached import). cache: false forces the fetch; passing the current lane makes the
-    // fetch hit the lane's scope where snaps actually live.
+    // empty BuilderAspect data — the Version hash excludes extension data, so it isn't replaced
+    // on a normal cached import). passing the current lane routes the fetch to the lane's scope
+    // where snaps actually live, and the lane-aware fetcher writes back any updated Version.
     const currentLane = await scope.legacyScope.getCurrentLaneObject();
     await scope.legacyScope.scopeImporter.importWithoutDeps(ComponentIdList.fromArray(ids), {
-      cache: false,
-      lane: currentLane || undefined,
+      lane: currentLane,
       reason: 'to refresh build artifacts',
     });
     const components = await host.getMany(ids);

--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -9,6 +9,7 @@ import { ComponentIdList } from '@teambit/component-id';
 import pMapSeries from 'p-map-series';
 import minimatch from 'minimatch';
 import { ArtifactFiles } from '@teambit/component.sources';
+import { isValidPath } from '@teambit/legacy.utils';
 import type { BuilderMain } from '../builder.main.runtime';
 import type { ArtifactsOpts } from './artifacts.cmd';
 import { ArtifactList } from './artifact-list';
@@ -88,7 +89,14 @@ export class ArtifactExtractor {
       // make sure the component-dir is just one dir. without this, every slash in the component-id will create a new dir.
       const idAsFilename = filenamify(id.toStringWithoutVersion(), { replacement: '_' });
       const compPath = path.join(outDir, idAsFilename);
-      await Promise.all(vinyls.map((vinyl) => fs.outputFile(path.join(compPath, vinyl.path), vinyl.contents)));
+      await Promise.all(
+        vinyls.map((vinyl) => {
+          if (!isValidPath(vinyl.path)) {
+            throw new Error(`refusing to write artifact "${vinyl.path}" for ${id.toString()}: unsafe path`);
+          }
+          return fs.outputFile(path.join(compPath, vinyl.path), vinyl.contents);
+        })
+      );
       totalSaved += vinyls.length;
     });
     return totalSaved;

--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -37,6 +37,8 @@ type ArtifactListPerId = {
 };
 
 export class ArtifactExtractor {
+  savedFilesCount = 0;
+
   constructor(
     private componentMain: ComponentMain,
     private builder: BuilderMain,
@@ -58,7 +60,7 @@ export class ArtifactExtractor {
       };
     });
     this.filterByOptions(artifactListPerId);
-    await this.saveFilesInFileSystemIfAsked(artifactListPerId);
+    this.savedFilesCount = await this.saveFilesInFileSystemIfAsked(artifactListPerId);
 
     return this.artifactsObjectsToExtractorResults(artifactListPerId);
   }
@@ -73,12 +75,13 @@ export class ArtifactExtractor {
     });
   }
 
-  private async saveFilesInFileSystemIfAsked(artifactListPerId: ArtifactListPerId[]) {
+  private async saveFilesInFileSystemIfAsked(artifactListPerId: ArtifactListPerId[]): Promise<number> {
     const outDir = this.options.outDir;
     if (!outDir) {
-      return;
+      return 0;
     }
     const scope = this.componentMain.getHost(ScopeAspect.id) as ScopeMain;
+    let totalSaved = 0;
     // @todo: optimize this to first import all missing hashes.
     await pMapSeries(artifactListPerId, async ({ id, artifacts }) => {
       const vinyls = await artifacts.getVinylsAndImportIfMissing(id, scope.legacyScope);
@@ -86,7 +89,9 @@ export class ArtifactExtractor {
       const idAsFilename = filenamify(id.toStringWithoutVersion(), { replacement: '_' });
       const compPath = path.join(outDir, idAsFilename);
       await Promise.all(vinyls.map((vinyl) => fs.outputFile(path.join(compPath, vinyl.path), vinyl.contents)));
+      totalSaved += vinyls.length;
     });
+    return totalSaved;
   }
 
   private artifactsObjectsToExtractorResults(artifactListPerId: ArtifactListPerId[]): ExtractorResult[] {

--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -51,16 +51,14 @@ export class ArtifactExtractor {
     const host = this.componentMain.getHost();
     const ids = await host.idsByPattern(this.pattern);
     const scope = this.componentMain.getHost(ScopeAspect.id) as ScopeMain;
-    // re-import the version objects so we pick up any builder data added by the remote build pipeline
-    // after the local snap was created. importMany with reFetchUnBuiltVersion treats versions whose
-    // buildStatus isn't "succeed"/"skipped" as stale and re-fetches them from the remote (including
-    // from the current lane's scope, in case the snap lives on a lane).
+    // re-import the version objects so we pick up any builder data added by the remote build
+    // pipeline after the local snap was created (the local Version may have been stored with
+    // empty BuilderAspect data — the hash excludes extension data, so it isn't replaced on a
+    // normal cached import). cache: false forces the fetch; passing the current lane makes the
+    // fetch hit the lane's scope where snaps actually live.
     const currentLane = await scope.legacyScope.getCurrentLaneObject();
-    await scope.legacyScope.scopeImporter.importMany({
-      ids: ComponentIdList.fromArray(ids),
-      reFetchUnBuiltVersion: true,
-      preferDependencyGraph: true,
-      throwForSeederNotFound: false,
+    await scope.legacyScope.scopeImporter.importWithoutDeps(ComponentIdList.fromArray(ids), {
+      cache: false,
       lane: currentLane || undefined,
       reason: 'to refresh build artifacts',
     });

--- a/scopes/pipelines/builder/artifact/artifacts.cmd.ts
+++ b/scopes/pipelines/builder/artifact/artifacts.cmd.ts
@@ -1,5 +1,5 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatTitle, formatSuccessSummary } from '@teambit/cli';
+import { formatTitle, formatSuccessSummary, formatWarningSummary } from '@teambit/cli';
 import chalk from 'chalk';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { ComponentMain } from '@teambit/component';
@@ -52,6 +52,10 @@ use --out-dir to download artifacts locally for inspection or deployment purpose
   async report([componentPattern]: [string], artifactsOpts: ArtifactsOpts): Promise<string> {
     const artifactExtractor = new ArtifactExtractor(this.componentMain, this.builder, componentPattern, artifactsOpts);
     const list = await artifactExtractor.list();
+    const totalArtifacts = list.reduce((sum, r) => sum + r.artifacts.length, 0);
+    if (totalArtifacts === 0) {
+      return formatWarningSummary(`no artifacts found for "${componentPattern}"`);
+    }
     const grouped = artifactExtractor.groupResultsByAspect(list);
     const outputArtifacts = (aspectId: string, artifactData: ExtractorArtifactResult[]) => {
       const title = formatTitle(aspectId);
@@ -72,7 +76,7 @@ use --out-dir to download artifacts locally for inspection or deployment purpose
       return `${idStr}\n${artifacts}`;
     };
     const footer = artifactsOpts.outDir
-      ? `\n\n${formatSuccessSummary('The above files were saved to the file system')}`
+      ? `\n\n${formatSuccessSummary(`${artifactExtractor.savedFilesCount} file(s) saved to "${artifactsOpts.outDir}"`)}`
       : '';
     return grouped.map(outputResult).join('\n\n') + footer;
   }


### PR DESCRIPTION
Three independent fixes to `bit artifacts`, all surfaced from `--out-dir` runs that silently misbehaved.

### 1. Refresh stale Version objects on lanes
A Version's hash excludes extension *data*, so a snap stored locally with `buildStatus: pending` shares the same hash as the remote's built copy with artifacts. After a local snap + CI build, the local Version is never replaced, and `bit artifacts` reports "no artifacts found" even though the remote has them. The previous `importWithoutDeps(..., { cache: true })` call also didn't pass the current lane, so any retry would hit the component's home scope instead of the lane scope where the snap actually lives.

Fix: pass the current lane to `importWithoutDeps`. The lane-aware fetcher routes to the lane scope and the writer (`mergeVersionObject`) overwrites the stale local copy.

### 2. Accurate file count + warning when nothing matches
`--out-dir` previously printed `✔ The above files were saved to the file system` even when zero artifacts existed (no directory was created). Now:
- `ArtifactExtractor.savedFilesCount` tracks vinyls actually written.
- Empty result → `⚠ no artifacts found for "<pattern>"`.
- Populated result → `✔ N file(s) saved to "<out-dir>"`.

### 3. Reject unsafe artifact paths
`vinyl.path` was passed straight into `path.join(compPath, vinyl.path)`. A malicious build task could store an artifact whose internal path is `../../../etc/passwd` and escape `out-dir`. Each `vinyl.path` now goes through `isValidPath` (the utility hardened in #10354) before write.