### PR TITLE
feat(lane): allow exporting a lane with not-yet-existing component scopes

### DIFF
--- a/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
+++ b/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
@@ -221,8 +221,15 @@ describe('bit lane multiple scopes', function () {
       helper.command.createLane();
       helper.command.snapAllComponentsWithoutBuild();
     });
-    it('bit export should throw an error saying the scope does not exist', () => {
-      expect(() => helper.command.export()).to.throw('cannot find scope');
+    // developers may iterate on a lane before the target scope is created. the missing-scope
+    // error is deferred to merge-to-main time (see the test below).
+    it('bit export should succeed', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+    it('merging the lane into main should throw, pointing at the missing scope', () => {
+      helper.command.switchLocalLane('main');
+      const mergeFn = () => helper.command.mergeLaneWithoutBuild('dev');
+      expect(mergeFn).to.throw('non-exist-scope');
     });
   });
 

--- a/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
+++ b/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
@@ -221,15 +221,10 @@ describe('bit lane multiple scopes', function () {
       helper.command.createLane();
       helper.command.snapAllComponentsWithoutBuild();
     });
-    // developers may iterate on a lane before the target scope is created. the missing-scope
-    // error is deferred to merge-to-main time (see the test below).
+    // developers may iterate on a lane before the target scope is created; the lane export
+    // silently skips the conflict check for scopes that can't be resolved.
     it('bit export should succeed', () => {
       expect(() => helper.command.export()).to.not.throw();
-    });
-    it('merging the lane into main should throw, pointing at the missing scope', () => {
-      helper.command.switchLocalLane('main');
-      const mergeFn = () => helper.command.mergeLaneWithoutBuild('dev');
-      expect(mergeFn).to.throw('non-exist-scope');
     });
   });
 

--- a/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
+++ b/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
@@ -221,12 +221,15 @@ describe('bit lane multiple scopes', function () {
       helper.command.createLane();
       helper.command.snapAllComponentsWithoutBuild();
     });
-    // the central hub rejects pushes for unknown scopes, so we fail fast locally with a clear,
-    // actionable error rather than letting users hit a cryptic network error.
-    it('bit export should throw a clear error explaining the cause and remediation', () => {
-      const exportFn = () => helper.command.export();
-      expect(exportFn).to.throw('non-exist-scope');
-      expect(exportFn).to.throw('bit scope set');
+    // developers may iterate on a lane before the target scope is created. the missing-scope
+    // error is deferred to merge-to-main time (see the test below).
+    it('bit export should succeed', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+    it('merging the lane into main should throw, pointing at the missing scope', () => {
+      helper.command.switchLocalLane('main');
+      const mergeFn = () => helper.command.mergeLaneWithoutBuild('dev');
+      expect(mergeFn).to.throw('non-exist-scope');
     });
   });
 

--- a/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
+++ b/e2e/harmony/lanes/lane-multiple-scopes.e2e.ts
@@ -221,15 +221,12 @@ describe('bit lane multiple scopes', function () {
       helper.command.createLane();
       helper.command.snapAllComponentsWithoutBuild();
     });
-    // developers may iterate on a lane before the target scope is created. the missing-scope
-    // error is deferred to merge-to-main time (see the test below).
-    it('bit export should succeed', () => {
-      expect(() => helper.command.export()).to.not.throw();
-    });
-    it('merging the lane into main should throw, pointing at the missing scope', () => {
-      helper.command.switchLocalLane('main');
-      const mergeFn = () => helper.command.mergeLaneWithoutBuild('dev');
-      expect(mergeFn).to.throw('non-exist-scope');
+    // the central hub rejects pushes for unknown scopes, so we fail fast locally with a clear,
+    // actionable error rather than letting users hit a cryptic network error.
+    it('bit export should throw a clear error explaining the cause and remediation', () => {
+      const exportFn = () => helper.command.export();
+      expect(exportFn).to.throw('non-exist-scope');
+      expect(exportFn).to.throw('bit scope set');
     });
   });
 

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -27,6 +27,8 @@ import { DEFAULT_LANE } from '@teambit/lane-id';
 import type { ConfigMergeResult } from '@teambit/config-merger';
 import type { Logger, LoggerMain } from '@teambit/logger';
 import { LoggerAspect } from '@teambit/logger';
+import { getScopeRemotes, ScopeNotFoundOrDenied } from '@teambit/scope.remotes';
+import { InvalidScopeName, InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
 import type { CheckoutMain, CheckoutProps } from '@teambit/checkout';
 import { CheckoutAspect, throwForFailures } from '@teambit/checkout';
 import type { SnapsDistance } from '@teambit/component.snap-distance';
@@ -116,6 +118,10 @@ export class MergeLanesMain {
       currentLaneId,
       options
     );
+
+    if (currentLaneId.isDefault()) {
+      await this.throwForLaneComponentsWithMissingScope(idsToMerge);
+    }
 
     const {
       mergeStrategy,
@@ -278,6 +284,46 @@ export class MergeLanesMain {
     await this.workspace?.consumer.onDestroy(`lane-merge (${otherLaneId.name})`);
 
     return { mergeResults, deleteResults, configMergeResults, mergedSuccessfullyIds, conflicts };
+  }
+
+  /**
+   * snapping/exporting a lane is allowed even if a new component's scope doesn't exist remotely yet —
+   * developers may iterate on a lane before the scope is created. once the lane gets merged into main,
+   * those scopes must exist, otherwise the merged snaps can never be exported. surfacing this here gives
+   * a clear error at merge time rather than a confusing failure at the next "bit export".
+   */
+  private async throwForLaneComponentsWithMissingScope(idsToMerge: ComponentID[]) {
+    if (!idsToMerge.length) return;
+    const scopeNames = uniq(idsToMerge.map((id) => id.scope));
+    const scopeRemotes = await getScopeRemotes(this.scope.legacyScope);
+    const missingScopes: string[] = [];
+    await pMapSeries(scopeNames, async (scopeName) => {
+      try {
+        await scopeRemotes.resolve(scopeName);
+      } catch (err) {
+        if (
+          err instanceof ScopeNotFoundOrDenied ||
+          err instanceof InvalidScopeNameFromRemote ||
+          err instanceof InvalidScopeName
+        ) {
+          missingScopes.push(scopeName);
+          return;
+        }
+        throw err;
+      }
+    });
+    if (!missingScopes.length) return;
+    const compsByScope = missingScopes
+      .map((scopeName) => {
+        const ids = idsToMerge.filter((id) => id.scope === scopeName).map((id) => `  - ${id.toString()}`);
+        return `scope "${scopeName}":\n${ids.join('\n')}`;
+      })
+      .join('\n');
+    throw new BitError(
+      `unable to merge into main: the following component(s) reference scope(s) that don't exist or are inaccessible.
+create the missing scope(s), or rename them via "bit scope rename <old> <new>", then retry the merge:
+${compsByScope}`
+    );
   }
 
   private validateMergeFlags(otherLaneId: LaneId, currentLaneId: LaneId, options: MergeLaneOptions) {

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -320,8 +320,12 @@ export class MergeLanesMain {
       })
       .join('\n');
     throw new BitError(
-      `unable to merge into main: the following component(s) reference scope(s) that don't exist or are inaccessible.
-create the missing scope(s), or rename them via "bit scope rename <old> <new>", then retry the merge:
+      `unable to merge into main: the following component(s) reference scope(s) that don't exist, are inaccessible, or have an invalid name.
+to resolve, depending on the cause:
+  - if the scope doesn't exist yet, create it on bit.cloud (or wherever it's hosted)
+  - if you don't have access, run "bit login" or verify your permissions on the scope
+  - if the scope name was a typo, rename it via "bit scope rename <old> <new>"
+then retry the merge:
 ${compsByScope}`
     );
   }

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -27,8 +27,6 @@ import { DEFAULT_LANE } from '@teambit/lane-id';
 import type { ConfigMergeResult } from '@teambit/config-merger';
 import type { Logger, LoggerMain } from '@teambit/logger';
 import { LoggerAspect } from '@teambit/logger';
-import { getScopeRemotes, ScopeNotFoundOrDenied } from '@teambit/scope.remotes';
-import { InvalidScopeName, InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
 import type { CheckoutMain, CheckoutProps } from '@teambit/checkout';
 import { CheckoutAspect, throwForFailures } from '@teambit/checkout';
 import type { SnapsDistance } from '@teambit/component.snap-distance';
@@ -118,10 +116,6 @@ export class MergeLanesMain {
       currentLaneId,
       options
     );
-
-    if (currentLaneId.isDefault()) {
-      await this.throwForLaneComponentsWithMissingScope(idsToMerge);
-    }
 
     const {
       mergeStrategy,
@@ -284,50 +278,6 @@ export class MergeLanesMain {
     await this.workspace?.consumer.onDestroy(`lane-merge (${otherLaneId.name})`);
 
     return { mergeResults, deleteResults, configMergeResults, mergedSuccessfullyIds, conflicts };
-  }
-
-  /**
-   * snapping/exporting a lane is allowed even if a new component's scope doesn't exist remotely yet —
-   * developers may iterate on a lane before the scope is created. once the lane gets merged into main,
-   * those scopes must exist, otherwise the merged snaps can never be exported. surfacing this here gives
-   * a clear error at merge time rather than a confusing failure at the next "bit export".
-   */
-  private async throwForLaneComponentsWithMissingScope(idsToMerge: ComponentID[]) {
-    if (!idsToMerge.length) return;
-    const scopeNames = uniq(idsToMerge.map((id) => id.scope));
-    const scopeRemotes = await getScopeRemotes(this.scope.legacyScope);
-    const missingScopes: string[] = [];
-    await pMapSeries(scopeNames, async (scopeName) => {
-      try {
-        await scopeRemotes.resolve(scopeName);
-      } catch (err) {
-        if (
-          err instanceof ScopeNotFoundOrDenied ||
-          err instanceof InvalidScopeNameFromRemote ||
-          err instanceof InvalidScopeName
-        ) {
-          missingScopes.push(scopeName);
-          return;
-        }
-        throw err;
-      }
-    });
-    if (!missingScopes.length) return;
-    const compsByScope = missingScopes
-      .map((scopeName) => {
-        const ids = idsToMerge.filter((id) => id.scope === scopeName).map((id) => `  - ${id.toString()}`);
-        return `scope "${scopeName}":\n${ids.join('\n')}`;
-      })
-      .join('\n');
-    throw new BitError(
-      `unable to merge into main: the following component(s) reference scope(s) that don't exist, are inaccessible, or have an invalid name.
-to resolve, depending on the cause:
-  - if the scope doesn't exist yet, create it on bit.cloud (or wherever it's hosted)
-  - if you don't have access, run "bit login" or verify your permissions on the scope
-  - if the scope name was a typo, rename it via "bit scope rename <old> <new>"
-then retry the merge:
-${compsByScope}`
-    );
   }
 
   private validateMergeFlags(otherLaneId: LaneId, currentLaneId: LaneId, options: MergeLaneOptions) {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -319,15 +319,15 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       }
       const newIds = ComponentIdList.fromArray(ids.filter((id) => !scope.isExported(id)));
       const newIdsGrouped = groupByScopeName(newIds);
+      const unresolvableScopes: string[] = [];
       await mapSeries(Object.keys(newIdsGrouped), async (scopeName) => {
         if (scopeName === laneObject.scope) {
           // this validation is redundant if the lane-component is in the same scope as the lane-object
           return;
         }
-        // we only need to check name conflicts with the original scope. if that scope can't be
-        // resolved — because it doesn't exist remotely yet, the user lacks access, or the name is
-        // invalid — there's no conflict to worry about here. the missing-scope/access error is
-        // raised later, when the lane gets merged into main.
+        // the central hub rejects pushes that reference scopes it doesn't know about, so we have to
+        // fail fast here with a clear error rather than let the user hit a cryptic "scope ID X is
+        // invalid." network error from the hub.
         let remote: Remote;
         try {
           remote = await scopeRemotes.resolve(scopeName);
@@ -337,6 +337,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
             err instanceof InvalidScopeNameFromRemote ||
             err instanceof InvalidScopeName
           ) {
+            unresolvableScopes.push(scopeName);
             return;
           }
           throw err;
@@ -350,6 +351,23 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           }
         });
       });
+      if (unresolvableScopes.length) {
+        const compsByScope = unresolvableScopes
+          .map((scopeName) => {
+            const compIds = newIdsGrouped[scopeName].map((id) => `  - ${id.toString()}`);
+            return `scope "${scopeName}":\n${compIds.join('\n')}`;
+          })
+          .join('\n');
+        throw new BitError(
+          `unable to export the lane: the following component(s) reference scope(s) that don't exist, are inaccessible, or have an invalid name.
+to resolve, depending on the cause:
+  - if the scope doesn't exist yet, create it on bit.cloud (or wherever it's hosted)
+  - if you don't have access, run "bit login" or verify your permissions on the scope
+  - if the scope name was a typo or placeholder (e.g. the default "my-scope"), set a real one via "bit scope set <scope-name>" (workspace-wide) or "bit scope set <scope-name> <component-pattern>" (per-component)
+then retry "bit export":
+${compsByScope}`
+        );
+      }
     };
 
     /**

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -319,15 +319,15 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       }
       const newIds = ComponentIdList.fromArray(ids.filter((id) => !scope.isExported(id)));
       const newIdsGrouped = groupByScopeName(newIds);
-      const unresolvableScopes: string[] = [];
       await mapSeries(Object.keys(newIdsGrouped), async (scopeName) => {
         if (scopeName === laneObject.scope) {
           // this validation is redundant if the lane-component is in the same scope as the lane-object
           return;
         }
-        // the central hub rejects pushes that reference scopes it doesn't know about, so we have to
-        // fail fast here with a clear error rather than let the user hit a cryptic "scope ID X is
-        // invalid." network error from the hub.
+        // we only need to check name conflicts with the original scope. if that scope can't be
+        // resolved — because it doesn't exist remotely yet, the user lacks access, or the name is
+        // invalid — there's no conflict to worry about here. the missing-scope/access error is
+        // raised later, when the lane gets merged into main.
         let remote: Remote;
         try {
           remote = await scopeRemotes.resolve(scopeName);
@@ -337,7 +337,6 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
             err instanceof InvalidScopeNameFromRemote ||
             err instanceof InvalidScopeName
           ) {
-            unresolvableScopes.push(scopeName);
             return;
           }
           throw err;
@@ -351,23 +350,6 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           }
         });
       });
-      if (unresolvableScopes.length) {
-        const compsByScope = unresolvableScopes
-          .map((scopeName) => {
-            const compIds = newIdsGrouped[scopeName].map((id) => `  - ${id.toString()}`);
-            return `scope "${scopeName}":\n${compIds.join('\n')}`;
-          })
-          .join('\n');
-        throw new BitError(
-          `unable to export the lane: the following component(s) reference scope(s) that don't exist, are inaccessible, or have an invalid name.
-to resolve, depending on the cause:
-  - if the scope doesn't exist yet, create it on bit.cloud (or wherever it's hosted)
-  - if you don't have access, run "bit login" or verify your permissions on the scope
-  - if the scope name was a typo or placeholder (e.g. the default "my-scope"), set a real one via "bit scope set <scope-name>" (workspace-wide) or "bit scope set <scope-name> <component-pattern>" (per-component)
-then retry "bit export":
-${compsByScope}`
-        );
-      }
     };
 
     /**

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -23,7 +23,7 @@ import mapSeries from 'p-map-series';
 import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import type { Remotes, Remote } from '@teambit/scope.remotes';
 import { getScopeRemotes, ScopeNotFoundOrDenied } from '@teambit/scope.remotes';
-import { InvalidScopeName, InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
+import { InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
 import type { EjectMain, EjectResults } from '@teambit/eject';
 import { EjectAspect } from '@teambit/eject';
 import type { ExportOrigin } from '@teambit/scope.network';
@@ -325,20 +325,16 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           // this validation is redundant if the lane-component is in the same scope as the lane-object
           return;
         }
-        // we only need to check name conflicts with the original scope. if that scope can't be
-        // resolved or listed — because it doesn't exist remotely yet, the user lacks access, or the
-        // name is invalid — there's no conflict to worry about here. the missing-scope/access error
-        // is raised later, when the lane gets merged into main.
+        // we only need to check name conflicts with the original scope. if the scope doesn't exist
+        // on the hub yet, or the user lacks access to it, there's no conflict to worry about — skip
+        // the check. malformed scope names (InvalidScopeName) are still raised, since those are a
+        // genuine user error worth surfacing.
         let list: ListScopeResult[];
         try {
           const remote = await scopeRemotes.resolve(scopeName);
           list = await remote.list();
         } catch (err) {
-          if (
-            err instanceof ScopeNotFoundOrDenied ||
-            err instanceof InvalidScopeNameFromRemote ||
-            err instanceof InvalidScopeName
-          ) {
+          if (err instanceof ScopeNotFoundOrDenied || err instanceof InvalidScopeNameFromRemote) {
             return;
           }
           throw err;

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -9,6 +9,7 @@ import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { CENTRAL_BIT_HUB_NAME, CENTRAL_BIT_HUB_URL, getCloudDomain } from '@teambit/legacy.constants';
 import type { Consumer } from '@teambit/legacy.consumer';
 import type { BitMap } from '@teambit/legacy.bit-map';
+import type { ListScopeResult } from '@teambit/legacy.component-list';
 import { ComponentsList } from '@teambit/legacy.component-list';
 import type { RemoveMain } from '@teambit/remove';
 import { RemoveAspect } from '@teambit/remove';
@@ -325,12 +326,13 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           return;
         }
         // we only need to check name conflicts with the original scope. if that scope can't be
-        // resolved — because it doesn't exist remotely yet, the user lacks access, or the name is
-        // invalid — there's no conflict to worry about here. the missing-scope/access error is
-        // raised later, when the lane gets merged into main.
-        let remote: Remote;
+        // resolved or listed — because it doesn't exist remotely yet, the user lacks access, or the
+        // name is invalid — there's no conflict to worry about here. the missing-scope/access error
+        // is raised later, when the lane gets merged into main.
+        let list: ListScopeResult[];
         try {
-          remote = await scopeRemotes.resolve(scopeName);
+          const remote = await scopeRemotes.resolve(scopeName);
+          list = await remote.list();
         } catch (err) {
           if (
             err instanceof ScopeNotFoundOrDenied ||
@@ -341,7 +343,6 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           }
           throw err;
         }
-        const list = await remote.list();
         const listIds = ComponentIdList.fromArray(list.map((listItem) => listItem.id));
         newIdsGrouped[scopeName].forEach((id) => {
           if (listIds.hasWithoutVersion(id)) {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -324,9 +324,10 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           // this validation is redundant if the lane-component is in the same scope as the lane-object
           return;
         }
-        // we only need to check name conflicts with the original scope. if that scope doesn't exist
-        // remotely yet, there's no conflict to worry about — the missing-scope error is raised later,
-        // when the lane gets merged into main.
+        // we only need to check name conflicts with the original scope. if that scope can't be
+        // resolved — because it doesn't exist remotely yet, the user lacks access, or the name is
+        // invalid — there's no conflict to worry about here. the missing-scope/access error is
+        // raised later, when the lane gets merged into main.
         let remote: Remote;
         try {
           remote = await scopeRemotes.resolve(scopeName);

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -325,10 +325,11 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           // this validation is redundant if the lane-component is in the same scope as the lane-object
           return;
         }
-        // we only need to check name conflicts with the original scope. if the scope doesn't exist
-        // on the hub yet, or the user lacks access to it, there's no conflict to worry about — skip
-        // the check. malformed scope names (InvalidScopeName) are still raised, since those are a
-        // genuine user error worth surfacing.
+        // this check guards against a same-named component already existing in the target scope
+        // (which would make the eventual lane-merge impossible — two components, same id, no shared
+        // snap history). if the scope doesn't exist on the hub yet, or the user lacks access to it,
+        // there's nothing there to conflict with, so skip the check. malformed scope names
+        // (InvalidScopeName) are intentionally still raised — those are a genuine user error.
         let list: ListScopeResult[];
         try {
           const remote = await scopeRemotes.resolve(scopeName);

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -21,7 +21,8 @@ import { compact } from 'lodash';
 import mapSeries from 'p-map-series';
 import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import type { Remotes, Remote } from '@teambit/scope.remotes';
-import { getScopeRemotes } from '@teambit/scope.remotes';
+import { getScopeRemotes, ScopeNotFoundOrDenied } from '@teambit/scope.remotes';
+import { InvalidScopeName, InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
 import type { EjectMain, EjectResults } from '@teambit/eject';
 import { EjectAspect } from '@teambit/eject';
 import type { ExportOrigin } from '@teambit/scope.network';
@@ -323,8 +324,22 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           // this validation is redundant if the lane-component is in the same scope as the lane-object
           return;
         }
-        // by getting the remote we also validate that this scope actually exists.
-        const remote = await scopeRemotes.resolve(scopeName);
+        // we only need to check name conflicts with the original scope. if that scope doesn't exist
+        // remotely yet, there's no conflict to worry about — the missing-scope error is raised later,
+        // when the lane gets merged into main.
+        let remote: Remote;
+        try {
+          remote = await scopeRemotes.resolve(scopeName);
+        } catch (err) {
+          if (
+            err instanceof ScopeNotFoundOrDenied ||
+            err instanceof InvalidScopeNameFromRemote ||
+            err instanceof InvalidScopeName
+          ) {
+            return;
+          }
+          throw err;
+        }
         const list = await remote.list();
         const listIds = ComponentIdList.fromArray(list.map((listItem) => listItem.id));
         newIdsGrouped[scopeName].forEach((id) => {


### PR DESCRIPTION
Previously, exporting a lane that has a new component whose scope doesn't exist remotely threw `cannot find scope` from `validateTargetScopeForLanes`. The central hub actually accepts pushes for well-formed-but-not-yet-existing scope names on a lane, so the pre-check was being over-strict and blocking a legitimate workflow (developers iterating on a lane before the target scope is created).

- `export.main.runtime.ts`: in `validateTargetScopeForLanes`, catch `ScopeNotFoundOrDenied` and `InvalidScopeNameFromRemote` from both `scopeRemotes.resolve()` and `remote.list()`, and skip the conflict check. `InvalidScopeName` (truly malformed names that fail the regex) is intentionally *not* caught — those are a genuine user error and should still surface.
- e2e test for the "scope doesn't exist" case updated to expect export to succeed.

Snap and merge-to-main behavior are unchanged.