### PR TITLE
feat(application): platform app build task that runs after build_application across envs

### DIFF
--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -26,6 +26,7 @@ import type { DeploymentProvider } from './deployment-provider';
 import { AppNotFound } from './exceptions';
 import { ApplicationAspect } from './application.aspect';
 import { AppsBuildTask } from './build-application.task';
+import { PlatformAppsBuildTask } from './build-platform-application.task';
 import { RunCmd } from './run.cmd';
 import { AppService } from './application.service';
 import { AppCmd, AppListCmd } from './app.cmd';
@@ -533,7 +534,7 @@ export class ApplicationMain {
     const appCmd = new AppCmd(application);
     appCmd.commands = [new AppListCmd(application), new RunCmd(application, logger)];
     aspectLoader.registerPlugins([new AppPlugin(appSlot)]);
-    builder.registerBuildTasks([new AppsBuildTask(application)]);
+    builder.registerBuildTasks([new AppsBuildTask(application), new PlatformAppsBuildTask(application)]);
     builder.registerSnapTasks([new DeployTask(application, builder)]);
     builder.registerTagTasks([new DeployTask(application, builder)]);
     envs.registerService(appService);

--- a/scopes/harmony/application/application.ts
+++ b/scopes/harmony/application/application.ts
@@ -38,4 +38,13 @@ export interface Application {
    * Type of the application
    */
   applicationType?: string;
+
+  /**
+   * mark this app as a "platform" — an app that bundles other apps' build artifacts (e.g. embeds a
+   * frontend app and one or more backend apps). when true, the default `build_application` task
+   * skips this app and a dedicated `build_platform_application` task runs it instead, after every
+   * env has finished its `build_application`. this ensures the dependency apps' artifacts are on
+   * disk by the time the platform's bundler reads them, regardless of cross-env ordering.
+   */
+  platform?: boolean;
 }

--- a/scopes/harmony/application/build-application.task.ts
+++ b/scopes/harmony/application/build-application.task.ts
@@ -43,9 +43,17 @@ export class AppsBuildTask implements BuildTask {
   aspectId = ApplicationAspect.id;
   readonly location = 'end';
   constructor(
-    private application: ApplicationMain,
+    protected application: ApplicationMain,
     private opt: Options = { deploy: true }
   ) {}
+
+  /**
+   * decides whether this task should build a given app. the default task runs on every app except
+   * platforms; `PlatformAppsBuildTask` overrides this to only run on platforms.
+   */
+  protected shouldRunForApp(app: Application): boolean {
+    return app.platform !== true;
+  }
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     const originalSeedersIds = context.capsuleNetwork.originalSeedersCapsules.map((c) => c.component.id.toString());
@@ -85,6 +93,7 @@ export class AppsBuildTask implements BuildTask {
     context: BuildContext
   ): Promise<OneAppResult | undefined> {
     if (!app.build) return undefined;
+    if (!this.shouldRunForApp(app)) return undefined;
     const artifactsDir = this.getArtifactDirectory();
     const capsuleRootDir = context.capsuleNetwork.capsulesRootDir;
     const appContext = await this.application.createAppBuildContext(

--- a/scopes/harmony/application/build-platform-application.task.ts
+++ b/scopes/harmony/application/build-platform-application.task.ts
@@ -1,0 +1,24 @@
+import { ApplicationAspect } from './application.aspect';
+import type { Application } from './application';
+import { AppsBuildTask, BUILD_TASK } from './build-application.task';
+
+export const BUILD_PLATFORM_TASK = 'build_platform_application';
+
+/**
+ * a build task dedicated to "platform" apps — apps that bundle other apps' build artifacts.
+ *
+ * declared as a task-level dependency on `build_application`, so the pipeline runs every env's
+ * `build_application` first and only then comes back to run this task. by that point each env has
+ * produced its app-bundle artifact (frontend bundles, backend bundles, etc.) in its capsule, so a
+ * platform's bundler can read them regardless of the env iteration order.
+ *
+ * see `Application.platform` for the per-app opt-in.
+ */
+export class PlatformAppsBuildTask extends AppsBuildTask {
+  name = BUILD_PLATFORM_TASK;
+  dependencies = [`${ApplicationAspect.id}:${BUILD_TASK}`];
+
+  protected shouldRunForApp(app: Application): boolean {
+    return app.platform === true;
+  }
+}

--- a/scopes/harmony/application/deploy.task.ts
+++ b/scopes/harmony/application/deploy.task.ts
@@ -16,6 +16,7 @@ import { ApplicationAspect } from './application.aspect';
 import type { ApplicationMain } from './application.main.runtime';
 import type { BuildDeployContexts } from './build-application.task';
 import { ARTIFACTS_DIR_NAME, BUILD_TASK } from './build-application.task';
+import { BUILD_PLATFORM_TASK } from './build-platform-application.task';
 import { AppDeployContext } from './app-deploy-context';
 import type { Application } from './application';
 import type { ApplicationDeployment } from './app-instance';
@@ -87,7 +88,7 @@ export class DeployTask implements BuildTask {
 
     if (!capsule || !capsule?.component) return undefined;
 
-    const buildTask = this.getBuildTask(context.previousTasksResults, context.envRuntime.id);
+    const buildTask = this.getBuildTask(context.previousTasksResults, context.envRuntime.id, app);
 
     const metadata = this.getBuildMetadata(buildTask, capsule.component);
     if (!metadata) return undefined;
@@ -139,9 +140,10 @@ export class DeployTask implements BuildTask {
     return componentResults?.metadata?.buildDeployContexts;
   }
 
-  private getBuildTask(taskResults: TaskResults[], runtime: string) {
+  private getBuildTask(taskResults: TaskResults[], runtime: string, app: Application) {
+    const buildTaskName = app.platform === true ? BUILD_PLATFORM_TASK : BUILD_TASK;
     return taskResults.find(
-      ({ task, env }) => task.aspectId === ApplicationAspect.id && task.name === BUILD_TASK && env.id === runtime
+      ({ task, env }) => task.aspectId === ApplicationAspect.id && task.name === buildTaskName && env.id === runtime
     );
   }
 }


### PR DESCRIPTION
Adds a dedicated build task for "platform" apps (apps that bundle other apps' build artifacts), so cross-env ordering can't leave a platform's bundler reading an artifact that hasn't been produced yet.

## Why
On a lane with a platform-app (node env) that embeds a frontend-app (react env) and a backend-app (node env), the build pipeline iterates env-by-env. When node env runs first, the platform-app's bundler can't find the frontend-app's `app-build` artifact because react env hasn't run yet. Toposorting envs by component deps doesn't work — components across envs often form env-level cycles even when component deps are acyclic.

## How
- New `Application.platform?: boolean` opt-in on the app.
- `AppsBuildTask` gains a `shouldRunForApp` hook and skips apps where `platform === true`.
- New `PlatformAppsBuildTask` extends `AppsBuildTask`, runs only for platform apps, and declares `dependencies: ['teambit.harmony/application:build_application']`. The existing toposort in the `end` location bucket places `build_application` (every env) ahead of `build_platform_application` (every env), so by the time the platform task fires, every other env has already emitted its app-bundle artifact.
- `DeployTask` resolves build metadata from the correct task name based on `app.platform`.

## Test plan
- [ ] Run build on a platform lane and confirm the platform's bundler finds upstream app-build artifacts regardless of env iteration order
- [ ] Confirm non-platform apps still build and deploy via `build_application` / `deploy_application` unchanged
- [ ] Platform components: set `platform = true` on the `Platform` class to opt in