### PR TITLE
fix(importer): resolve `bit import <id>` to main head for hidden lane.updateDependents

### DIFF
--- a/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
+++ b/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
@@ -1066,6 +1066,43 @@ describe('local snap cascades updateDependents on the lane', function () {
         expect(promotedSnap.parents).to.include(comp2HashOnMain);
         expect(promotedSnap.parents).to.not.include(comp2InUpdDepInitial);
       });
+
+      // -------------------------------------------------------------------------------------
+      // After the export, a second consumer who imports the lane from scratch must see comp2
+      // as a real lane component — both on the lane object and in the workspace bitmap. This
+      // confirms the promotion is observable to consumers, not just a workspace-local rewrite.
+      // -------------------------------------------------------------------------------------
+      describe('a fresh workspace then imports the exported lane', () => {
+        let comp2HeadAfterPromote: string;
+        before(() => {
+          const remoteLane = helper.command.catLane('dev', helper.scopes.remotePath);
+          const comp2OnRemoteLane = remoteLane.components.find((c) => c.id.name === 'comp2') as { head: string };
+          comp2HeadAfterPromote = comp2OnRemoteLane.head;
+
+          helper.scopeHelper.reInitWorkspace();
+          helper.scopeHelper.addRemoteScope(helper.scopes.remotePath);
+          helper.command.importLane('dev', '-x');
+        });
+
+        it('the imported lane object lists comp2 under components (visible, not hidden)', () => {
+          const localLane = helper.command.catLane('dev');
+          const comp2InComp = localLane.components.find((c) => c.id.name === 'comp2') as { head: string };
+          expect(comp2InComp, 'comp2 should be visible on the imported lane').to.exist;
+          expect(comp2InComp.head).to.equal(comp2HeadAfterPromote);
+        });
+
+        it('the imported lane does NOT carry comp2 in updateDependents', () => {
+          const localLane = helper.command.catLane('dev');
+          const comp2InUpdDep = (localLane.updateDependents || []).find((s) => s.includes('comp2'));
+          expect(comp2InUpdDep, 'comp2 must not appear in updateDependents on the imported lane').to.be.undefined;
+        });
+
+        it('comp2 lands in the fresh workspace bitmap at the promoted lane head', () => {
+          const bitMap = helper.bitMap.read();
+          expect(bitMap).to.have.property('comp2');
+          expect(bitMap.comp2.version).to.equal(comp2HeadAfterPromote);
+        });
+      });
     });
   });
 });

--- a/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
+++ b/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
@@ -996,4 +996,76 @@ describe('local snap cascades updateDependents on the lane', function () {
       expect(comp3OnRemote.head).to.equal(comp3HeadAfterSnap);
     });
   });
+
+  // ---------------------------------------------------------------------------------------------
+  // Scenario 19: explicit `bit import <id>` of a hidden updateDependent must land main's tagged
+  // version in the workspace bitmap — not the lane's cascade snap. A subsequent snap then
+  // promotes the component cleanly into `lane.components` and clears the hidden entry, so it
+  // never lives in both buckets at once. Also locks down the snap's parent chain: it descends
+  // from main's head, not the cascade hash, so promote-on-import doesn't silently graft the
+  // cascade history into the lane component graph.
+  // ---------------------------------------------------------------------------------------------
+  describe('scenario 19: bit import of hidden updateDependent lands main version; snap promotes cleanly', () => {
+    let comp2InUpdDepInitial: string;
+    let comp2HashOnMain: string;
+
+    before(async () => {
+      const base = await buildBaseRemoteState();
+      comp2InUpdDepInitial = base.comp2InUpdDepInitial;
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath);
+      helper.command.importLane('dev', '-x');
+      helper.command.importComponent('comp2');
+
+      comp2HashOnMain = helper.command.getHead(`${helper.scopes.remote}/comp2`);
+      // sanity — the cascade snap on the lane and main's head are distinct hashes
+      expect(comp2InUpdDepInitial).to.not.equal(comp2HashOnMain);
+    });
+
+    it("bitmap.comp2 should land at main's tag (0.0.1), not the lane's cascade snap", () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.have.property('comp2');
+      expect(bitMap.comp2.version).to.equal('0.0.1');
+      expect(bitMap.comp2.version).to.not.equal(comp2InUpdDepInitial);
+    });
+
+    it('comp2 stays hidden on the remote (import alone does not promote)', () => {
+      const remoteLane = helper.command.catLane('dev', helper.scopes.remotePath);
+      expect(remoteLane.updateDependents).to.have.lengthOf(1);
+      expect(remoteLane.updateDependents[0].split('@')[1]).to.equal(comp2InUpdDepInitial);
+    });
+
+    describe('after editing and snapping the imported comp2', () => {
+      before(() => {
+        helper.fs.outputFile(`${helper.scopes.remote}/comp2/index.js`, "module.exports = () => 'comp2-v2';");
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+      });
+
+      it('comp2 lands in lane.components on the remote (promoted from hidden)', () => {
+        const remoteLane = helper.command.catLane('dev', helper.scopes.remotePath);
+        const comp2InComp = remoteLane.components.find((c) => c.id.name === 'comp2');
+        expect(comp2InComp, 'comp2 should be in lane.components after promotion').to.exist;
+      });
+
+      it('comp2 is removed from lane.updateDependents (no duplicate across both buckets)', () => {
+        const remoteLane = helper.command.catLane('dev', helper.scopes.remotePath);
+        const comp2InUpdDep = (remoteLane.updateDependents || []).find((s) => s.includes('comp2'));
+        expect(comp2InUpdDep, 'comp2 must not remain in updateDependents after promotion').to.be.undefined;
+      });
+
+      it("the promoted snap descends from main's head, not the prior cascade snap", () => {
+        const remoteLane = helper.command.catLane('dev', helper.scopes.remotePath);
+        const comp2OnLane = remoteLane.components.find((c) => c.id.name === 'comp2') as { head: string };
+        const promotedSnap = helper.command.catComponent(
+          `${helper.scopes.remote}/comp2@${comp2OnLane.head}`,
+          helper.scopes.remotePath
+        );
+        expect(promotedSnap.parents).to.have.lengthOf(1);
+        expect(promotedSnap.parents).to.include(comp2HashOnMain);
+        expect(promotedSnap.parents).to.not.include(comp2InUpdDepInitial);
+      });
+    });
+  });
 });

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -26,7 +26,7 @@ import type {
 } from '@teambit/component-writer';
 import { LATEST_VERSION } from '@teambit/component-version';
 import type { EnvsMain } from '@teambit/envs';
-import { compact, difference, fromPairs } from 'lodash';
+import { compact, difference, fromPairs, partition } from 'lodash';
 import type { WorkspaceConfigUpdateResult } from '@teambit/config-merger';
 import type { Logger } from '@teambit/logger';
 import { DependentsGetter } from './dependents-getter';
@@ -105,6 +105,14 @@ export default class ImportComponents {
   mergeStatus: { [id: string]: FilesStatus };
   private remoteLane: Lane | undefined;
   private divergeData: Array<ModelComponent> = [];
+  private _visibleLaneIds?: ComponentIdList;
+  /** Visible lane components only — excludes hidden `lane.updateDependents`. */
+  private get visibleLaneIds(): ComponentIdList {
+    if (!this._visibleLaneIds) {
+      this._visibleLaneIds = this.remoteLane?.toComponentIds() || new ComponentIdList();
+    }
+    return this._visibleLaneIds;
+  }
   constructor(
     private workspace: Workspace,
     private graph: GraphMain,
@@ -200,30 +208,25 @@ export default class ImportComponents {
     const bitIds: ComponentIdList = await this.getBitIds();
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
     await this._throwForPotentialIssues(bitIds);
-    // Split the fetch by lane membership. The user-explicit `bit import <id>` path may include
-    // ids that aren't visible on the lane — either truly off-lane components, or hidden cascade
-    // entries living only in `lane.updateDependents`. The lane's remote-lane store carries hidden
-    // heads (needed for cascade divergence on lane import), so honoring `lane` here would resolve
-    // hidden entries to their lane-snap hash instead of main's tag. Visible lane ids still go
-    // through the lane fetch; everything else falls back to main.
-    const visibleLaneIds = this.remoteLane?.toComponentIds() || new ComponentIdList();
-    const onLaneIds = ComponentIdList.fromArray(bitIds.filter((id) => visibleLaneIds.searchWithoutVersion(id)));
-    // Off-lane ids include hidden `lane.updateDependents` entries and components that aren't on
-    // the lane at all. We must NOT resolve them through the lane — `laneHeadLocal` carries the
-    // hidden cascade head (needed for export-pending detection) and would otherwise leak into
-    // `toComponentVersion`, landing the cascade snap in the bitmap instead of main's tag. Pre-pin
-    // each off-lane id to the main head (`modelComponent.head`) so the downstream version
-    // resolution can't fall back to `laneHeadLocal`.
-    const offLaneRaw = bitIds.filter((id) => !visibleLaneIds.searchWithoutVersion(id));
+    // Off-lane ids (incl. hidden `lane.updateDependents`) must not be resolved through the lane:
+    // `laneHeadLocal` carries the hidden cascade head — legitimate for export-pending detection,
+    // but it would leak into `toComponentVersion` and land the cascade snap in the bitmap instead
+    // of main's tag. Pre-pin off-lane ids to `modelComponent.head` so the downstream resolution
+    // can't fall back to `laneHeadLocal`.
+    const visibleLaneIds = this.visibleLaneIds;
+    const [onLaneRaw, offLaneRawList] = partition(bitIds, (id) => Boolean(visibleLaneIds.searchWithoutVersion(id)));
+    const onLaneIds = ComponentIdList.fromArray(onLaneRaw);
+    const offLaneNeedingHead = offLaneRawList.filter((id) => !id.hasVersion());
+    const headDefs = await this.scope.sources.getMany(offLaneNeedingHead);
+    const headByIdStr = new Map(
+      headDefs.map(({ id, component }) => [id.toStringWithoutVersion(), component?.head] as const)
+    );
     const offLaneIds = ComponentIdList.fromArray(
-      await Promise.all(
-        offLaneRaw.map(async (id) => {
-          if (id.hasVersion()) return id;
-          const mc = await this.scope.sources.get(id);
-          const mainHead = mc?.head;
-          return mainHead ? id.changeVersion(mainHead.toString()) : id;
-        })
-      )
+      offLaneRawList.map((id) => {
+        if (id.hasVersion()) return id;
+        const mainHead = headByIdStr.get(id.toStringWithoutVersion());
+        return mainHead ? id.changeVersion(mainHead.toString()) : id;
+      })
     );
     const versionDependenciesArr: VersionDependencies[] = [];
     if (onLaneIds.length) {
@@ -580,15 +583,12 @@ if you just want to get a quick look into this snap, create a new workspace and 
     if (!this.options.lanes) {
       throw new Error(`getBitIdsForLanes: this.options.lanes must be set`);
     }
-    // Two separate views of the lane's ids:
-    //  - `remoteLaneIds` (visible + hidden): used for the no-ids object-fetch path so hidden
-    //    entries' Version objects land locally for merge/diverge calculations.
-    //  - `visibleRemoteLaneIds` (visible only): used when the user explicitly names ids or
-    //    wildcards. `bit import comp2` for a comp2 that lives in `lane.updateDependents` (hidden)
-    //    must NOT resolve to the lane's hidden snap — that's the cascaded bookkeeping head;
-    //    explicit import should land main's version so the workspace can promote it via snap.
-    const visibleRemoteLaneIds = this.remoteLane?.toComponentIds() || new ComponentIdList();
+    // For the no-ids object-fetch path we include hidden entries — their Version objects must
+    // land locally for merge/diverge calculations. For explicit ids/wildcards we use visible-only,
+    // otherwise `bit import comp2` (when comp2 is hidden on the lane) would resolve to the
+    // cascade snap instead of main's tag.
     const remoteLaneIds = this.remoteLane?.toComponentIdsIncludeUpdateDependents() || new ComponentIdList();
+    const visibleRemoteLaneIds = this.visibleLaneIds;
 
     if (!this.options.ids.length) {
       const bitMapIds = this.consumer.bitMap.getAllBitIds();

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -200,9 +200,40 @@ export default class ImportComponents {
     const bitIds: ComponentIdList = await this.getBitIds();
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
     await this._throwForPotentialIssues(bitIds);
-    const versionDependenciesArr = await this._importComponentsObjects(bitIds, {
-      lane: this.remoteLane,
-    });
+    // Split the fetch by lane membership. The user-explicit `bit import <id>` path may include
+    // ids that aren't visible on the lane — either truly off-lane components, or hidden cascade
+    // entries living only in `lane.updateDependents`. The lane's remote-lane store carries hidden
+    // heads (needed for cascade divergence on lane import), so honoring `lane` here would resolve
+    // hidden entries to their lane-snap hash instead of main's tag. Visible lane ids still go
+    // through the lane fetch; everything else falls back to main.
+    const visibleLaneIds = this.remoteLane?.toComponentIds() || new ComponentIdList();
+    const onLaneIds = ComponentIdList.fromArray(bitIds.filter((id) => visibleLaneIds.searchWithoutVersion(id)));
+    // Off-lane ids include hidden `lane.updateDependents` entries and components that aren't on
+    // the lane at all. We must NOT resolve them through the lane — `laneHeadLocal` carries the
+    // hidden cascade head (needed for export-pending detection) and would otherwise leak into
+    // `toComponentVersion`, landing the cascade snap in the bitmap instead of main's tag. Pre-pin
+    // each off-lane id to the main head (`modelComponent.head`) so the downstream version
+    // resolution can't fall back to `laneHeadLocal`.
+    const offLaneRaw = bitIds.filter((id) => !visibleLaneIds.searchWithoutVersion(id));
+    const offLaneIds = ComponentIdList.fromArray(
+      await Promise.all(
+        offLaneRaw.map(async (id) => {
+          if (id.hasVersion()) return id;
+          const mc = await this.scope.sources.get(id);
+          const mainHead = mc?.head;
+          return mainHead ? id.changeVersion(mainHead.toString()) : id;
+        })
+      )
+    );
+    const versionDependenciesArr: VersionDependencies[] = [];
+    if (onLaneIds.length) {
+      const onLaneResults = await this._importComponentsObjects(onLaneIds, { lane: this.remoteLane });
+      versionDependenciesArr.push(...onLaneResults);
+    }
+    if (offLaneIds.length) {
+      const offLaneResults = await this._importComponentsObjects(offLaneIds, {});
+      versionDependenciesArr.push(...offLaneResults);
+    }
 
     return this.processAndWriteComponents(beforeImportVersions, versionDependenciesArr);
   }
@@ -549,11 +580,14 @@ if you just want to get a quick look into this snap, create a new workspace and 
     if (!this.options.lanes) {
       throw new Error(`getBitIdsForLanes: this.options.lanes must be set`);
     }
-    // include hidden lane.updateDependents — `importObjectsOnLane` runs with `objectsOnly=true`
-    // and is the workspace's `bit fetch --lanes` fetch path. Hidden entries' Version objects must
-    // be present locally so subsequent merge/diverge checks can resolve their lane heads.
-    // (Hidden entries don't enter the workspace bitmap regardless — they live only in
-    // lane.updateDependents, not in lane.components.)
+    // Two separate views of the lane's ids:
+    //  - `remoteLaneIds` (visible + hidden): used for the no-ids object-fetch path so hidden
+    //    entries' Version objects land locally for merge/diverge calculations.
+    //  - `visibleRemoteLaneIds` (visible only): used when the user explicitly names ids or
+    //    wildcards. `bit import comp2` for a comp2 that lives in `lane.updateDependents` (hidden)
+    //    must NOT resolve to the lane's hidden snap — that's the cascaded bookkeeping head;
+    //    explicit import should land main's version so the workspace can promote it via snap.
+    const visibleRemoteLaneIds = this.remoteLane?.toComponentIds() || new ComponentIdList();
     const remoteLaneIds = this.remoteLane?.toComponentIdsIncludeUpdateDependents() || new ComponentIdList();
 
     if (!this.options.ids.length) {
@@ -569,7 +603,7 @@ if you just want to get a quick look into this snap, create a new workspace and 
     const idsWithoutWildcardPreferFromLane = await Promise.all(
       idsWithoutWildcard.map(async (idStr) => {
         const id = await this.getIdFromStr(idStr);
-        const fromLane = remoteLaneIds.searchWithoutVersion(id);
+        const fromLane = visibleRemoteLaneIds.searchWithoutVersion(id);
         return fromLane && !id.hasVersion() ? fromLane : id;
       })
     );
@@ -581,7 +615,7 @@ if you just want to get a quick look into this snap, create a new workspace and 
     }
 
     await pMapSeries(idsWithWildcard, async (idStr: string) => {
-      const existingOnLanes = await this.workspace.filterIdsFromPoolIdsByPattern(idStr, remoteLaneIds, false);
+      const existingOnLanes = await this.workspace.filterIdsFromPoolIdsByPattern(idStr, visibleRemoteLaneIds, false);
 
       if (this.options.laneOnly) {
         // When --lane-only is specified, import only components that exist on the lane, never from main

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -208,37 +208,48 @@ export default class ImportComponents {
     const bitIds: ComponentIdList = await this.getBitIds();
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
     await this._throwForPotentialIssues(bitIds);
-    // Off-lane ids (incl. hidden `lane.updateDependents`) must not be resolved through the lane:
-    // `laneHeadLocal` carries the hidden cascade head — legitimate for export-pending detection,
-    // but it would leak into `toComponentVersion` and land the cascade snap in the bitmap instead
-    // of main's tag. Pre-pin off-lane ids to `modelComponent.head` so the downstream resolution
-    // can't fall back to `laneHeadLocal`.
-    const visibleLaneIds = this.visibleLaneIds;
-    const [onLaneRaw, offLaneRawList] = partition(bitIds, (id) => Boolean(visibleLaneIds.searchWithoutVersion(id)));
-    const onLaneIds = ComponentIdList.fromArray(onLaneRaw);
-    const offLaneNeedingHead = offLaneRawList.filter((id) => !id.hasVersion());
-    const headDefs = await this.scope.sources.getMany(offLaneNeedingHead);
+    const versionDependenciesArr = await this.fetchVersionDependenciesForImport(bitIds);
+
+    return this.processAndWriteComponents(beforeImportVersions, versionDependenciesArr);
+  }
+
+  /**
+   * Hidden `lane.updateDependents` entries must not resolve through the lane: `laneHeadLocal`
+   * carries the cascade head — legitimate for export-pending detection — but it would leak into
+   * `toComponentVersion` and land the cascade snap in the bitmap instead of main's tag. Pre-pin
+   * hidden ids to `modelComponent.head` and fetch them via the no-lane path. Visible-on-lane
+   * and truly off-lane ids stay on the original lane-fetch path so their normal delta logic
+   * (lane head for visible, latest-from-main for off-lane) is preserved.
+   */
+  private async fetchVersionDependenciesForImport(bitIds: ComponentIdList): Promise<VersionDependencies[]> {
+    const lane = this.remoteLane;
+    if (!lane) {
+      return this._importComponentsObjects(bitIds, {});
+    }
+    const [hiddenRaw, others] = partition(bitIds, (id) => Boolean(lane.findUpdateDependent(id)));
+    const othersList = ComponentIdList.fromArray(others);
+    const hiddenNeedingHead = hiddenRaw.filter((id) => !id.hasVersion());
+    const headDefs = await this.scope.sources.getMany(hiddenNeedingHead);
     const headByIdStr = new Map(
       headDefs.map(({ id, component }) => [id.toStringWithoutVersion(), component?.head] as const)
     );
-    const offLaneIds = ComponentIdList.fromArray(
-      offLaneRawList.map((id) => {
+    const hiddenIds = ComponentIdList.fromArray(
+      hiddenRaw.map((id) => {
         if (id.hasVersion()) return id;
         const mainHead = headByIdStr.get(id.toStringWithoutVersion());
         return mainHead ? id.changeVersion(mainHead.toString()) : id;
       })
     );
     const versionDependenciesArr: VersionDependencies[] = [];
-    if (onLaneIds.length) {
-      const onLaneResults = await this._importComponentsObjects(onLaneIds, { lane: this.remoteLane });
-      versionDependenciesArr.push(...onLaneResults);
+    if (othersList.length) {
+      const r = await this._importComponentsObjects(othersList, { lane });
+      versionDependenciesArr.push(...r);
     }
-    if (offLaneIds.length) {
-      const offLaneResults = await this._importComponentsObjects(offLaneIds, {});
-      versionDependenciesArr.push(...offLaneResults);
+    if (hiddenIds.length) {
+      const r = await this._importComponentsObjects(hiddenIds, {});
+      versionDependenciesArr.push(...r);
     }
-
-    return this.processAndWriteComponents(beforeImportVersions, versionDependenciesArr);
+    return versionDependenciesArr;
   }
 
   /**


### PR DESCRIPTION
## Summary

`bit import comp2` on a lane where `comp2` lives in `lane.updateDependents` was landing the cascade snap hash in the workspace bitmap instead of main's tagged version. This broke the promote-on-import flow — the user expects main's canonical version to edit and snap.

Side-effect of the cascade work in #10358: hidden Version objects are now fetched on lane import, and `laneHeadLocal` carries the hidden cascade head (needed for export-pending detection of cascade snaps). Both are intentional, but they contaminated `toComponentVersion(undefined)` for explicit imports.

## Fix

In `importSpecificComponents`, partition explicit-id imports by lane visibility:
- **Visible-on-lane** → fetch through the lane (unchanged)
- **Off-lane** (incl. hidden `lane.updateDependents`, components not on the lane) → fetch from main, with id pre-pinned to `modelComponent.head` so version resolution can't fall back to `laneHeadLocal`

The no-ids lane-import path (`importObjectsOnLane`) is untouched — hidden Version objects still get pulled for cascade/divergence calculations.

## Test plan

- [x] All 46 cascade e2e scenarios pass (`e2e/harmony/lanes/update-dependents-cascade.e2e.ts`)
- [x] Lint clean
