### PR TITLE
fix(scope): validate object refs in /scope/fetch

### DIFF
--- a/components/legacy/scope-api/lib/fetch.ts
+++ b/components/legacy/scope-api/lib/fetch.ts
@@ -2,6 +2,7 @@ import type { Readable } from 'stream';
 import Queue from 'p-queue';
 import { ComponentIdList } from '@teambit/component-id';
 import semver from 'semver';
+import { isHash } from '@teambit/component-version';
 import { LaneId } from '@teambit/lane-id';
 import { LATEST_BIT_VERSION } from '@teambit/legacy.constants';
 import { logger } from '@teambit/legacy.logger';
@@ -338,6 +339,12 @@ async function fetchByType(
       break;
     }
     case 'object': {
+      // ids here are raw object hashes from the client. validate before constructing Refs because
+      // Ref.hash is later joined into a filesystem path (Repository.objectPath) and a malformed
+      // hash containing path-traversal segments would escape the objects dir on fs.readFile.
+      for (const id of ids) {
+        if (!isHash(id)) throw new Error(`invalid object ref: ${JSON.stringify(id)}`);
+      }
       const refs = ids.map((id) => new Ref(id));
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       objectsReadableGenerator.pushObjects(refs, scope);


### PR DESCRIPTION
`/scope/fetch` with `type: 'object'` was passing user-supplied `ids` directly into `new Ref(id)` without format validation. The other fetch types already validate via `ComponentID.fromString` or `LaneId.parse`; this brings the `object` type in line.

Validates each id with `isHash` (3–40 hex chars, so short-hash lookups still work) before constructing the `Ref`.