### PR TITLE
fix(doctor): exclude previous doctor-results archives from new archive

### DIFF
--- a/e2e/doctor/doctor-infra.e2e.ts
+++ b/e2e/doctor/doctor-infra.e2e.ts
@@ -132,6 +132,32 @@ describe('bit doctor infra', function () {
     });
   });
 
+  describe('archive should exclude previously created doctor-results archives', () => {
+    let secondArchiveEntries: string[];
+    const firstArchiveName = 'doctor-results-1000000000000.tar';
+    const secondArchiveName = 'doctor-results-2000000000000.tar';
+    before(async () => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(1);
+      const firstPath = path.join(helper.scopes.localPath, firstArchiveName);
+      helper.command.runCmd(`bit doctor --archive ${firstPath}`);
+      const secondPath = path.join(helper.scopes.localPath, secondArchiveName);
+      helper.command.runCmd(`bit doctor --archive ${secondPath}`);
+      secondArchiveEntries = await getTarEntries(secondPath);
+    });
+    it('should create the first archive on disk', () => {
+      expect(path.join(helper.scopes.localPath, firstArchiveName)).to.be.a.file().and.not.empty;
+    });
+    it('should archive workspace files (sanity check)', () => {
+      const workspaceFiles = secondArchiveEntries.filter((e) => e.includes('workspace.jsonc'));
+      expect(workspaceFiles).to.have.lengthOf.at.least(1);
+    });
+    it('should not include the previously created doctor-results archive', () => {
+      const matched = secondArchiveEntries.filter((e) => /(^|\/)doctor-results-\d+\.tar(\.gz)?$/.test(e));
+      expect(matched).to.have.lengthOf(0);
+    });
+  });
+
   describe('list all checks', () => {
     let output;
     let parsedOutput;

--- a/scopes/harmony/doctor/doctor.main.runtime.ts
+++ b/scopes/harmony/doctor/doctor.main.runtime.ts
@@ -307,8 +307,8 @@ export class DoctorMain {
 
     const doctorResultsRegex = /^doctor-results-\d+\.tar(\.gz)?$/;
     const ignore = (fileName: string) => {
-      if (fileName === '.DS_Store') return true;
       const baseName = path.basename(fileName);
+      if (baseName === '.DS_Store') return true;
       if (doctorResultsRegex.test(baseName)) return true;
       if (
         !includeNodeModules &&

--- a/scopes/harmony/doctor/doctor.main.runtime.ts
+++ b/scopes/harmony/doctor/doctor.main.runtime.ts
@@ -243,11 +243,10 @@ export class DoctorMain {
     if (fileName === '.') {
       return this._getDefaultFileName();
     }
-    let finalFileName = fileName;
-    if (getExt(fileName) !== 'tar' && getExt(fileName) !== 'tar.gz') {
-      finalFileName = `${this.getWithoutExt(finalFileName)}.tar`;
+    if (fileName.endsWith('.tar') || fileName.endsWith('.tar.gz')) {
+      return fileName;
     }
-    return finalFileName;
+    return `${this.getWithoutExt(fileName)}.tar`;
   }
 
   private _getDefaultFileName() {

--- a/scopes/harmony/doctor/doctor.main.runtime.ts
+++ b/scopes/harmony/doctor/doctor.main.runtime.ts
@@ -305,8 +305,11 @@ export class DoctorMain {
       return packExamineResults(pack);
     }
 
+    const doctorResultsRegex = /^doctor-results-\d+\.tar(\.gz)?$/;
     const ignore = (fileName: string) => {
       if (fileName === '.DS_Store') return true;
+      const baseName = path.basename(fileName);
+      if (doctorResultsRegex.test(baseName)) return true;
       if (
         !includeNodeModules &&
         (fileName.startsWith(`node_modules${path.sep}`) || fileName.includes(`${path.sep}node_modules${path.sep}`))


### PR DESCRIPTION
When running `bit doctor -a` multiple times, the second run was including the archive created by the first run. Now the `ignore` function filters out any file matching the default `doctor-results-<timestamp>.tar(.gz)?` pattern, so stale archives are skipped automatically.