### PR TITLE
ci: add manual workflow to flip a version's stable flag in index.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,9 @@ parameters:
   release_stable:
     type: boolean
     default: true
+  release_test_mode:
+    type: boolean
+    default: false
 
 # ========================================
 # ORBS
@@ -999,13 +1002,18 @@ jobs:
           environment:
             RELEASE_VERSION: "<< pipeline.parameters.release_version >>"
             RELEASE_STABLE: "<< pipeline.parameters.release_stable >>"
+            RELEASE_TEST_MODE: "<< pipeline.parameters.release_test_mode >>"
           command: node scripts/update-bit-stable-flag.js
       - run:
           name: Upload index.json
-          command: gsutil cp index.json gs://bvm.bit.dev/bit/index.json
-      - run:
-          name: clear index.json cache
-          command: gsutil setmeta -h "Cache-Control:no-cache" gs://bvm.bit.dev/bit/index.json
+          command: |
+            if [ "<< pipeline.parameters.release_test_mode >>" = "true" ]; then
+              TARGET="index-test.json"
+            else
+              TARGET="index.json"
+            fi
+            gsutil cp index.json "gs://bvm.bit.dev/bit/$TARGET"
+            gsutil setmeta -h "Cache-Control:no-cache" "gs://bvm.bit.dev/bit/$TARGET"
       - store_artifacts:
           path: index.json
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,21 @@ master_only_filter: &master_only_filter
       only: master
 
 # ========================================
+# PIPELINE PARAMETERS
+# ========================================
+
+parameters:
+  run_set_stable:
+    type: boolean
+    default: false
+  release_version:
+    type: string
+    default: ""
+  release_stable:
+    type: boolean
+    default: true
+
+# ========================================
 # ORBS
 # ========================================
 
@@ -970,6 +985,30 @@ jobs:
       - store_artifacts:
           path: bit/index.json
 
+  set_release_stable_flag:
+    docker:
+      - image: bitcli/node-gcloud-sdk
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Configure gcloud auth
+          command: echo "${COMMAND_GCLOUD_AUTHENTICATE}" > /tmp/gcloud-service-key.json && gcloud auth activate-service-account --key-file=/tmp/gcloud-service-key.json
+      - run:
+          name: Update stable flag in index.json
+          environment:
+            RELEASE_VERSION: "<< pipeline.parameters.release_version >>"
+            RELEASE_STABLE: "<< pipeline.parameters.release_stable >>"
+          command: node scripts/update-bit-stable-flag.js
+      - run:
+          name: Upload index.json
+          command: gsutil cp index.json gs://bvm.bit.dev/bit/index.json
+      - run:
+          name: clear index.json cache
+          command: gsutil setmeta -h "Cache-Control:no-cache" gs://bvm.bit.dev/bit/index.json
+      - store_artifacts:
+          path: index.json
+
   # ========== Docker Jobs ==========
   docker_build_node_22:
     machine:
@@ -1172,8 +1211,16 @@ jobs:
 # ========================================
 
 workflows:
+  # Manual workflow: flip a published version's stable flag in index.json.
+  # Trigger from the CircleCI web app with run_set_stable=true, release_version=<version>, release_stable=<true|false>.
+  set_release_stable_flag:
+    when: << pipeline.parameters.run_set_stable >>
+    jobs:
+      - set_release_stable_flag
+
   # Main build and test workflow
   build_and_test:
+    unless: << pipeline.parameters.run_set_stable >>
     jobs:
       - checkout_code
       - set_ssh_key
@@ -1324,6 +1371,7 @@ workflows:
 
   # TODO: check if we can combine it with the regular nightly somehow
   harmony_deploy:
+    unless: << pipeline.parameters.run_set_stable >>
     jobs:
       - harmony_deploy_approval_job:
           <<: *master_only_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,13 @@ parameters:
     type: string
     default: ""
   release_stable:
-    type: boolean
-    default: true
+    type: enum
+    enum: ["true", "false"]
+    default: "true"
   release_test_mode:
-    type: boolean
-    default: false
+    type: enum
+    enum: ["true", "false"]
+    default: "false"
 
 # ========================================
 # ORBS

--- a/scripts/update-bit-stable-flag.js
+++ b/scripts/update-bit-stable-flag.js
@@ -3,6 +3,7 @@ const https = require('https');
 
 const BIT_VERSION = process.env.RELEASE_VERSION;
 const STABLE = process.env.RELEASE_STABLE;
+const TEST_MODE = process.env.RELEASE_TEST_MODE === 'true';
 
 if (!BIT_VERSION) {
   console.error('RELEASE_VERSION env variable is required');
@@ -14,6 +15,7 @@ if (STABLE !== 'true' && STABLE !== 'false') {
 }
 
 const stable = STABLE === 'true';
+const indexObjectName = TEST_MODE ? 'index-test.json' : 'index.json';
 const random = Math.floor(Math.random() * 100000);
 
 // Fetch directly from GCS to bypass any CDN caching.
@@ -21,7 +23,7 @@ https
   .get(
     {
       host: 'storage.googleapis.com',
-      path: `/bvm.bit.dev/bit/index.json?random=${random}`,
+      path: `/bvm.bit.dev/bit/${indexObjectName}?random=${random}`,
       port: 443,
       headers: { 'Content-Type': 'application/json' },
     },
@@ -47,7 +49,9 @@ https
           delete release.stable;
         }
         fs.writeFileSync('index.json', JSON.stringify(index), 'utf8');
-        console.log(`Marked version ${BIT_VERSION} as ${stable ? 'stable' : 'not stable'}`);
+        console.log(
+          `Marked version ${BIT_VERSION} as ${stable ? 'stable' : 'not stable'} in ${indexObjectName}`
+        );
       });
     }
   )

--- a/scripts/update-bit-stable-flag.js
+++ b/scripts/update-bit-stable-flag.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const https = require('https');
+
+const BIT_VERSION = process.env.RELEASE_VERSION;
+const STABLE = process.env.RELEASE_STABLE;
+
+if (!BIT_VERSION) {
+  console.error('RELEASE_VERSION env variable is required');
+  process.exit(1);
+}
+if (STABLE !== 'true' && STABLE !== 'false') {
+  console.error(`RELEASE_STABLE must be "true" or "false", got "${STABLE}"`);
+  process.exit(1);
+}
+
+const stable = STABLE === 'true';
+const random = Math.floor(Math.random() * 100000);
+
+// Fetch directly from GCS to bypass any CDN caching.
+https
+  .get(
+    {
+      host: 'storage.googleapis.com',
+      path: `/bvm.bit.dev/bit/index.json?random=${random}`,
+      port: 443,
+      headers: { 'Content-Type': 'application/json' },
+    },
+    (response) => {
+      let body = '';
+      response.on('data', (d) => {
+        body += d;
+      });
+      response.on('end', () => {
+        if (response.statusCode !== 200) {
+          console.error(`Failed to fetch index.json: HTTP ${response.statusCode}`);
+          process.exit(1);
+        }
+        const index = JSON.parse(body);
+        const release = index.find((r) => r.version === BIT_VERSION);
+        if (!release) {
+          console.error(`version ${BIT_VERSION} not found in index.json`);
+          process.exit(1);
+        }
+        if (stable) {
+          release.stable = true;
+        } else {
+          delete release.stable;
+        }
+        fs.writeFileSync('index.json', JSON.stringify(index), 'utf8');
+        console.log(`Marked version ${BIT_VERSION} as ${stable ? 'stable' : 'not stable'}`);
+      });
+    }
+  )
+  .on('error', (err) => {
+    console.error('Failed to fetch index.json:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Adds a CircleCI workflow that mutates the `stable` flag for a specific version in `gs://bvm.bit.dev/bit/index.json`, replacing the manual `bvm release set --stable` step.
- New pipeline parameters (`run_set_stable`, `release_version`, `release_stable`) gate a new `set_release_stable_flag` job/workflow; `build_and_test` and `harmony_deploy` use `unless: << pipeline.parameters.run_set_stable >>` so a manual stable-flip pipeline doesn't trigger them.
- `scripts/update-bit-stable-flag.js` fetches `index.json` directly from GCS (bypassing CDN cache), sets or removes the `stable` flag, and writes the file for upload.

## How to trigger
In the CircleCI web app on master: **Trigger Pipeline** → **Add +**, then set:
- `run_set_stable` = `true`
- `release_version` = e.g. `1.13.184`
- `release_stable` = `true` (mark stable) or `false` (mark back to unstable)

## Test plan
- [ ] Trigger pipeline on master with `run_set_stable=false` (or unset) and confirm only the usual workflows run (the new workflow is skipped).
- [ ] Trigger pipeline with `run_set_stable=true`, a known published `release_version`, and `release_stable=true`; verify `index.json` has the `stable: true` flag set for that version and `build_and_test`/`harmony_deploy` did not run.
- [ ] Re-trigger with the same version and `release_stable=false`; verify the `stable` flag is removed.
- [ ] Trigger with a bogus `release_version`; verify the job fails fast with a clear error.