### PR TITLE
feat(api-server): allow overriding bind host via BIT_SERVER_HOST

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -125,6 +125,7 @@ export class ApiServerMain {
     });
 
     const port = options.port || (await this.getRandomPort());
+    const { bindHost, isOverride } = resolveBindHost();
 
     // Generate a per-server auth token and persist it to a 0600 file before
     // any HTTP request can be handled. Clients (e.g. the bit-vscode extension)
@@ -140,7 +141,7 @@ export class ApiServerMain {
     // The host-check middleware runs first to reject DNS-rebinding attacks
     // (where a malicious page resolves attacker.example to 127.0.0.1).
     const app = expressFactory();
-    app.use(this.createHostCheckMiddleware());
+    app.use(this.createHostCheckMiddleware({ loopbackOnly: !isOverride }));
     app.use(
       cors({
         origin(origin, callback) {
@@ -222,12 +223,7 @@ export class ApiServerMain {
       })
     );
 
-    // Bind to loopback by default — never accept connections from the LAN.
-    // Clients are expected to use 127.0.0.1 (or localhost, which resolves to
-    // it). Hosted environments (e.g. cloud workspaces) that route traffic
-    // through a non-loopback IP can override with BIT_SERVER_HOST.
-    const bindHost = getBindHost();
-    if (bindHost !== '127.0.0.1') {
+    if (isOverride) {
       this.logger.debug(
         `api-server: binding to ${bindHost} (from BIT_SERVER_HOST), loopback Host-header check disabled`
       );
@@ -300,8 +296,7 @@ export class ApiServerMain {
    * the bearer token is the only line of defense — which is appropriate
    * because the operator explicitly opted in to non-loopback bind.
    */
-  private createHostCheckMiddleware(): Middleware {
-    const loopbackOnly = !process.env.BIT_SERVER_HOST;
+  private createHostCheckMiddleware({ loopbackOnly }: { loopbackOnly: boolean }): Middleware {
     const allowed = new Set(['localhost', '127.0.0.1', '::1']);
     return (req: Request, res: Response, next: NextFunction) => {
       if (!loopbackOnly) return next();
@@ -574,14 +569,16 @@ export class ApiServerMain {
 ApiServerAspect.addRuntime(ApiServerMain);
 
 /**
- * Address the api-server should bind to. Defaults to `127.0.0.1` (loopback
- * only). Hosted environments where bit-server runs behind a router/proxy on
- * a different interface (e.g. cloud workspaces) can set `BIT_SERVER_HOST` to
- * an explicit IP or `0.0.0.0`. Empty/whitespace values are ignored.
+ * Resolve the api-server bind host from `BIT_SERVER_HOST`, falling back to
+ * loopback. `isOverride` is the single source of truth for "did the operator
+ * opt out of loopback-only mode?" — used both to choose the bind address and
+ * to disable the loopback Host-header check. Whitespace-only env values are
+ * treated as unset to avoid silently weakening security via a misconfigured
+ * shell.
  */
-function getBindHost(): string {
-  const fromEnv = process.env.BIT_SERVER_HOST?.trim();
-  return fromEnv || '127.0.0.1';
+function resolveBindHost(): { bindHost: string; isOverride: boolean } {
+  const override = process.env.BIT_SERVER_HOST?.trim();
+  return { bindHost: override || '127.0.0.1', isOverride: !!override };
 }
 
 /**

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -222,9 +222,17 @@ export class ApiServerMain {
       })
     );
 
-    // Bind to loopback only — never accept connections from the LAN. Clients
-    // are expected to use 127.0.0.1 (or localhost, which resolves to it).
-    const server = await app.listen(port, '127.0.0.1');
+    // Bind to loopback by default — never accept connections from the LAN.
+    // Clients are expected to use 127.0.0.1 (or localhost, which resolves to
+    // it). Hosted environments (e.g. cloud workspaces) that route traffic
+    // through a non-loopback IP can override with BIT_SERVER_HOST.
+    const bindHost = getBindHost();
+    if (bindHost !== '127.0.0.1') {
+      this.logger.debug(
+        `api-server: binding to ${bindHost} (from BIT_SERVER_HOST), loopback Host-header check disabled`
+      );
+    }
+    const server = await app.listen(port, bindHost);
 
     return new Promise((resolve, reject) => {
       server.on('error', (err) => {
@@ -285,10 +293,18 @@ export class ApiServerMain {
    * The server already listens on 127.0.0.1 only, so any request reaching us
    * arrived via loopback. The remaining concern is the *named* origin the
    * browser thinks it's talking to.
+   *
+   * Disabled when `BIT_SERVER_HOST` is set, since by definition the server
+   * is then reachable via a non-loopback address whose Host header we can't
+   * enumerate ahead of time (e.g. a cloud-workspace hostname). In that mode
+   * the bearer token is the only line of defense — which is appropriate
+   * because the operator explicitly opted in to non-loopback bind.
    */
   private createHostCheckMiddleware(): Middleware {
+    const loopbackOnly = !process.env.BIT_SERVER_HOST;
     const allowed = new Set(['localhost', '127.0.0.1', '::1']);
     return (req: Request, res: Response, next: NextFunction) => {
+      if (!loopbackOnly) return next();
       const hostHeader = req.headers.host || '';
       // Parse hostname from "host:port". IPv6 may be bracketed: "[::1]:1234"
       // → "::1"; IPv4 / hostname is plain: "127.0.0.1:1234" → "127.0.0.1".
@@ -556,6 +572,17 @@ export class ApiServerMain {
 }
 
 ApiServerAspect.addRuntime(ApiServerMain);
+
+/**
+ * Address the api-server should bind to. Defaults to `127.0.0.1` (loopback
+ * only). Hosted environments where bit-server runs behind a router/proxy on
+ * a different interface (e.g. cloud workspaces) can set `BIT_SERVER_HOST` to
+ * an explicit IP or `0.0.0.0`. Empty/whitespace values are ignored.
+ */
+function getBindHost(): string {
+  const fromEnv = process.env.BIT_SERVER_HOST?.trim();
+  return fromEnv || '127.0.0.1';
+}
 
 /**
  * Extract the token from an `Authorization: Bearer <token>` header.

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -290,11 +290,13 @@ export class ApiServerMain {
    * arrived via loopback. The remaining concern is the *named* origin the
    * browser thinks it's talking to.
    *
-   * Disabled when `BIT_SERVER_HOST` is set, since by definition the server
-   * is then reachable via a non-loopback address whose Host header we can't
-   * enumerate ahead of time (e.g. a cloud-workspace hostname). In that mode
-   * the bearer token is the only line of defense — which is appropriate
-   * because the operator explicitly opted in to non-loopback bind.
+   * Disabled when `BIT_SERVER_HOST` resolves to a non-loopback address,
+   * since by definition the server is then reachable via a hostname we
+   * can't enumerate ahead of time (e.g. a cloud-workspace hostname). In
+   * that mode the bearer token is the primary line of defense; the
+   * unauthenticated exemptions (`OPTIONS` preflight and `/api/_health`)
+   * become reachable from the network — `/api/_health` is a tiny "ok"
+   * liveness probe and intentionally exposed.
    */
   private createHostCheckMiddleware({ loopbackOnly }: { loopbackOnly: boolean }): Middleware {
     const allowed = new Set(['localhost', '127.0.0.1', '::1']);
@@ -568,17 +570,20 @@ export class ApiServerMain {
 
 ApiServerAspect.addRuntime(ApiServerMain);
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+
 /**
  * Resolve the api-server bind host from `BIT_SERVER_HOST`, falling back to
- * loopback. `isOverride` is the single source of truth for "did the operator
- * opt out of loopback-only mode?" — used both to choose the bind address and
- * to disable the loopback Host-header check. Whitespace-only env values are
- * treated as unset to avoid silently weakening security via a misconfigured
- * shell.
+ * loopback. `isOverride` is the single source of truth for "is the server
+ * reachable from outside loopback?" — used both to choose the bind address
+ * and to disable the loopback Host-header check. Derived from the *resolved*
+ * host (not env presence) so `BIT_SERVER_HOST=127.0.0.1` and whitespace-only
+ * values don't silently weaken the DNS-rebinding mitigation.
  */
 function resolveBindHost(): { bindHost: string; isOverride: boolean } {
   const override = process.env.BIT_SERVER_HOST?.trim();
-  return { bindHost: override || '127.0.0.1', isOverride: !!override };
+  const bindHost = override || '127.0.0.1';
+  return { bindHost, isOverride: !LOOPBACK_HOSTS.has(bindHost.toLowerCase()) };
 }
 
 /**

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -116,11 +116,7 @@ export class ServerCommander {
     if (process.argv.includes(CMD_SERVER_TOKEN)) return this.printServerTokenAndExit();
     printBitVersionIfAsked();
     const port = await this.getExistingUsedPort();
-    // Mirror the api-server's bind host. Defaults to loopback; hosted
-    // environments override via BIT_SERVER_HOST so the CLI dials the same
-    // interface bit-server is listening on.
-    const host = process.env.BIT_SERVER_HOST?.trim() || '127.0.0.1';
-    const url = `http://${host}:${port}/api`;
+    const url = `http://${resolveDialHost()}:${port}/api`;
     const shouldUsePTY = process.env.BIT_CLI_SERVER_PTY === 'true';
 
     if (shouldUsePTY) {
@@ -427,6 +423,26 @@ export function shouldUseBitServer() {
     process.argv.length > 2 && // if it has no args, it shows the help
     !commandsToSkip.includes(process.argv[2])
   );
+}
+
+/**
+ * Address the CLI uses to dial the local bit-server. Mirrors the api-server's
+ * bind host (`BIT_SERVER_HOST`) so the same env var works for both sides in
+ * hosted environments. Two host values need translating: `0.0.0.0` / `::`
+ * are bind-only wildcards — not valid as destinations — so dial loopback
+ * instead. Raw IPv6 addresses get bracketed for URL safety.
+ */
+function resolveDialHost(): string {
+  const override = process.env.BIT_SERVER_HOST?.trim();
+  if (!override) return '127.0.0.1';
+  if (override === '0.0.0.0') return '127.0.0.1';
+  if (override === '::') return '[::1]';
+  // Bracket any literal IPv6 (contains ':' but isn't an IPv4 with port —
+  // detected by 2+ colons).
+  if (override.includes(':') && override.split(':').length > 2 && !override.startsWith('[')) {
+    return `[${override}]`;
+  }
+  return override;
 }
 
 /**

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -116,7 +116,11 @@ export class ServerCommander {
     if (process.argv.includes(CMD_SERVER_TOKEN)) return this.printServerTokenAndExit();
     printBitVersionIfAsked();
     const port = await this.getExistingUsedPort();
-    const url = `http://127.0.0.1:${port}/api`;
+    // Mirror the api-server's bind host. Defaults to loopback; hosted
+    // environments override via BIT_SERVER_HOST so the CLI dials the same
+    // interface bit-server is listening on.
+    const host = process.env.BIT_SERVER_HOST?.trim() || '127.0.0.1';
+    const url = `http://${host}:${port}/api`;
     const shouldUsePTY = process.env.BIT_CLI_SERVER_PTY === 'true';
 
     if (shouldUsePTY) {

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -168,10 +168,18 @@ export class CliMcpServerMain {
   /**
    * Build the URL used to dial the local bit-server. Mirrors the api-server's
    * bind host: `BIT_SERVER_HOST` lets hosted environments (e.g. cloud
-   * workspaces) reach bit-server on a non-loopback interface.
+   * workspaces) reach bit-server on a non-loopback interface. `0.0.0.0` /
+   * `::` are bind-only wildcards (not valid destinations) so dial loopback
+   * instead; raw IPv6 addresses get bracketed for URL safety.
    */
   private buildServerUrl(port: number): string {
-    const host = process.env.BIT_SERVER_HOST?.trim() || '127.0.0.1';
+    const override = process.env.BIT_SERVER_HOST?.trim();
+    let host: string;
+    if (!override || override === '0.0.0.0') host = '127.0.0.1';
+    else if (override === '::') host = '[::1]';
+    else if (override.includes(':') && override.split(':').length > 2 && !override.startsWith('['))
+      host = `[${override}]`;
+    else host = override;
     return `http://${host}:${port}/api`;
   }
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -122,7 +122,7 @@ export class CliMcpServerMain {
           if (startedPort) this.serverPort = startedPort;
         }
         if (this.serverPort) {
-          this.serverUrl = `http://127.0.0.1:${this.serverPort}/api`;
+          this.serverUrl = this.buildServerUrl(this.serverPort);
           // bit-server 1.13.166+ requires a bearer token; older versions don't
           // write the token file and getBitServerToken returns undefined.
           this.serverToken = this.getBitServerToken(cwd);
@@ -163,6 +163,16 @@ export class CliMcpServerMain {
       this.logger.error(`[MCP-DEBUG] error getting existing port from bit server at ${cwd}. err: ${err.message}`);
       return undefined;
     }
+  }
+
+  /**
+   * Build the URL used to dial the local bit-server. Mirrors the api-server's
+   * bind host: `BIT_SERVER_HOST` lets hosted environments (e.g. cloud
+   * workspaces) reach bit-server on a non-loopback interface.
+   */
+  private buildServerUrl(port: number): string {
+    const host = process.env.BIT_SERVER_HOST?.trim() || '127.0.0.1';
+    return `http://${host}:${port}/api`;
   }
 
   /**
@@ -226,7 +236,7 @@ export class CliMcpServerMain {
                 const port = parseInt(portMatch[1], 10);
                 this.logger.debug(`[MCP-DEBUG] bit-server started on port ${port}`);
                 this.serverPort = port;
-                this.serverUrl = `http://127.0.0.1:${port}/api`;
+                this.serverUrl = this.buildServerUrl(port);
                 resolve(port);
               }
             }


### PR DESCRIPTION
The local bit-server currently binds to `127.0.0.1` only and rejects non-loopback `Host` headers. That blocks hosted environments (e.g. cloud workspaces) where the server sits behind a router on a different interface — even `/api/_health` returns 403.

When `BIT_SERVER_HOST` resolves to a non-loopback address:
- `app.listen` binds to that address (e.g. `0.0.0.0` or a specific IP).
- The loopback Host-header (DNS-rebinding) check is disabled — the bearer token is the primary defense. `OPTIONS` preflight and `/api/_health` remain exempt by design (health is a tiny "ok" liveness probe).
- `server-commander` (CLI fast-mode) and `cli-mcp-server` dial the same host so local clients on the remote box can still reach bit-server.

Setting `BIT_SERVER_HOST` to a loopback value (`127.0.0.1` / `localhost` / `::1`) or leaving it unset/whitespace-only is a no-op: loopback-only bind + Host-header check stays on.

The CLI/MCP dial side normalizes bind-only wildcards to a reachable interface (`0.0.0.0` → `127.0.0.1`, `::` → `[::1]`) and brackets raw IPv6 literals for URL safety, since wildcards aren't valid destination addresses.