### PR TITLE
fix(importer): route cross-scope lane updateDependents to the lane's scope

### DIFF
--- a/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
+++ b/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
@@ -1105,4 +1105,76 @@ describe('local snap cascades updateDependents on the lane', function () {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------------------------
+  // Scenario 15: importing a lane whose hidden updateDependent originates from a DIFFERENT scope
+  // than the lane. The cascade snap of that updateDependent lives in the lane's scope (where the
+  // bare-scope producer pushed it), NOT on the component's origin-scope main. The fetcher's
+  // `groupByLanes` routing must therefore send updateDependents to the lane's scope — otherwise it
+  // asks the origin scope for a lane-only hash it never had and the import dies with
+  // "component <updateDependent> was not found". Single-scope scenarios above can't catch this
+  // because lane.scope === the component's origin scope, so the misroute resolves to the same place.
+  // ---------------------------------------------------------------------------------------------
+  describe('scenario 15: import a lane with a cross-scope updateDependent', () => {
+    let anotherRemote: string;
+    let anotherRemotePath: string;
+    let comp2InUpdDep: string;
+    before(async () => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const newScope = helper.scopeHelper.getNewBareScope();
+      anotherRemote = newScope.scopeName;
+      anotherRemotePath = newScope.scopePath;
+      // wire every scope to know every other scope.
+      helper.scopeHelper.addRemoteScope(anotherRemotePath);
+      helper.scopeHelper.addRemoteScope(anotherRemotePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, anotherRemotePath);
+
+      // comp2 -> comp3. comp3 stays on the lane's scope (remote); comp2 lives on anotherRemote and
+      // is the cross-scope updateDependent.
+      helper.fixtures.populateComponents(3, false, '', false);
+      helper.command.setScope(anotherRemote, 'comp2');
+      helper.command.linkAndRewire();
+      helper.command.compile();
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.command.createLane();
+      helper.command.snapComponentWithoutBuild('comp3', '--skip-auto-snap --unmodified');
+      helper.command.export();
+
+      // seed comp2 (from anotherRemote) into lane.updateDependents and push it to the lane's scope.
+      const bareSnap = helper.scopeHelper.getNewBareScope('-bare-seed-updep');
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareSnap.scopePath);
+      helper.scopeHelper.addRemoteScope(anotherRemotePath, bareSnap.scopePath);
+      await helper.snapping.snapFromScope(
+        bareSnap.scopePath,
+        [{ componentId: `${anotherRemote}/comp2`, message: 'cross-scope update-dependent' }],
+        { lane: `${helper.scopes.remote}/dev`, updateDependents: true, push: true }
+      );
+      const lane = helper.command.catLane('dev', helper.scopes.remotePath);
+      comp2InUpdDep = lane.updateDependents[0];
+      expect(comp2InUpdDep, 'precondition: comp2 must be seeded as an updateDependent').to.include(
+        `${anotherRemote}/comp2`
+      );
+    });
+
+    it('importing the lane should not throw "component not found" for the cross-scope updateDependent', () => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(anotherRemotePath);
+      expect(() => helper.command.importLane('dev', '-x')).to.not.throw();
+    });
+
+    it('the cross-scope updateDependent`s cascade snap is fetched into the local scope', () => {
+      const hash = comp2InUpdDep.split('@')[1];
+      const obj = helper.command.catObject(hash);
+      expect(obj).to.be.a('string').and.not.empty;
+    });
+
+    it('the updateDependent stays hidden — only comp3 is in the workspace bitmap', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.have.property('comp3');
+      expect(bitMap).to.not.have.property('comp2');
+    });
+  });
 });

--- a/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
+++ b/e2e/harmony/lanes/update-dependents-cascade.e2e.ts
@@ -1107,7 +1107,7 @@ describe('local snap cascades updateDependents on the lane', function () {
   });
 
   // ---------------------------------------------------------------------------------------------
-  // Scenario 15: importing a lane whose hidden updateDependent originates from a DIFFERENT scope
+  // Scenario 20: importing a lane whose hidden updateDependent originates from a DIFFERENT scope
   // than the lane. The cascade snap of that updateDependent lives in the lane's scope (where the
   // bare-scope producer pushed it), NOT on the component's origin-scope main. The fetcher's
   // `groupByLanes` routing must therefore send updateDependents to the lane's scope — otherwise it
@@ -1115,10 +1115,13 @@ describe('local snap cascades updateDependents on the lane', function () {
   // "component <updateDependent> was not found". Single-scope scenarios above can't catch this
   // because lane.scope === the component's origin scope, so the misroute resolves to the same place.
   // ---------------------------------------------------------------------------------------------
-  describe('scenario 15: import a lane with a cross-scope updateDependent', () => {
+  describe('scenario 20: import a lane with a cross-scope updateDependent', () => {
     let anotherRemote: string;
     let anotherRemotePath: string;
     let comp2InUpdDep: string;
+    // the whole flow (incl. the fresh-workspace import) runs in `before` so any one `it` can be
+    // run in isolation with `.only`. Without the fix the import throws ComponentNotFound for the
+    // cross-scope updateDependent, failing this hook and surfacing the regression for every `it`.
     before(async () => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();
       const newScope = helper.scopeHelper.getNewBareScope();
@@ -1152,23 +1155,22 @@ describe('local snap cascades updateDependents on the lane', function () {
         { lane: `${helper.scopes.remote}/dev`, updateDependents: true, push: true }
       );
       const lane = helper.command.catLane('dev', helper.scopes.remotePath);
-      comp2InUpdDep = lane.updateDependents[0];
-      expect(comp2InUpdDep, 'precondition: comp2 must be seeded as an updateDependent').to.include(
-        `${anotherRemote}/comp2`
-      );
-    });
+      comp2InUpdDep = lane.updateDependents[0] || '';
 
-    it('importing the lane should not throw "component not found" for the cross-scope updateDependent', () => {
+      // fresh workspace: import the lane. This is the line that regressed.
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope(helper.scopes.remotePath);
       helper.scopeHelper.addRemoteScope(anotherRemotePath);
-      expect(() => helper.command.importLane('dev', '-x')).to.not.throw();
+      helper.command.importLane('dev', '-x');
     });
 
-    it('the cross-scope updateDependent`s cascade snap is fetched into the local scope', () => {
+    it('seeds comp2 from the other scope as a hidden updateDependent (precondition)', () => {
+      expect(comp2InUpdDep).to.include(`${anotherRemote}/comp2`);
+    });
+
+    it('the cross-scope updateDependent`s lane-only cascade snap is fetched into the local scope', () => {
       const hash = comp2InUpdDep.split('@')[1];
-      const obj = helper.command.catObject(hash);
-      expect(obj).to.be.a('string').and.not.empty;
+      expect(() => helper.command.catObject(hash)).to.not.throw();
     });
 
     it('the updateDependent stays hidden — only comp3 is in the workspace bitmap', () => {

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -590,12 +590,12 @@ please create a new lane instead, which will include all components of this lane
    * save the objects and the lane to the local scope.
    * this method doesn't change anything in the workspace.
    */
-  async fetchLaneWithItsComponents(laneId: LaneId, includeUpdateDependents = false): Promise<Lane> {
+  async fetchLaneWithItsComponents(laneId: LaneId): Promise<Lane> {
     this.logger.debug(`fetching lane ${laneId.toString()}`);
     const lane = await this.importer.importLaneObject(laneId);
     if (!lane) throw new Error(`unable to import lane ${laneId.toString()} from the remote`);
 
-    await this.importer.fetchLaneComponents(lane, includeUpdateDependents);
+    await this.importer.fetchLaneComponents(lane);
     this.logger.debug(`fetching lane ${laneId.toString()} done, fetched ${lane.components.length} components`);
     return lane;
   }

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -334,7 +334,10 @@ export class MergeLanesMain {
       const shouldFetch = !lane || (!skipFetch && !lane.isNew);
       if (shouldFetch) {
         // don't assign `lane` to the result of this command. otherwise, if you have local snaps, it'll ignore them and use the remote-lane.
-        const otherLane = await this.lanes.fetchLaneWithItsComponents(otherLaneId, shouldIncludeUpdateDependents);
+        // note: fetching always includes the lane's hidden updateDependents (and routes them to the
+        // lane's scope); `shouldIncludeUpdateDependents` still governs whether they take part in the
+        // merge itself, via `idsToMerge` below.
+        const otherLane = await this.lanes.fetchLaneWithItsComponents(otherLaneId);
         laneToFetchArtifactsFrom = otherLane;
         lane = await legacyScope.loadLane(otherLaneId);
       }

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -139,17 +139,20 @@ export class ImporterMain {
    * fetch lane's components and save them in the local scope.
    * once done, merge the lane object and save it as well.
    */
-  async fetchLaneComponents(lane: Lane, includeUpdateDependents = false) {
+  async fetchLaneComponents(lane: Lane) {
     // hidden lane.updateDependents are part of the lane's graph and the merge engine needs
     // their Version objects available locally to do per-component diverge checks. We always
-    // fetch the full set; the `includeUpdateDependents` flag now only controls server-side
-    // semantics around how the remote handles the updateDependents array, not whether to fetch.
+    // fetch the full set, so we must also pass `includeUpdateDependents: true` to importMany:
+    // the fetcher's `groupByLanes` routing relies on this flag to send these ids to the lane's
+    // scope (where the cascade snaps live) instead of each component's origin scope (which only
+    // holds main, not the lane-only cascade hash). Without it, cross-scope updateDependents fail
+    // with "component not found" because their origin scope doesn't have the lane snap.
     const ids = lane.toComponentIdsIncludeUpdateDependents();
     await this.scope.legacyScope.scopeImporter.importMany({
       ids,
       lane,
       reason: `for fetching lane ${lane.id()}`,
-      includeUpdateDependents,
+      includeUpdateDependents: true,
     });
     const { mergeLane } = await this.scope.legacyScope.sources.mergeLane(lane, true);
     const isRemoteLaneEqualsToMergedLane = lane.isEqual(mergeLane);
@@ -271,6 +274,10 @@ export class ImporterMain {
         ids: lane.toComponentIdsIncludeUpdateDependents(),
         lane,
         reason: `for fetching lane ${lane.id()}`,
+        // route the hidden updateDependents to the lane's scope (where their cascade snaps live).
+        // see the note in `fetchLaneComponents` — without this flag `groupByLanes` sends them to
+        // each component's origin scope, which doesn't have the lane-only cascade hash.
+        includeUpdateDependents: true,
       });
       const { mergeLane } = await this.scope.legacyScope.sources.mergeLane(lane, true);
       const isRemoteLaneEqualsToMergedLane = lane.isEqual(mergeLane);


### PR DESCRIPTION
## Problem

Importing a lane whose hidden `updateDependents` originate from a **different scope** than the lane fails with `component "<scope>/<comp>@<hash>" was not found`. Reproduce with an empty workspace: `bit init` then `bit lane import <scope-x>/<lane> -x`, where the lane has an updateDependent from `scope-y`. Worked before #10358.

## Root cause

#10358 made `fetchLaneComponents` always include the lane's hidden `updateDependents` in the fetched `ids`, but left `includeUpdateDependents` flowing through as `false` on the workspace import path.

That flag also drives **client-side scope routing** in `objects-fetcher.ts:groupByLanes()`: when `false`, `compIds` excludes hidden entries, so a cross-scope updateDependent fails the `isLaneIncludeId` check and gets routed to its **origin scope** instead of the **lane's scope**. The cascade snap is a lane-only hash that lives only in the lane's scope (the origin scope has only `main`), so the fetch finds nothing and `bitIdsToVersionDeps` throws `ComponentNotFound`.

Single-scope lanes never hit this because `lane.scope === component.scope` — which is why the existing scenarios missed it.

## Fix

Since these lane-fetch paths always request the full id set, always route them to the lane's scope by passing `includeUpdateDependents: true` in `fetchLaneComponents` and the bare-scope `fetchLanesUsingScope`. Dropped the now-dead `includeUpdateDependents` param from `fetchLaneComponents`/`fetchLaneWithItsComponents`. The merge *decision* still respects `shouldIncludeUpdateDependents` via `idsToMerge` — only fetch routing changed.

## Test

Adds `scenario 20` to `update-dependents-cascade.e2e.ts` — a cross-scope updateDependent import. Verified it fails on all 3 assertions with the fix reverted and passes with it applied. Also verified against the real-world remote.