### PR TITLE
fix(workspace): component falsely shown as modified due to extensionDependencies order

### DIFF
--- a/components/legacy/consumer/consumer.ts
+++ b/components/legacy/consumer/consumer.ts
@@ -353,6 +353,13 @@ export default class Consumer {
       componentFromModel.devPackageDependencies = sortObjectByKeys(componentFromModel.devPackageDependencies);
       componentFromModel.peerPackageDependencies = sortObjectByKeys(componentFromModel.peerPackageDependencies);
       sortOverrides(componentFromModel.overrides);
+      // normalize the order of the extensions. `Version.id()` (used for the hash comparison) serializes
+      // `extensionDependencies` - a getter derived from the order of `extensions` (extensionsBitIds). unlike the
+      // `extensions` config field, which id() already sorts via sortById(), this derived list is not normalized.
+      // so a mere reordering of extensions (e.g. the env aspect moving position) would otherwise make the
+      // component appear modified while "bit diff" shows no diff (it compares deps by identity, ignoring order).
+      version.extensions = version.extensions.sortById();
+      componentFromModel.extensions = componentFromModel.extensions.sortById();
     }
     function sortOverrides(overrides) {
       if (!overrides) return;

--- a/components/legacy/extension-data/extension-data.spec.ts
+++ b/components/legacy/extension-data/extension-data.spec.ts
@@ -117,6 +117,40 @@ describe('ExtensionDataList', () => {
       expect(filteredAsObject).to.not.have.property('my-scope/ext4');
     });
   });
+  describe('extensionsBitIds order normalization (regression for false-positive "modified" status)', () => {
+    // a component was wrongly reported as modified by "bit status" while "bit diff" showed no diff, because the
+    // order of `extensionDependencies` (derived from `extensionsBitIds`) differed between the stored model
+    // Version and the recomputed filesystem Version. that order is serialized into Version.id()/calculateHash(),
+    // so a mere reorder (e.g. the env aspect moving position) flipped the hash. the modified-check now sorts the
+    // extensions by id first, which must yield a deterministic extensionsBitIds order regardless of input order.
+    const buildList = (ids: string[]) =>
+      ExtensionDataList.fromArray(ids.map((id) => new ExtensionDataEntry(undefined, ComponentID.fromString(id))));
+    let fromModelOrder: string[];
+    let fromFsOrder: string[];
+    before(() => {
+      const idsInModelOrder = [
+        'teambit.dot-cloud/osv-scanner@0.0.2',
+        'teambit.dot-cloud/trivy-scanner@0.0.2',
+        'teambit.dot-symphony/envs/aspect@0.0.9',
+        'teambit.dot-cloud/bit-cloud@0.0.1',
+      ];
+      const idsInFsOrder = [
+        'teambit.dot-symphony/envs/aspect@0.0.9',
+        'teambit.dot-cloud/osv-scanner@0.0.2',
+        'teambit.dot-cloud/trivy-scanner@0.0.2',
+        'teambit.dot-cloud/bit-cloud@0.0.1',
+      ];
+      fromModelOrder = buildList(idsInModelOrder)
+        .sortById()
+        .extensionsBitIds.map((id) => id.toString());
+      fromFsOrder = buildList(idsInFsOrder)
+        .sortById()
+        .extensionsBitIds.map((id) => id.toString());
+    });
+    it('should produce the same extensionsBitIds order after sortById, regardless of input order', () => {
+      expect(fromFsOrder).to.deep.equal(fromModelOrder);
+    });
+  });
   describe('to config array', () => {
     let configArr;
     before(() => {


### PR DESCRIPTION
A component could appear as `modified` in `bit status` while `bit diff --verbose` shows no diff.

The only difference between the model `Version` and the recomputed filesystem `Version` was the *order* of the `extensionDependencies` array (same ids/versions, e.g. the env aspect in a different position). `status` compares `Version.calculateHash()`, and `Version.id()` serializes `extensionDependencies` in array order. That array is a computed getter derived from `extensions.extensionsBitIds`, whose order isn't normalized — `id()` sorts the `extensions` config field via `sortById()` but not the derived `extensionDependencies`. A reorder therefore flipped the hash. `bit diff` compares extension deps by identity, so it correctly reported no diff.

Fix: normalize the extensions order on both versions in `isComponentModified`'s `sortProperties` before the hash comparison, matching what already happens for dependencies/devDependencies/package deps. Only order is normalized — real changes are still detected.