### PR TITLE
fix(lanes): bit status crash after change-scope on a forked lane

### DIFF
--- a/e2e/harmony/lanes/lane-management.e2e.ts
+++ b/e2e/harmony/lanes/lane-management.e2e.ts
@@ -1,4 +1,6 @@
 import chai, { expect } from 'chai';
+import fs from 'fs-extra';
+import path from 'path';
 import { InvalidScopeName } from '@teambit/legacy-bit-id';
 import { Helper, fixtures } from '@teambit/legacy.e2e-helper';
 import chaiFs from 'chai-fs';
@@ -70,6 +72,73 @@ describe('bit lane management', function () {
         const err = new InvalidScopeName('invalid.scope.name');
         const cmd = () => helper.command.changeLaneScope('invalid.scope.name');
         helper.general.expectToThrow(cmd, err);
+      });
+    });
+    // regression: "bit status" used to throw "TargetHeadNotFound" after forking an imported lane and
+    // changing its scope. once forked to a different scope, the divergence fell back to comparing against
+    // the component's main-head. since the component lives on a different scope than the lane, its main-head
+    // Version object isn't fetched by "bit lane import", so the comparison crashed.
+    describe('on a forked lane whose components have a main-head that was not fetched', () => {
+      let anotherRemotePath: string;
+      let anotherRemoteName: string;
+      let compId: string;
+      before(() => {
+        // the component (bar1) lives on "anotherRemote", the lane lives on the default remote scope.
+        helper.scopeHelper.setWorkspaceWithRemoteScope();
+        const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+        anotherRemotePath = scopePath;
+        anotherRemoteName = scopeName;
+        helper.scopeHelper.addRemoteScope(scopePath);
+        helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+        helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+        compId = `${scopeName}/bar1`;
+        helper.fs.outputFile('bar1/index.js', 'console.log("v1");');
+        helper.command.add('bar1', `--scope ${scopeName}`);
+        // main-head (M1) on "anotherRemote"
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+        // lane-head (L1) on the default remote lane
+        helper.command.createLane('lane-a');
+        helper.command.snapAllComponentsWithoutBuild('--unmodified');
+        helper.command.export();
+        // advance main (M2) so its head diverges from the lane-head and won't be in the lane history
+        helper.command.switchLocalLane('main', '-x');
+        helper.command.snapAllComponentsWithoutBuild('--unmodified');
+        helper.command.export();
+
+        // consumer: import the lane (the component's main-head, on anotherRemote, is not part of the lane history).
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.scopeHelper.addRemoteScope(anotherRemotePath);
+        helper.command.importLane('lane-a', '-x');
+        // reproduce the real-world corrupted state: the component's main-head is recorded as the component head,
+        // but it is absent from the VersionHistory object (it lives on the component's own scope, on a branch not
+        // reachable from the lane). additionally there is no remote main-ref for that scope, so the divergence
+        // falls back to the main-head and can't find it in the VersionHistory.
+        const mainHead = helper.command.getHead(compId);
+        const vhHash = helper.command.catVersionHistory(compId).hash;
+        const mainHeadPath = helper.general.getHashPathOfObject(mainHead);
+        const vhPath = helper.general.getHashPathOfObject(vhHash);
+        const removeFromAllScopes = (objPath: string) => {
+          helper.fs.deleteObject(objPath);
+          fs.removeSync(path.join(anotherRemotePath, 'objects', objPath));
+          fs.removeSync(path.join(helper.scopes.remotePath, 'objects', objPath));
+        };
+        // drop the VersionHistory object so it's rebuilt locally (from Version objects that lack the main-head),
+        // and drop the main-head Version object everywhere so "bit status" can't re-fetch and re-add it.
+        removeFromAllScopes(vhPath);
+        removeFromAllScopes(mainHeadPath);
+        // remove the remote main-ref of the component's scope, so divergence reaches the (missing) main-head.
+        fs.removeSync(path.join(helper.scopes.localPath, '.bit/refs/remotes', anotherRemoteName, 'main'));
+        helper.command.createLane('forked-lane');
+        helper.command.changeLaneScope('another-scope');
+      });
+      it('bit status should not throw', () => {
+        expect(() => helper.command.status()).to.not.throw();
+      });
+      it('should show the lane component as staged (all snaps to be re-exported to the new scope)', () => {
+        const status = helper.command.statusJson();
+        expect(status.stagedComponents).to.have.lengthOf(1);
       });
     });
   });

--- a/scopes/scope/objects/models/model-component.ts
+++ b/scopes/scope/objects/models/model-component.ts
@@ -366,9 +366,15 @@ export default class Component extends BitObject {
 
     const calculateRemote = async () => {
       if (this.laneHeadRemote) return this.laneHeadRemote;
-      if (lane.isNew && lane.forkedFrom && lane.forkedFrom.scope === lane.scope) {
-        // the last check is to make sure that if this lane will be exported to a different scope than the original
-        // lane, all snaps of the original lane will be considered as local and will be exported later on.
+      if (lane.isNew && lane.forkedFrom) {
+        if (lane.forkedFrom.scope !== lane.scope) {
+          // this lane was forked and will be exported to a different scope than the original lane (e.g. after
+          // "bit lane change-scope"). all snaps of the original lane must be re-exported to the new scope, so there
+          // is no remote baseline to compare against - returning null makes the divergence treat all local snaps as
+          // staged. (without this, the fallback below compares against the main-head, which can throw
+          // TargetHeadNotFound when that main Version object isn't present locally - e.g. after "bit lane import".)
+          return null;
+        }
         const headFromFork = await repo.remoteLanes.getRef(lane.forkedFrom, this.toComponentId());
         if (headFromFork) return headFromFork;
       }


### PR DESCRIPTION
Running `bit status` after `bit lane import` → `bit lane create` → `bit lane change-scope` crashed with:

```
error: a remote of "<comp>" points to <hash>, which is missing from the VersionHistory object for some reason.
running "bit import" should fix the issue.
```

**Cause:** when a forked lane is rescoped to a scope different from the original lane, `calculateRemote()` (in `model-component.ts`) handled only the same-scope fork explicitly and let the cross-scope case fall through to comparing against the component's main-head. For components that live on a different scope than the lane, that main-head object isn't fetched by `bit lane import` (it's on a branch not reachable from the lane), so it's absent from the VersionHistory object and the divergence computation threw `TargetHeadNotFound`.

**Fix:** cross-scope forks now return `null` (no remote baseline → all snaps treated as local/staged, to be re-exported to the new scope). This matches the documented intent of the original `forkedFrom.scope === lane.scope` guard and avoids the fragile missing-object comparison. Same-scope forks and non-forked lanes are unchanged.

Added an e2e regression test that reproduces the exact error without the fix and passes with it.