### PR TITLE
fix(cli): redact --token flag from debug log and analytics

### DIFF
--- a/components/legacy/scope-api/lib/fetch.ts
+++ b/components/legacy/scope-api/lib/fetch.ts
@@ -1,5 +1,6 @@
 import type { Readable } from 'stream';
 import Queue from 'p-queue';
+import { omit } from 'lodash';
 import { ComponentIdList } from '@teambit/component-id';
 import semver from 'semver';
 import { isHash } from '@teambit/component-version';
@@ -121,11 +122,13 @@ fetchOptions`,
     fetchOptions
   );
   const dateNow = new Date().toISOString().split('.')[0];
+  // Strip authorization/cookie before storing — this metadata gets serialized into trace logs.
+  const redactedHeaders = headers ? omit(headers, ['authorization', 'cookie']) : headers;
   openConnectionsMetadata[currentFetch] = {
     started: dateNow,
     ids,
     fetchOptions,
-    headers,
+    headers: redactedHeaders,
   };
   logger.trace(
     `DEBUG-CONNECTIONS: Date now: ${dateNow}. Connections:\n${JSON.stringify(openConnectionsMetadata, null, 2)}`

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -51,20 +51,29 @@ export class CommandRunner {
   }
 
   private bootstrapCommand() {
+    // Redact --token before anything is logged or sent to analytics. The raw token
+    // is the user's bit.cloud credential; debug logs are persisted to disk and
+    // routinely shared in support tickets / issues.
+    const redactedFlags = this.getRedactedFlagsForReporting();
     try {
-      Analytics.init(this.commandName, this.flags, this.args);
+      Analytics.init(this.commandName, redactedFlags, this.args);
     } catch (err: any) {
       // ignoring the error, we don't want to fail the app if analytics failed.
       logger.error('failed to initialize analytics', err);
     }
     logger.info(`[*] started a new command: "${this.commandName}" with the following data:`, {
       args: this.args,
-      flags: this.flags,
+      flags: redactedFlags,
     });
     const token = this.flags[TOKEN_FLAG_NAME];
     if (token) {
       globalFlags.token = token.toString();
     }
+  }
+
+  private getRedactedFlagsForReporting(): Flags {
+    if (this.flags[TOKEN_FLAG_NAME] == null) return this.flags;
+    return { ...this.flags, [TOKEN_FLAG_NAME]: '<redacted>' };
   }
 
   private async invokeOnCommandStart() {


### PR DESCRIPTION
When a user passes `--token <secret>` on the CLI, the raw value was getting logged via `logger.info` in `command-runner.ts:bootstrapCommand` (lands in `~/Library/Caches/Bit/logs/debug.log`) and forwarded into `Analytics.init` for usage reporting. Debug logs are routinely shared in support tickets and issues, so the token value could escape that way.

Redacts the `token` flag to `<redacted>` before either reporting path is hit. The actual value still flows to `globalFlags.token` for the original purpose.

Also strips `authorization` / `cookie` from the `openConnectionsMetadata` trace dump in `/scope/fetch` — same pattern, same disk-log leakage shape if trace logging is on.