### PR TITLE
feat(tester): support running specific test files via "bit test <file-path>"

### DIFF
--- a/e2e/harmony/jest.e2e.ts
+++ b/e2e/harmony/jest.e2e.ts
@@ -73,6 +73,33 @@ describe('Jest Tester', function () {
       expect(output).to.have.string('build succeeded');
     });
   });
+  (IS_WINDOWS ? describe.skip : describe)('test a single spec file', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(2);
+      helper.fs.outputFile('comp1/comp1.spec.ts', specFilePassingFixture());
+      helper.fs.outputFile('comp1/foo.spec.ts', specFilePassingFixture('foo describe', 'foo it'));
+      helper.fs.outputFile('comp2/comp2.spec.ts', specFilePassingFixture('comp2 describe', 'comp2 it'));
+    });
+    it('should run only the tests of the given file', () => {
+      const output = helper.command.test('comp1/foo.spec.ts', true);
+      expect(output).to.have.string('foo it');
+      expect(output).to.not.have.string('should pass');
+      expect(output).to.not.have.string('comp2 it');
+    });
+    it('should test only the component that owns the given file', () => {
+      const output = helper.command.test('comp1/foo.spec.ts', true);
+      expect(output).to.have.string('testing total of 1 components');
+    });
+    it('should support multiple test-file paths', () => {
+      const output = helper.command.test('comp1/foo.spec.ts comp1/comp1.spec.ts', true);
+      // with multiple test suites, Jest prints a PASS line per file rather than the individual test names
+      expect(output).to.have.string('foo.spec.ts');
+      expect(output).to.have.string('comp1.spec.ts');
+      expect(output).to.not.have.string('comp2.spec.ts');
+      expect(output).to.have.string('Tests:       2 passed, 2 total');
+    });
+  });
   describe('component with an errored test', () => {
     before(() => {
       helper.scopeHelper.reInitWorkspace();

--- a/e2e/harmony/mocha-tester.e2e.ts
+++ b/e2e/harmony/mocha-tester.e2e.ts
@@ -190,6 +190,37 @@ describe('second spec file', () => {
       expect(output).to.not.have.string('2 passing');
     });
   });
+  describe('testing a single spec file', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(2);
+      setupMochaEnv();
+      helper.command.setEnv('comp1', envId);
+      helper.command.setEnv('comp2', envId);
+      helper.command.install();
+      helper.fs.outputFile('comp1/first.spec.ts', specFileWithNamesFixture('first spec file', 'first-file test'));
+      helper.fs.outputFile('comp1/second.spec.ts', specFileWithNamesFixture('second spec file', 'second-file test'));
+      helper.fs.outputFile('comp2/comp2.spec.ts', specFileWithNamesFixture('comp2 spec file', 'comp2 test'));
+    });
+    it('should run only the tests of the given file', () => {
+      const output = helper.command.test('comp1/first.spec.ts', true);
+      expect(output).to.have.string('first-file test');
+      expect(output).to.not.have.string('second-file test');
+      expect(output).to.not.have.string('comp2 test');
+      expect(output).to.have.string('1 passing');
+    });
+    it('should test only the component that owns the given file', () => {
+      const output = helper.command.test('comp1/first.spec.ts', true);
+      expect(output).to.have.string('testing total of 1 components');
+    });
+    it('should support multiple test-file paths', () => {
+      const output = helper.command.test('comp1/first.spec.ts comp1/second.spec.ts', true);
+      expect(output).to.have.string('first-file test');
+      expect(output).to.have.string('second-file test');
+      expect(output).to.not.have.string('comp2 test');
+      expect(output).to.have.string('2 passing');
+    });
+  });
 });
 
 function shouldOutputTestPassed(output: string) {
@@ -202,6 +233,16 @@ function specFilePassingFixture() {
   return `import { expect } from 'chai';
 describe('test', () => {
   it('should pass', () => {
+    expect(true).to.be.true;
+  });
+});
+`;
+}
+
+function specFileWithNamesFixture(describeText: string, itText: string) {
+  return `import { expect } from 'chai';
+describe('${describeText}', () => {
+  it('${itText}', () => {
     expect(true).to.be.true;
   });
 });

--- a/e2e/harmony/test-harmony.e2e.ts
+++ b/e2e/harmony/test-harmony.e2e.ts
@@ -26,4 +26,29 @@ describe('test command on Harmony', function () {
       expect(junitFile).to.include('Your test suite must contain at least one test');
     });
   });
+  describe('passing test-file paths instead of a component pattern', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile(
+        'comp1/comp1.spec.ts',
+        `it('should pass', () => { expect(true).toBeTruthy(); });
+`
+      );
+    });
+    it('should throw a descriptive error when the file is not a test file of the component', () => {
+      const output = helper.general.runWithTryCatch('bit test comp1/index.js');
+      expect(output).to.have.string('is not a recognized test file');
+      expect(output).to.have.string('comp1.spec.ts');
+    });
+    it('should throw when the file does not belong to any component', () => {
+      helper.fs.outputFile('some-file.spec.ts', '');
+      const output = helper.general.runWithTryCatch('bit test some-file.spec.ts');
+      expect(output).to.have.string('does not belong to any component');
+    });
+    it('should throw when mixing test-file paths with component patterns', () => {
+      const output = helper.general.runWithTryCatch('bit test comp1 comp1/comp1.spec.ts');
+      expect(output).to.have.string('unable to mix test-file paths with component patterns');
+    });
+  });
 });

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -29,19 +29,20 @@ type TestFlags = {
 };
 
 export class TestCmd implements Command {
-  name = 'test [component-pattern...]';
+  name = 'test [pattern-or-test-file...]';
   description = 'run component tests';
   extendedDescription = `executes tests using the testing framework configured by each component's environment (Jest, Mocha, etc.).
 by default only runs tests for new and modified components. use --unmodified to test all components.
-to run specific test files only, pass paths to the files themselves, e.g. "bit test path/to/comp/my-comp.spec.ts".
-note the distinction: a directory path selects the component in that directory and runs all its tests, while a path
-to a test file runs only that file. multiple patterns or test-file paths can be provided, separated by spaces.
+to run specific test files only, pass their paths instead of a component pattern, e.g. "bit test path/to/comp/my-comp.spec.ts".
 supports watch mode, coverage reporting, and debug mode for development workflows.`;
   helpUrl = 'reference/testing/tester-overview';
   arguments = [
     {
-      name: 'component-pattern...',
-      description: `${COMPONENT_PATTERN_HELP}. alternatively, provide path(s) to test file(s) (not directories) to run only these files, e.g. "bit test path/to/comp/my-comp.spec.ts"`,
+      name: 'pattern-or-test-file...',
+      description: `one of two modes (multiple values are supported, separated by spaces):
+1) component pattern: ${COMPONENT_PATTERN_HELP}
+2) test-file path: a path to a test file, to run only this file, e.g. "bit test path/to/comp/my-comp.spec.ts".
+note that a directory path selects the component in that directory and runs all its tests, while a test-file path runs only that file`,
     },
   ];
   alias = 'at';

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -1,6 +1,10 @@
+import path from 'path';
+import fs from 'fs-extra';
 import type { Command, CommandOptions, GenericObject } from '@teambit/cli';
 import { formatHint } from '@teambit/cli';
 import chalk from 'chalk';
+import { BitError } from '@teambit/bit-error';
+import type { Component } from '@teambit/component';
 import type { Logger } from '@teambit/logger';
 import type { Workspace } from '@teambit/workspace';
 import { OutsideWorkspaceError } from '@teambit/workspace';
@@ -24,16 +28,17 @@ type TestFlags = {
 };
 
 export class TestCmd implements Command {
-  name = 'test [component-pattern]';
+  name = 'test [component-pattern...]';
   description = 'run component tests';
   extendedDescription = `executes tests using the testing framework configured by each component's environment (Jest, Mocha, etc.).
 by default only runs tests for new and modified components. use --unmodified to test all components.
+to run specific test files only, pass their paths instead of a component pattern, e.g. "bit test path/to/comp/my-comp.spec.ts".
 supports watch mode, coverage reporting, and debug mode for development workflows.`;
   helpUrl = 'reference/testing/tester-overview';
   arguments = [
     {
-      name: 'component-pattern',
-      description: COMPONENT_PATTERN_HELP,
+      name: 'component-pattern...',
+      description: `${COMPONENT_PATTERN_HELP}. alternatively, provide path(s) to test file(s) to run only these files (e.g. "bit test path/to/comp/my-comp.spec.ts")`,
     },
   ];
   alias = 'at';
@@ -65,7 +70,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
   ) {}
 
   async report(
-    [userPattern]: [string],
+    [userPatterns = []]: [string[]],
     {
       watch = false,
       debug = false,
@@ -94,18 +99,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     timer.start();
     if (!this.workspace) throw new OutsideWorkspaceError();
 
-    const getPatternWithScope = () => {
-      if (!userPattern && !scope) return undefined;
-      const pattern = userPattern || '**';
-      return scopeName ? `${scopeName}/${pattern}` : pattern;
-    };
-    const patternWithScope = getPatternWithScope();
-    // If pattern is provided, don't pass the unmodified flag as "all" - the pattern should take precedence
-    const components = await this.workspace.getComponentsByUserInput(
-      patternWithScope ? false : unmodified,
-      patternWithScope,
-      true
-    );
+    const { components, testFiles } = await this.getComponentsToTest(userPatterns, unmodified, scopeName);
     if (!components.length) {
       const data = formatHint(
         `no components found to test.\nuse "--unmodified" flag to test all components or specify the ids to test.\notherwise, only new and modified components will be tested`
@@ -135,6 +129,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         env,
         coverage,
         updateSnapshot,
+        testFiles,
       });
     } else {
       // testers such as Jest reassign `console.warn` to forward into `this.logger.warn` inside their `test()`,
@@ -149,6 +144,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
           junit,
           coverage,
           updateSnapshot,
+          testFiles,
         });
       } finally {
         restore?.();
@@ -175,7 +171,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
   }
 
   async json(
-    [userPattern]: [string],
+    [userPatterns = []]: [string[]],
     {
       watch = false,
       debug = false,
@@ -191,18 +187,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     timer.start();
     if (!this.workspace) throw new OutsideWorkspaceError();
 
-    const getPatternWithScope = () => {
-      if (!userPattern) return undefined;
-      const pattern = userPattern || '**';
-      return pattern;
-    };
-    const patternWithScope = getPatternWithScope();
-    // If pattern is provided, don't pass the unmodified flag as "all" - the pattern should take precedence
-    const components = await this.workspace.getComponentsByUserInput(
-      patternWithScope ? false : unmodified,
-      patternWithScope,
-      true
-    );
+    const { components, testFiles } = await this.getComponentsToTest(userPatterns, unmodified);
     if (!components.length) {
       this.logger.info(`no components found to test.
   use "--unmodified" flag to test all components or specify the ids to test.
@@ -227,6 +212,7 @@ supports watch mode, coverage reporting, and debug mode for development workflow
         junit,
         coverage,
         updateSnapshot,
+        testFiles,
       });
     } finally {
       restore();
@@ -274,6 +260,82 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       code,
       data,
     };
+  }
+
+  /**
+   * resolve the components to test from the user input. the input entries can be either component patterns or paths
+   * of test files. when test-file paths are provided, also return their absolute paths so the tester runs only them.
+   */
+  private async getComponentsToTest(
+    userPatterns: string[],
+    unmodified: boolean,
+    scopeName?: string
+  ): Promise<{ components: Component[]; testFiles?: string[] }> {
+    const byTestFiles = await this.getComponentsByTestFiles(userPatterns);
+    if (byTestFiles) return byTestFiles;
+    const getPatternWithScope = () => {
+      if (!userPatterns.length && !scopeName) return undefined;
+      const pattern = userPatterns.length ? userPatterns.join(', ') : '**';
+      return scopeName ? `${scopeName}/${pattern}` : pattern;
+    };
+    const patternWithScope = getPatternWithScope();
+    // If pattern is provided, don't pass the unmodified flag as "all" - the pattern should take precedence
+    const components = await this.workspace.getComponentsByUserInput(
+      patternWithScope ? false : unmodified,
+      patternWithScope,
+      true
+    );
+    return { components };
+  }
+
+  /**
+   * if the given entries are paths of existing files, resolve them to their owning components.
+   * returns undefined when none of the entries is an existing file, in which case they are treated as
+   * component patterns.
+   */
+  private async getComponentsByTestFiles(
+    entries: string[]
+  ): Promise<{ components: Component[]; testFiles: string[] } | undefined> {
+    if (!entries.length) return undefined;
+    const isFile = (entry: string) => {
+      const absPath = path.resolve(entry);
+      return fs.existsSync(absPath) && fs.statSync(absPath).isFile();
+    };
+    const fileEntries = entries.filter((entry) => isFile(entry));
+    if (!fileEntries.length) return undefined;
+    if (fileEntries.length < entries.length) {
+      const nonFiles = entries.filter((entry) => !fileEntries.includes(entry));
+      throw new BitError(
+        `unable to mix test-file paths with component patterns. the following are not existing files: ${nonFiles.join(
+          ', '
+        )}`
+      );
+    }
+    const componentsById: { [idStr: string]: Component } = {};
+    const testFiles: string[] = [];
+    for (const entry of fileEntries) {
+      const absPath = path.resolve(entry);
+      const componentId = await this.workspace.getComponentIdByPath(absPath);
+      if (!componentId) {
+        throw new BitError(`the file "${entry}" does not belong to any component in this workspace, unable to test it`);
+      }
+      const idStr = componentId.toString();
+      if (!componentsById[idStr]) {
+        componentsById[idStr] = await this.workspace.get(componentId);
+      }
+      const component = componentsById[idStr];
+      const testFilesOfComp = this.tester.getTestFiles(component);
+      if (!testFilesOfComp.some((file) => file.path === absPath)) {
+        const suggestion = testFilesOfComp.length
+          ? `the test files of "${component.id.toStringWithoutVersion()}" are: ${testFilesOfComp
+              .map((file) => file.relative)
+              .join(', ')}`
+          : `the component "${component.id.toStringWithoutVersion()}" has no test files`;
+        throw new BitError(`the file "${entry}" is not a recognized test file. ${suggestion}`);
+      }
+      testFiles.push(absPath);
+    }
+    return { components: Object.values(componentsById), testFiles };
   }
 }
 

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -315,9 +315,7 @@ note that a directory path selects the component in that directory and runs all 
     if (fileEntries.length < entries.length) {
       const nonFiles = entries.filter((entry) => !fileEntries.includes(entry));
       throw new BitError(
-        `unable to mix test-file paths with component patterns. the following are not existing files: ${nonFiles.join(
-          ', '
-        )}`
+        `unable to mix test-file paths with component patterns. the following are not files: ${nonFiles.join(', ')}`
       );
     }
     const componentsById: { [idStr: string]: Component } = {};

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@teambit/logger';
 import type { Workspace } from '@teambit/workspace';
 import { OutsideWorkspaceError } from '@teambit/workspace';
 import { Timer } from '@teambit/toolbox.time.timer';
+import { pathNormalizeToLinux } from '@teambit/toolbox.path.path';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { TesterMain, TestResults } from './tester.main.runtime';
 import { aggregateTestResults, formatTestReport } from './test-output-formatter';
@@ -299,7 +300,12 @@ supports watch mode, coverage reporting, and debug mode for development workflow
     if (!entries.length) return undefined;
     const isFile = (entry: string) => {
       const absPath = path.resolve(entry);
-      return fs.existsSync(absPath) && fs.statSync(absPath).isFile();
+      try {
+        return fs.statSync(absPath).isFile();
+      } catch {
+        // e.g. the file doesn't exist or permission issues. treat as a non-file so it goes through the pattern flow.
+        return false;
+      }
     };
     const fileEntries = entries.filter((entry) => isFile(entry));
     if (!fileEntries.length) return undefined;
@@ -325,7 +331,8 @@ supports watch mode, coverage reporting, and debug mode for development workflow
       }
       const component = componentsById[idStr];
       const testFilesOfComp = this.tester.getTestFiles(component);
-      if (!testFilesOfComp.some((file) => file.path === absPath)) {
+      const absPathLinux = pathNormalizeToLinux(absPath);
+      if (!testFilesOfComp.some((file) => pathNormalizeToLinux(file.path) === absPathLinux)) {
         const suggestion = testFilesOfComp.length
           ? `the test files of "${component.id.toStringWithoutVersion()}" are: ${testFilesOfComp
               .map((file) => file.relative)

--- a/scopes/defender/tester/test.cmd.ts
+++ b/scopes/defender/tester/test.cmd.ts
@@ -33,13 +33,15 @@ export class TestCmd implements Command {
   description = 'run component tests';
   extendedDescription = `executes tests using the testing framework configured by each component's environment (Jest, Mocha, etc.).
 by default only runs tests for new and modified components. use --unmodified to test all components.
-to run specific test files only, pass their paths instead of a component pattern, e.g. "bit test path/to/comp/my-comp.spec.ts".
+to run specific test files only, pass paths to the files themselves, e.g. "bit test path/to/comp/my-comp.spec.ts".
+note the distinction: a directory path selects the component in that directory and runs all its tests, while a path
+to a test file runs only that file. multiple patterns or test-file paths can be provided, separated by spaces.
 supports watch mode, coverage reporting, and debug mode for development workflows.`;
   helpUrl = 'reference/testing/tester-overview';
   arguments = [
     {
       name: 'component-pattern...',
-      description: `${COMPONENT_PATTERN_HELP}. alternatively, provide path(s) to test file(s) to run only these files (e.g. "bit test path/to/comp/my-comp.spec.ts")`,
+      description: `${COMPONENT_PATTERN_HELP}. alternatively, provide path(s) to test file(s) (not directories) to run only these files, e.g. "bit test path/to/comp/my-comp.spec.ts"`,
     },
   ];
   alias = 'at';

--- a/scopes/defender/tester/tester.main.runtime.ts
+++ b/scopes/defender/tester/tester.main.runtime.ts
@@ -79,6 +79,11 @@ export type TesterOptions = {
    */
   updateSnapshot?: boolean;
 
+  /**
+   * absolute paths of specific test files to run. when provided, only these files are tested.
+   */
+  testFiles?: string[];
+
   callback?: CallbackFn;
 };
 

--- a/scopes/defender/tester/tester.service.ts
+++ b/scopes/defender/tester/tester.service.ts
@@ -9,6 +9,7 @@ import type {
   ServiceTransformationMap,
 } from '@teambit/envs';
 import { ComponentMap } from '@teambit/component';
+import { pathNormalizeToLinux } from '@teambit/toolbox.path.path';
 import type { Workspace } from '@teambit/workspace';
 import highlight from 'cli-highlight';
 import type { PubSubEngine } from 'graphql-subscriptions';
@@ -109,8 +110,12 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
       return new Tests([]);
     }
     const tester: Tester = context.env.getTester();
+    // when specific test files were requested (e.g. `bit test path/to/comp.spec.ts`), run only them.
+    const requestedTestFiles = options.testFiles?.map((filePath) => pathNormalizeToLinux(filePath));
     const allSpecFiles = ComponentMap.as(context.components, (component) => {
-      return detectTestFiles(component, this.devFiles);
+      const files = detectTestFiles(component, this.devFiles);
+      if (!requestedTestFiles?.length) return files;
+      return files.filter((file) => requestedTestFiles.includes(pathNormalizeToLinux(file.path)));
     });
     // drop components with zero spec files before handing them to the tester — otherwise testers
     // like Mocha invoke their reporter once per component and print "0 passing (0ms)" noise.
@@ -130,14 +135,23 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
       const componentPatterns = this.devFiles.getDevPatterns(component, TesterAspect.id);
       const packageRootDir = await this.workspace.getComponentPackagePath(component);
 
+      const getPaths = () => {
+        if (requestedTestFiles?.length) {
+          // pass the exact requested spec files to the tester instead of the dev patterns, so testers
+          // such as Jest (which relies on the patterns rather than on specFiles) run only these files.
+          const matchedSpecFiles = specFiles.getValueByComponentId(component.id) || [];
+          return matchedSpecFiles.map((file) => ({ path: file.path, relative: file.relative }));
+        }
+        return componentPatterns.map((pattern: string) => ({
+          path: resolve(componentDir, pattern),
+          relative: pattern,
+        }));
+      };
+
       return {
         componentDir,
         packageRootDir,
-        paths:
-          componentPatterns.map((pattern: string) => ({
-            path: resolve(componentDir, pattern),
-            relative: pattern,
-          })) || [],
+        paths: getPaths(),
       };
     });
 


### PR DESCRIPTION
Adds the ability to test specific files instead of an entire component: `bit test path/to/comp/foo.spec.ts` (multiple paths supported). When a positional arg resolves to an existing file, it is mapped to its owning component and only that file runs; otherwise args are treated as component patterns as before.

The filtering is done once in the tester service (`specFiles` + `patterns`), so it works for both Jest (testMatch) and Mocha (specFiles) with no tester changes.

Errors are designed to be actionable: passing a non-test file lists the component's actual test files; unowned files and mixing files with patterns are rejected with clear messages.

Includes e2e tests for Jest and Mocha (single file, multiple files, owning-component scoping) plus the error cases.