### PR TITLE
feat(workspace): support running bit commands from a git worktree

### DIFF
--- a/components/legacy/consumer/consumer.ts
+++ b/components/legacy/consumer/consumer.ts
@@ -55,6 +55,14 @@ type ConsumerProps = {
 const BITMAP_HISTORY_DIR_NAME = 'bitmap-history';
 const BITMAP_HISTORY_METADATA_FILE_NAME = 'bitmap-history-metadata.txt';
 
+function isDirectory(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false; // path doesn't exist (or isn't accessible)
+  }
+}
+
 export default class Consumer {
   projectPath: PathOsBasedAbsolute;
   created: boolean;
@@ -423,7 +431,10 @@ export default class Consumer {
   static _getScopePath(projectPath: PathOsBasedAbsolute, noGit: boolean): PathOsBasedAbsolute {
     const gitDirPath = path.join(projectPath, DOT_GIT_DIR);
     let resolvedScopePath = path.join(projectPath, BIT_HIDDEN_DIR);
-    if (!noGit && fs.existsSync(gitDirPath) && !fs.existsSync(resolvedScopePath)) {
+    // only a real ".git" directory hosts the embedded scope at ".git/bit". in a git worktree or
+    // submodule ".git" is a pointer FILE, so fall back to a standalone ".bit" inside the workspace
+    // (same as a non-git workspace) instead of composing an invalid ".git/bit" path.
+    if (!noGit && isDirectory(gitDirPath) && !fs.existsSync(resolvedScopePath)) {
       resolvedScopePath = path.join(gitDirPath, BIT_GIT_DIR);
     }
     return resolvedScopePath;

--- a/components/legacy/e2e-helper/e2e-git-helper.ts
+++ b/components/legacy/e2e-helper/e2e-git-helper.ts
@@ -35,6 +35,18 @@ export default class GitHelper {
     return this.command.runCmd(`git config --${location} ${key} ${val}`);
   }
 
+  /**
+   * create a git worktree at the given path on a new branch. the worktree gets a `.git` pointer
+   * FILE (not a directory) referencing its private git dir inside the main repo.
+   */
+  addWorktree(worktreePath: string, branch: string) {
+    return this.command.runCmd(`git worktree add ${worktreePath} -b ${branch}`);
+  }
+
+  removeWorktree(worktreePath: string) {
+    return this.command.runCmd(`git worktree remove ${worktreePath} --force`);
+  }
+
   unsetGitConfig(key: string, location = 'local') {
     return this.command.runCmd(`git config --unset --${location} ${key}`);
   }

--- a/components/modules/find-scope-path/find-scope-path.ts
+++ b/components/modules/find-scope-path/find-scope-path.ts
@@ -1,4 +1,3 @@
-import findUp from 'find-up';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { BIT_GIT_DIR, BIT_HIDDEN_DIR, DOT_GIT_DIR, OBJECTS_DIR } from '@teambit/legacy.constants';
@@ -6,22 +5,49 @@ import { BIT_GIT_DIR, BIT_HIDDEN_DIR, DOT_GIT_DIR, OBJECTS_DIR } from '@teambit/
 /**
  * search for a scope path by walking up parent directories until reaching root.
  * @param fromPath (e.g. /tmp/workspace)
- * @returns absolute scope-path if found (e.g. /tmp/workspace/.bit or /tmp/workspace/.git/bit)
+ * @returns absolute scope-path if found (e.g. /tmp/workspace/.bit or /tmp/workspace/.git/bit).
+ * in a git worktree/submodule (where ".git" is a pointer file, not a directory) the scope is a
+ * standalone ".bit" inside the workspace, same as a non-git workspace.
  */
 export function findScopePath(fromPath: string): string | undefined {
   if (!fromPath) return undefined;
   if (!fs.existsSync(fromPath)) return undefined;
-  const filePath = findUp.sync(
-    [
-      OBJECTS_DIR, // for bare-scope
-      path.join(BIT_HIDDEN_DIR, OBJECTS_DIR),
-      path.join(DOT_GIT_DIR, BIT_GIT_DIR, OBJECTS_DIR),
-    ],
-    { cwd: fromPath, type: 'directory' }
-  );
-  if (!filePath) return undefined;
-  if (filePath.endsWith(path.join('.git', 'objects'))) {
-    return undefined; // happens when "objects" dir is deleted from the scope
+  let currentPath = path.resolve(fromPath);
+  for (;;) {
+    // 1) bare scope: <dir>/objects
+    if (isDir(path.join(currentPath, OBJECTS_DIR))) {
+      // ".git/objects" is git's own object store, not a bit scope. it's reachable when walking up from
+      // a scope-path whose "objects" dir was deleted (e.g. ".git/bit"). keep the legacy behavior of bailing out.
+      if (path.basename(currentPath) === DOT_GIT_DIR) return undefined;
+      return currentPath;
+    }
+    // 2) workspace scope: <dir>/.bit/objects (also where a git worktree/submodule keeps its scope)
+    if (isDir(path.join(currentPath, BIT_HIDDEN_DIR, OBJECTS_DIR))) return path.join(currentPath, BIT_HIDDEN_DIR);
+    // 3) git-embedded scope (standard checkout only): <dir>/.git/bit/objects
+    const gitEmbeddedScope = path.join(currentPath, DOT_GIT_DIR, BIT_GIT_DIR);
+    if (isDir(path.join(gitEmbeddedScope, OBJECTS_DIR))) return gitEmbeddedScope;
+    // 4) a worktree/submodule root (".git" is a pointer file) with no scope yet is a hard boundary.
+    // its scope belongs at its own ".bit" (created on init/auto-init) — walking further up could
+    // pick up an unrelated outer repo's scope (and e.g. "bit init --reset-scope" would then wipe it).
+    if (isFile(path.join(currentPath, DOT_GIT_DIR))) return undefined;
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) return undefined; // reached the filesystem root
+    currentPath = parentPath;
   }
-  return path.dirname(filePath);
+}
+
+function isDir(dirPath: string): boolean {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
 }

--- a/e2e/harmony/git-worktree.e2e.ts
+++ b/e2e/harmony/git-worktree.e2e.ts
@@ -1,0 +1,191 @@
+import chai, { expect } from 'chai';
+import chaiFs from 'chai-fs';
+import * as path from 'path';
+import fs from 'fs-extra';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(chaiFs);
+
+/**
+ * E2E for running bit commands inside a git worktree.
+ *
+ * In a worktree, `.git` is a FILE containing a `gitdir: <main>/.git/worktrees/<name>` pointer
+ * rather than a directory. Bit used to blindly compose `.git/bit` and crash with
+ * `ENOTDIR: not a directory, open '.git/bit/unmerged.json'`.
+ *
+ * The supported model: a worktree is treated like a non-git (standalone) workspace — its scope is a
+ * self-contained `.bit` inside the worktree, starting empty like a fresh clone. The first bit command
+ * auto-initializes it, the committed `.gitignore` (which Bit writes with a `.bit` entry) keeps it out
+ * of git, and `git worktree remove` deletes it together with the worktree directory.
+ */
+describe('git worktree support', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  // tag+export `numComponents` components into a git workspace and make the initial commit, so a
+  // worktree can be branched off it. `.bit` is gitignored to keep the worktrees' scopes out of git.
+  function initGitWorkspaceWithExportedComponents(numComponents: number, gitIgnore: string[]) {
+    helper.scopeHelper.setWorkspaceWithRemoteScope();
+    helper.git.initNewGitRepo(true);
+    helper.fixtures.populateComponents(numComponents);
+    helper.command.tagAllWithoutBuild();
+    helper.command.export();
+    helper.git.writeGitIgnore(gitIgnore);
+    helper.command.runCmd('git add .');
+    helper.command.runCmd('git commit -m "initial commit"');
+  }
+
+  describe('running bit commands from a git worktree', () => {
+    let worktreePath: string;
+    let firstBitCommandOutput: string;
+
+    before(() => {
+      initGitWorkspaceWithExportedComponents(2, ['node_modules/', '.bit/']);
+
+      worktreePath = `${helper.scopes.localPath}-worktree`;
+      helper.git.addWorktree(worktreePath, 'feature-branch');
+
+      // the first bit command in the worktree. it should auto-init an empty ".bit" scope inside the
+      // worktree (same as the fresh-clone flow). registering the remote is needed anyway for the new
+      // scope to be able to import objects.
+      firstBitCommandOutput = helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, worktreePath);
+    });
+
+    after(() => {
+      if (fs.existsSync(worktreePath)) {
+        helper.git.removeWorktree(worktreePath);
+      }
+    });
+
+    it('the worktree should have .git as a file, not a directory (sanity)', () => {
+      const dotGit = path.join(worktreePath, '.git');
+      expect(fs.statSync(dotGit).isFile()).to.be.true;
+    });
+
+    it('the first bit command should not throw ENOTDIR', () => {
+      expect(firstBitCommandOutput).to.not.include('ENOTDIR');
+    });
+
+    it('should auto-init a standalone ".bit" scope inside the worktree (never compose .git/bit)', () => {
+      expect(path.join(worktreePath, '.bit', 'objects')).to.be.a.directory();
+      expect(path.join(worktreePath, '.bit', 'scope.json')).to.be.a.file();
+    });
+
+    describe('bit import and bit status in the worktree', () => {
+      let statusOutput: string;
+      before(() => {
+        helper.command.runCmd('bit import', worktreePath);
+        statusOutput = helper.command.runCmd('bit status', worktreePath);
+      });
+
+      it('bit status should run successfully (no ENOTDIR crash)', () => {
+        expect(statusOutput).to.not.include('ENOTDIR');
+      });
+
+      it('bit list should show the components with their exported version', () => {
+        const list: Record<string, any>[] = JSON.parse(helper.command.runCmd('bit list --json', worktreePath));
+        expect(list).to.have.lengthOf(2);
+        const comp1 = list.find((c) => c.id.includes('comp1'));
+        expect(comp1?.currentVersion).to.equal('0.0.1');
+      });
+    });
+
+    describe('snapping in the worktree', () => {
+      let mainHeadBeforeSnap: string;
+      before(() => {
+        mainHeadBeforeSnap = helper.command.getHead('comp1');
+        // the worktree is a fresh checkout without node_modules. link the workspace components
+        // so comp1's dependency on comp2 is resolvable.
+        helper.command.runCmd('bit link', worktreePath);
+        fs.outputFileSync(path.join(worktreePath, 'comp1', 'worktree-change.js'), 'console.log("from worktree");');
+        helper.command.runCmd('bit snap comp1 --message "snap from worktree"', worktreePath);
+      });
+
+      it('the snap should land in the worktree scope', () => {
+        const worktreeHead = helper.command.getHead('comp1', worktreePath);
+        expect(worktreeHead).to.not.equal(mainHeadBeforeSnap);
+      });
+
+      it('the main workspace scope should be unaffected', () => {
+        const mainHeadAfterSnap = helper.command.getHead('comp1');
+        expect(mainHeadAfterSnap).to.equal(mainHeadBeforeSnap);
+      });
+
+      it('the main workspace status should remain clean', () => {
+        helper.command.expectStatusToBeClean();
+      });
+    });
+
+    describe('lanes are independent per worktree', () => {
+      before(() => {
+        helper.command.runCmd('bit lane create worktree-lane', worktreePath);
+      });
+
+      it('the worktree should be on the new lane', () => {
+        const worktreeLanes = JSON.parse(helper.command.runCmd('bit lane list --json', worktreePath));
+        expect(worktreeLanes.currentLane).to.equal('worktree-lane');
+      });
+
+      it('the main workspace should stay on main and not know the lane', () => {
+        const mainLanes = helper.command.listLanesParsed();
+        expect(mainLanes.currentLane).to.equal('main');
+        const laneNames = mainLanes.lanes.map((lane: any) => lane.name || lane.id?.name);
+        expect(laneNames).to.not.include('worktree-lane');
+      });
+    });
+
+    describe('git worktree remove cleans up the scope', () => {
+      before(() => {
+        helper.git.removeWorktree(worktreePath);
+        helper.command.runCmd('git worktree prune');
+      });
+
+      it('the worktree directory (including its .bit scope) should be gone', () => {
+        expect(fs.existsSync(worktreePath)).to.be.false;
+      });
+    });
+  });
+
+  /**
+   * a worktree created INSIDE the main workspace directory is a hard boundary for scope resolution:
+   * before its own scope is initialized, bit must NOT walk up and pick the main workspace's scope
+   * (a `bit init --reset-scope` would then wipe the main scope).
+   */
+  describe('a worktree nested inside the main workspace directory', () => {
+    let nestedWorktreePath: string;
+    let mainScopeObjectsPath: string;
+
+    before(() => {
+      initGitWorkspaceWithExportedComponents(1, ['node_modules/', '.bit/', 'nested-wt/']);
+
+      nestedWorktreePath = path.join(helper.scopes.localPath, 'nested-wt');
+      helper.git.addWorktree(nestedWorktreePath, 'nested-branch');
+      // the main workspace ran `bit init` before `git init`, so its scope is a standalone ".bit".
+      mainScopeObjectsPath = path.join(helper.scopes.localPath, '.bit', 'objects');
+    });
+
+    it('bit init --reset-scope as the first command in the fresh worktree should not wipe the main scope', () => {
+      // depending on whether consumer creation persisted the worktree scope first, this either resets
+      // the worktree's own (empty) scope or errors with "scope not found". either way, the main
+      // workspace's scope must never be picked by the walk-up and wiped.
+      helper.general.runWithTryCatch('bit init --reset-scope', nestedWorktreePath);
+      expect(mainScopeObjectsPath).to.be.a.directory().and.not.empty;
+    });
+
+    it('bit commands in the nested worktree should use its own scope, not the main one', () => {
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, nestedWorktreePath);
+      helper.command.runCmd('bit import', nestedWorktreePath);
+      helper.command.runCmd('bit status', nestedWorktreePath);
+      expect(path.join(nestedWorktreePath, '.bit', 'objects')).to.be.a.directory();
+      expect(mainScopeObjectsPath).to.be.a.directory().and.not.empty;
+    });
+  });
+});


### PR DESCRIPTION
Previously, any bit command run from a git worktree crashed with `ENOTDIR: not a directory, open '.git/bit/unmerged.json'` — in a worktree (or submodule) `.git` is a pointer **file** (`gitdir: <main>/.git/worktrees/<name>`), not a directory, and Bit blindly composed `.git/bit` as the scope path.

A worktree is now treated like a standalone (non-git) workspace: its local scope is a self-contained `.bit` inside the worktree. This reuses an existing, fully-supported scope location, so the rest of the codebase (e.g. `bit doctor --archive`, which walks the workspace root) keeps working unchanged. The committed `.gitignore` (which Bit writes with a `.bit` entry) keeps it out of git, and `git worktree remove` deletes the scope together with the worktree directory. The scope starts empty like a fresh clone and is auto-initialized by the first bit command; `bit import`/`bit install` populates it.

Implementation (minimal):
- `Consumer._getScopePath` composes `.git/bit` only when `.git` is a real **directory**; otherwise (worktree/submodule) it falls back to `.bit`.
- `findScopePath` walks up to locate the scope and stops at a worktree/submodule boundary, so a not-yet-initialized worktree can't resolve (and `bit init --reset-scope` wipe) an outer repo's scope.

Submodules (also a `.git` pointer file) get the same treatment.

Known limitation: a branch whose `.bitmap` references staged-but-unexported snaps can't resolve them in a new worktree (same as a fresh clone) — export first.