### PR TITLE
fix(capsule): prune by age only, drop size-based eviction

### DIFF
--- a/components/legacy/constants/constants.ts
+++ b/components/legacy/constants/constants.ts
@@ -394,12 +394,6 @@ export const CFG_USE_DATED_CAPSULES = 'use_dated_capsules';
 export const CFG_CACHE_LOCK_ONLY_CAPSULES = 'cache_lock_only_capsules';
 
 /**
- * Soft size limit (in GB) for the global capsules dir. When exceeded, the auto-prune trigger
- * runs an LRU eviction of aspect-version subdirs until the cache drops below this size.
- */
-export const CFG_CAPSULES_MAX_SIZE_GB = 'capsules_max_size_gb';
-
-/**
  * Age threshold (in days) for aspect-version and scope capsule pruning. Capsules whose
  * last-used marker is older than this are considered stale and removed. Workspace capsules
  * are deleted regardless of age.

--- a/scopes/component/isolator/capsule-cache.ts
+++ b/scopes/component/isolator/capsule-cache.ts
@@ -21,7 +21,6 @@ import { isFeatureEnabled, CAPSULE_AUTO_PRUNE } from '@teambit/harmony.modules.f
 import {
   CFG_CAPSULES_AUTO_PRUNE,
   CFG_CAPSULES_MAX_AGE_DAYS,
-  CFG_CAPSULES_MAX_SIZE_GB,
   CFG_CAPSULES_SCOPES_ASPECTS_DATED_DIR,
 } from '@teambit/legacy.constants';
 import type CapsuleList from './capsule-list';
@@ -49,13 +48,12 @@ export type PruneCapsulesOptions = {
   olderThanDays?: number;
   includeOrphans?: boolean;
   keepWorkspaceCaps?: boolean;
-  sizeTargetGb?: number;
   dryRun?: boolean;
   /**
    * Compute byte sizes for every entry being considered. When false, all `sizeBytes`
    * in the report are 0 and the cache walk skips the expensive recursive `lstat` pass —
    * deletion (rename-to-trash) is O(1) and runs in milliseconds even on multi-GB caches.
-   * Forced on when `sizeTargetGb` is set because that path needs sizes to enforce.
+   * Opt-in (via `bit capsule prune --with-sizes`) since the walk is slow on large caches.
    */
   withSizes?: boolean;
 };
@@ -257,14 +255,11 @@ export class CapsuleCache {
       await fs.outputFile(stampPath, '');
 
       // Guard against non-numeric/empty config (NaN) and negative values (which would
-      // invert the age cutoff / size target and wipe the whole cache).
+      // invert the age cutoff and wipe the whole cache).
       const olderThanDays = Math.max(0, toFiniteNumber(this.configStore.getConfig(CFG_CAPSULES_MAX_AGE_DAYS)) ?? 30);
-      const sizeTargetGb = Math.max(0, toFiniteNumber(this.configStore.getConfig(CFG_CAPSULES_MAX_SIZE_GB)) ?? 10);
 
-      this.logger.debug(
-        `[auto-prune] spawning detached child. olderThanDays=${olderThanDays}, sizeTargetGb=${sizeTargetGb}`
-      );
-      this.spawnDetachedAutoPrune(olderThanDays, sizeTargetGb);
+      this.logger.debug(`[auto-prune] spawning detached child. olderThanDays=${olderThanDays}`);
+      this.spawnDetachedAutoPrune(olderThanDays);
     } finally {
       if (claimed) {
         try {
@@ -284,22 +279,18 @@ export class CapsuleCache {
    * Recursion guard: the child also runs onBeforeExit → maybeAutoPrune, but it reads the
    * stamp file that we just wrote and bails out before re-spawning.
    */
-  private spawnDetachedAutoPrune(olderThanDays: number, sizeTargetGb: number): void {
+  private spawnDetachedAutoPrune(olderThanDays: number): void {
     const bitEntry = process.argv[1];
     if (!bitEntry) {
       this.logger.debug('[auto-prune] cannot detach: process.argv[1] is empty');
       return;
     }
     try {
-      const child = spawn(
-        process.execPath,
-        [bitEntry, 'capsule', 'prune', '--older-than', String(olderThanDays), '--size-target', String(sizeTargetGb)],
-        {
-          detached: true,
-          stdio: 'ignore',
-          windowsHide: true,
-        }
-      );
+      const child = spawn(process.execPath, [bitEntry, 'capsule', 'prune', '--older-than', String(olderThanDays)], {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      });
       child.unref();
     } catch (err: any) {
       this.logger.debug(`[auto-prune] failed to spawn detached child: ${err.message}`);
@@ -507,21 +498,18 @@ export class CapsuleCache {
    *   - scope-aspects-root: never deleted as a whole; per-aspect-version children pruned by age
    *   - scope caps and unmarked dirs older than threshold: deleted
    *   - orphans (marker says originPath gone): deleted
-   *   - after the above, if sizeTargetGb given and size still exceeds it, evict oldest-first
    */
   async pruneCapsules(opts: PruneCapsulesOptions = {}): Promise<PruneCapsulesReport> {
     // Clamp to >= 0: a negative age would put the cutoff in the future (everything looks
-    // "too old" → whole cache deleted); a negative size target would force evicting
-    // everything. Both are almost certainly user error, so floor them at 0.
+    // "too old" → whole cache deleted), almost certainly user error, so floor it at 0.
     const olderThanDays = Math.max(0, opts.olderThanDays ?? 30);
-    const sizeTargetGb = opts.sizeTargetGb === undefined ? undefined : Math.max(0, opts.sizeTargetGb);
     const includeOrphans = opts.includeOrphans !== false;
     const keepWorkspaceCaps = opts.keepWorkspaceCaps === true;
     const dryRun = opts.dryRun === true;
     // Size accounting requires an expensive recursive lstat across the whole cache. Skip
-    // it by default so the foreground command returns in ms (deletes are O(1) renames);
-    // force on for size-target enforcement and when the caller asks for byte accounting.
-    const computeSizes = opts.withSizes === true || sizeTargetGb !== undefined;
+    // it by default so the command returns in ms (deletes are O(1) renames); opt in via
+    // `--with-sizes` when you want byte totals in the report.
+    const computeSizes = opts.withSizes === true;
     const ageCutoffMs = Date.now() - olderThanDays * ONE_DAY_MS;
     const datedDirName = this.configStore.getConfig(CFG_CAPSULES_SCOPES_ASPECTS_DATED_DIR) || 'dated-capsules';
 
@@ -566,10 +554,6 @@ export class CapsuleCache {
         await this.pruneAspectsRootChildren(root.path, ageCutoffMs, dryRun, computeSizes, removed);
         continue;
       }
-    }
-
-    if (sizeTargetGb !== undefined) {
-      await this.applySizeTarget(sizeTargetGb, removed, dryRun);
     }
 
     const totalRemovedBytes = removed.reduce((sum, r) => sum + r.sizeBytes, 0);
@@ -690,65 +674,6 @@ export class CapsuleCache {
           dryRun
         );
       }
-    }
-  }
-
-  /**
-   * After the standard prune, if total still exceeds the target, keep evicting the
-   * oldest remaining aspect-version subdirs until under the limit.
-   */
-  private async applySizeTarget(
-    sizeTargetGb: number,
-    removed: PruneCapsulesReport['removed'],
-    dryRun: boolean
-  ): Promise<void> {
-    const targetBytes = sizeTargetGb * 1024 * 1024 * 1024;
-    const removedPaths = new Set(removed.map((r) => r.path));
-    // Re-walk what's left (one pass, with sizes) to find both the current total and the
-    // oldest aspect-version children to evict.
-    const roots = await this.listAllCapsuleRoots();
-    const totalBytes = roots.reduce((sum, r) => sum + r.sizeBytes, 0);
-    const aspectChildren: Array<{ path: string; lastUsedMs: number; sizeBytes: number; originPath?: string }> = [];
-    for (const root of roots) {
-      if (
-        root.kind !== 'scope-aspects-root' &&
-        !(root.kind === 'unmarked' && (await this.looksLikeAspectsRoot(root.path)))
-      ) {
-        continue;
-      }
-      let entries: fs.Dirent[] = [];
-      try {
-        entries = await fs.readdir(root.path, { withFileTypes: true });
-      } catch {
-        continue;
-      }
-      for (const entry of entries) {
-        if (!this.isPrunableSubdir(entry)) continue;
-        const childPath = path.join(root.path, entry.name);
-        if (removedPaths.has(childPath)) continue;
-        const { marker, lastUsedMs } = await this.readMarkerInfo(childPath);
-        const sizeBytes = await this.computeDirSize(childPath);
-        aspectChildren.push({ path: childPath, lastUsedMs, sizeBytes, originPath: marker?.originPath });
-      }
-    }
-    aspectChildren.sort((a, b) => a.lastUsedMs - b.lastUsedMs);
-    // In dry-run the standard-prune entries are still on disk (counted in totalBytes), so
-    // subtract them; in a real run they were already moved to trash and excluded from the walk.
-    let remainingBytes = totalBytes - (dryRun ? removed.reduce((s, r) => s + r.sizeBytes, 0) : 0);
-    for (const child of aspectChildren) {
-      if (remainingBytes <= targetBytes) break;
-      await this.recordRemoval(
-        removed,
-        {
-          path: child.path,
-          kind: 'scope-aspect',
-          reason: `size-target-${sizeTargetGb}gb`,
-          sizeBytes: child.sizeBytes,
-          originPath: child.originPath,
-        },
-        dryRun
-      );
-      remainingBytes -= child.sizeBytes;
     }
   }
 }

--- a/scopes/harmony/cli-reference/cli-reference.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.mdx
@@ -313,7 +313,6 @@ use --dry-run first to preview what would be removed.
 | `--older-than <days>`   |                  | age threshold in days for aspect-version/scope capsule pruning (default 30)                                                                      |
 | `--keep-workspace-caps` |                  | skip workspace capsule deletion                                                                                                                  |
 | `--no-orphans`          |                  | don't delete capsules whose origin path no longer exists                                                                                         |
-| `--size-target <gb>`    |                  | after standard pruning, LRU-evict aspect-versions until total drops below this size (forces --with-sizes)                                        |
 | `--dry-run`             |                  | preview what would be removed without deleting                                                                                                   |
 | `--with-sizes`          |                  | compute byte sizes for the report (walks the full cache; slow on large caches). default: off — sizes shown as 0 but the prune itself is instant. |
 | `--json`                |       `-j`       | json format                                                                                                                                      |

--- a/scopes/workspace/workspace/capsule.cmd.ts
+++ b/scopes/workspace/workspace/capsule.cmd.ts
@@ -5,7 +5,7 @@ import type { CapsuleList, IsolateComponentsOptions, IsolatorMain, PruneCapsules
 import { CAPSULE_ORIGIN_FILE } from '@teambit/isolator';
 import type { ScopeMain } from '@teambit/scope';
 import type { ConfigStoreMain } from '@teambit/config-store';
-import { CFG_CAPSULES_MAX_AGE_DAYS, CFG_CAPSULES_MAX_SIZE_GB } from '@teambit/legacy.constants';
+import { CFG_CAPSULES_MAX_AGE_DAYS } from '@teambit/legacy.constants';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
@@ -288,7 +288,6 @@ type PruneOpts = {
   olderThan?: number;
   keepWorkspaceCaps?: boolean;
   noOrphans?: boolean;
-  sizeTarget?: number;
   dryRun?: boolean;
   withSizes?: boolean;
   json?: boolean;
@@ -305,11 +304,6 @@ use --dry-run first to preview what would be removed.`;
     ['', 'older-than <days>', 'age threshold in days for aspect-version/scope capsule pruning (default 30)'],
     ['', 'keep-workspace-caps', 'skip workspace capsule deletion'],
     ['', 'no-orphans', "don't delete capsules whose origin path no longer exists"],
-    [
-      '',
-      'size-target <gb>',
-      'after standard pruning, LRU-evict aspect-versions until total drops below this size (forces --with-sizes)',
-    ],
     ['', 'dry-run', 'preview what would be removed without deleting'],
     [
       '',
@@ -362,12 +356,10 @@ use --dry-run first to preview what would be removed.`;
     // CLI flags win; otherwise fall back to user config so manual and auto-prune
     // behave consistently. Final fallback to defaults happens in `pruneCapsules`.
     const olderThanFromConfig = this.configStore.getConfig(CFG_CAPSULES_MAX_AGE_DAYS);
-    const sizeTargetFromConfig = this.configStore.getConfig(CFG_CAPSULES_MAX_SIZE_GB);
     return this.isolator.pruneCapsules({
       olderThanDays: toFiniteNumber(opts.olderThan) ?? toFiniteNumber(olderThanFromConfig),
       keepWorkspaceCaps: opts.keepWorkspaceCaps === true,
       includeOrphans: opts.noOrphans !== true,
-      sizeTargetGb: toFiniteNumber(opts.sizeTarget) ?? toFiniteNumber(sizeTargetFromConfig),
       dryRun: opts.dryRun === true,
       withSizes: opts.withSizes === true,
     });


### PR DESCRIPTION
## Problem

The capsule auto-prune (`bit capsule prune --size-target 10`) was wiping scope-aspects capsules across **all** repos sharing the global cache. With ~10 bit checkouts, every aspect capsule got evicted daily, making rebuilds slow.

Root cause is in `applySizeTarget`: it measured the **whole** cache total but could only evict scope-aspect children. When the un-evictable remainder (workspace/scope caps, ~11 GB of legacy unmarked dirs, each aspect-root's own `node_modules`) already exceeded the target, the loop evicted 100% of aspect capsules across every repo and still never reached the target. Evidence from logs: 569 removals tagged `size-target-10gb` vs only 14 for `older-than-30d`, and the cache stayed at 18 GB after "pruning" to a 10 GB target.

Size accounting also forced an expensive recursive `lstat` walk of the entire cache on every auto-prune.

## Change

Drop size-based eviction entirely; prune by **age + orphan** only.

- Auto-prune spawns `bit capsule prune --older-than <N>` (no `--size-target`); no size walk → O(1) rename-to-trash deletes.
- Removed `applySizeTarget`, the `--size-target` flag, and `CFG_CAPSULES_MAX_SIZE_GB`.
- `--with-sizes` stays as an opt-in for byte totals in the report.

The cache now self-bounds to "workspaces touched within `--older-than` (default 30d)"; throwaway/temp scopes are still caught by the orphan check.