### PR TITLE
chore: clean up misleading root package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,7 @@
 {
-  "name": "@teambit/legacy",
-  "version": "1.0.770",
+  "name": "bit-workspace",
   "license": "Apache-2.0",
-  "main": "./dist/api.js",
-  "preferGlobal": true,
-  "private": false,
-  "files": [
-    "/dist"
-  ],
+  "private": true,
   "engines": {
     "node": ">=12.22.0"
   },
@@ -18,26 +12,10 @@
       "git add"
     ]
   },
-  "pkg": {
-    "assets": [
-      "dist/analytics/analytics-sender.js",
-      "dist/specs-runner/worker.js"
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/teambit/bit"
   },
-  "keywords": [
-    "bit",
-    "components",
-    "collaboration",
-    "web",
-    "react",
-    "react-components",
-    "angular",
-    "angular-components"
-  ],
   "scripts": {
     "dev-link": "node ./scripts/establish-dev-link.js $1",
     "dev-link:windows": "node ./scripts/establish-dev-link-windows.js $1",
@@ -71,15 +49,6 @@
     "build-centos-image": "docker build ./scripts/linux/centos -t centos-rpm",
     "build-debian-image": "docker build ./scripts/linux/debian -t debian-deb",
     "doc-gen": "node ./scripts/doc-generator.js",
-    "pkg": "pkg bin/bit.js --targets node10 --out-path releases/ --options --no-warnings --config package.json",
-    "pkg:linux": "pkg bin/bit.js --targets node10-linux-x64 --out-path releases/linux --options --no-warnings --config package.json",
-    "pkg:mac": "pkg bin/bit.js --targets node10-macos-x64 --out-path releases/mac --options --no-warnings --config package.json",
-    "pkg:windows": "pkg bin/bit.js --targets node10-win-x64 --out-path releases/windows --options --no-warnings --config package.json",
-    "pkg:all": "pkg bin/bit.js --targets node10-macos-x64,node10-win-x64,node10-linux-x64 --out-path releases/ --options --no-warnings --config package.json",
-    "pre-release:inc-pack": "npm run pkg:all && npm run pre-release",
-    "release:inc-pack": "npm run pkg:all && npm run release",
-    "brew-bump:dry-run": "BIT_VERSION=$(cat ./package.json | jq .version -r) && brew bump-formula-pr bit --url='https://registry.npmjs.org/bit-bin/-/bit-bin-${BIT_VERSION}.tgz' --message='version bump' --dry-run",
-    "brew-bump": "BIT_VERSION=$(cat ./package.json | jq .version -r) && brew bump-formula-pr bit --url='https://registry.npmjs.org/bit-bin/-/bit-bin-${BIT_VERSION}.tgz' --message='version bump'",
     "assert:master": "node ./scripts/assert-master.js",
     "nightly": "npm run assert:master && git tag -d manual-nightly && git push --delete origin manual-nightly && git tag manual-nightly && git push origin manual-nightly",
     "generate-cli-reference": "bit cli generate > scopes/harmony/cli-reference/cli-reference.mdx && prettier scopes/harmony/cli-reference/cli-reference.mdx --write",


### PR DESCRIPTION
The root `package.json` is a leftover from the old `@teambit/legacy`/`bit-bin` single-package days. Since legacy was refactored into Bit components, its `name`/`version` and publish-artifact fields are dead and misleading — nothing reads them, the real CLI publishes as `@teambit/bit` (managed by Bit's own tag mechanism), and `dist/` no longer exists. Worse, `name: @teambit/legacy` + `private: false` is a latent footgun: it collides with a real published package, so an accidental `npm publish` from the root would target it.

This file is now just a private workspace root holding npm scripts and dev-tooling config, so make it read honestly:

- rename to `bit-workspace`, set `private: true`
- drop dead publish fields: `version`, `main`, `files`, `preferGlobal`, `pkg`, `keywords`
- remove dead scripts: `pkg:*`, `pre-release:inc-pack`, `release:inc-pack`, `brew-bump*` (old `bit-bin` binary/Homebrew flow; verified not referenced by CircleCI or GitHub workflows; the `:inc-pack` ones already chained to non-existent `pre-release`/`release` targets)

Functional config is untouched: `repository`, `engines`, `lint-staged`, `dependencies`, `pnpm`, and all build/test/lint/setup/generate scripts.