### PR TITLE
chore: add .pr_agent.toml to configure Qodo reviews

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,35 @@
+[github_app]
+# Commands run automatically when a PR is opened.
+pr_commands = [
+    "/agentic_describe",
+    "/agentic_review",
+]
+
+# Re-run commands when new commits are pushed to the PR.
+handle_push_trigger = true
+
+# Commands run automatically on push (requires handle_push_trigger = true).
+push_commands = [
+    "/agentic_review",
+]
+
+[config]
+# Skip automated reviews on bot-authored PRs (e.g. dependency bumps or CI bots).
+# Qodo auto-detects most bots; these are listed explicitly to be safe.
+ignore_pr_authors = [
+    "dependabot[bot]",
+    "renovate[bot]",
+    "teambit-ci",
+]
+
+# Optional: also skip reviews on chore/ci PRs by title (regex list).
+# Left commented so maintainers can opt in. Note that bot dependency bumps
+# are already covered by ignore_pr_authors above.
+# ignore_pr_title = ["^chore", "^ci"]
+
+[review_agent]
+# Extra instructions for the Issues Agent (bug, security, performance detection).
+# issues_user_guidelines = ""
+
+# Extra instructions for the Compliance Agent (rule checking).
+# compliance_user_guidelines = ""


### PR DESCRIPTION
Adds `.pr_agent.toml` to enable Qodo agentic reviews on PRs.

- On PR open: `/agentic_describe` + `/agentic_review`
- On push: `/agentic_review`
- Skips bot-authored PRs (dependabot, renovate, teambit-ci)