### PR TITLE
ci: unpin bvm, restore bvm upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,8 +224,8 @@ commands:
     steps:
       - run: bvm config set DEFAULT_LINK bbit
       - run: bvm config set RELEASE_TYPE nightly
-      # - run: bvm upgrade
-      - run: bvm install 1.13.217
+      - run: bvm upgrade
+      # - run: bvm install 1.11.42
       - run: bvm link --verbose
       - bit_config:
           env: "hub"


### PR DESCRIPTION
Reverts the temporary bvm pin to 1.13.217 (from #10420). Now that a fixed bit version — bundling the self-contained `mdx-multi-compiler@2.0.46` — is released, CI can track latest again via `bvm upgrade`.