### PR TITLE
ci: block direct pushes to master via pre-push hook

### DIFF
--- a/.claude/hooks/block-master-push.sh
+++ b/.claude/hooks/block-master-push.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# PreToolUse guard for Claude Code: deny any `git push` that targets master or main.
+# Receives the hook JSON on stdin; prints a deny decision when blocked, nothing otherwise.
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+case "$cmd" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+deny() {
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$1"
+  exit 0
+}
+
+# Examine only the `git push ...` segment(s) of the command, with quoted strings removed,
+# so unrelated prose (commit messages, PR bodies mentioning master) doesn't false-positive.
+# Not airtight against deliberately quoted refs - the .husky/pre-push hook backstops those.
+push_segments=$(printf '%s' "$cmd" | sed "s/'[^']*'//g"' ; s/"[^"]*"//g ; s/&&/\n/g; s/;/\n/g; s/|/\n/g' | grep 'git push')
+
+# explicit master/main as a standalone word (branch arg or refspec), incl. refs/heads/ form
+if printf '%s' "$push_segments" | grep -qE '(^|[^A-Za-z0-9_/.-])(master|main)([^A-Za-z0-9_.-]|$)' ||
+  printf '%s' "$push_segments" | grep -qE 'refs/heads/(master|main)([^A-Za-z0-9_.-]|$)'; then
+  deny "Blocked: this git push references master/main. Never push to master/main — create a feature branch and open a PR instead."
+fi
+
+# bare `git push` (no explicit master/main): deny when the current branch is master/main
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+case "$branch" in
+  master|main)
+    deny "Blocked: the current branch is $branch, so this push would update $branch. Move the work to a feature branch (git branch feat-x && git reset --hard origin/$branch && git checkout feat-x) and open a PR."
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check-e2e-only.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-master-push.sh"
           }
         ]
       }

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,16 @@
+# Block direct pushes to master. All changes must go through a PR.
+# CI is exempt (release automation pushes version bumps to master).
+[ -n "$CI" ] && exit 0
+
+while read local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/master)
+      if [ "${ALLOW_MASTER_PUSH:-0}" != "1" ]; then
+        echo "✗ Direct push to master is blocked. Open a PR instead." >&2
+        echo "  Emergency override: ALLOW_MASTER_PUSH=1 git push" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,12 @@
-# Block direct pushes to master. All changes must go through a PR.
+# Block direct pushes to master/main. All changes must go through a PR.
 # CI is exempt (release automation pushes version bumps to master).
 [ -n "$CI" ] && exit 0
 
 while read local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
-    refs/heads/master)
+    refs/heads/master | refs/heads/main)
       if [ "${ALLOW_MASTER_PUSH:-0}" != "1" ]; then
-        echo "✗ Direct push to master is blocked. Open a PR instead." >&2
+        echo "✗ Direct push to ${remote_ref#refs/heads/} is blocked. Open a PR instead." >&2
         echo "  Emergency override: ALLOW_MASTER_PUSH=1 git push" >&2
         exit 1
       fi


### PR DESCRIPTION
Two layers of protection against direct pushes to the default branch — everything must go through a PR:

1. **`.husky/pre-push`** — rejects any such push at the git level, for every contributor. CI is exempt ($CI is set there) so release automation that pushes version bumps keeps working. Emergency override: `ALLOW_MASTER_PUSH=1`.

2. **`.claude/hooks/block-master-push.sh`** + project-settings PreToolUse hook — blocks Claude Code from even attempting such a push (explicit refspec, refs/heads form, or a bare push while on the default branch), steering it to a feature branch + PR. Quoted strings are stripped before matching so commit messages/PR bodies mentioning the branch name don't false-positive; deliberately quoted refs are backstopped by layer 1.

Both layers verified locally: a dry-run push to the default branch is rejected by each independently (the Claude hook even blocked this PR's own commit until the false-positive handling was added); branch pushes pass.