### PR TITLE
ci: verify generated CLI-reference files are committed in the PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,6 +667,54 @@ jobs:
           name: 'make sure the packages used in legacy are specified in package.json'
           command: 'cd bit && node scripts/validate-pkg-exist-in-pkg-json.js'
 
+  # Verify the generated CLI-reference / core-aspects files are committed and up to date.
+  # These files (cli-reference.{mdx,json,docs.mdx}, the claude-skill docs, and
+  # core-aspects-ids.json) are component sources, so they belong in the PR rather than
+  # being regenerated and committed post-merge on master by bit_merge. This shifts that
+  # generation left: it regenerates the files and fails if the working tree differs,
+  # telling the author to run the generate-* scripts and commit the result. Mirrors the
+  # environment bit_merge already uses to run `bit cli generate`.
+  check_generated_reference:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ./
+      - bit_global_for_npm
+      - bit_config
+      - restore_common_caches
+      - run:
+          name: 'regenerate CLI-reference and core-aspects files'
+          command: |
+            cd bit
+            npm run generate-cli-reference
+            npm run generate-cli-reference-json
+            npm run generate-cli-reference-docs
+            npm run generate-cli-skill
+            npm run generate-core-aspects-ids
+      - run:
+          name: 'fail if any generated reference file is out of date'
+          command: |
+            cd bit
+            GENERATED="scopes/harmony/cli-reference/cli-reference.mdx \
+                       scopes/harmony/cli-reference/cli-reference.json \
+                       scopes/harmony/cli-reference/cli-reference.docs.mdx \
+                       contrib/claude-skill-bit-cli/SKILL.md \
+                       contrib/claude-skill-bit-cli/CLI_REFERENCE.md \
+                       scopes/harmony/testing/load-aspect/core-aspects-ids.json"
+            # cli-reference.docs.mdx embeds the running bit version in its frontmatter
+            # (cli.cmd.ts: "Bit version: ${getBitVersion()}"), which is a release-time
+            # value not knowable in a PR. Ignore hunks whose only change is that line so
+            # the check doesn't flap on every version bump.
+            DIFF=$(git diff -I'Bit version: [0-9]' -- $GENERATED)
+            if [ -z "$DIFF" ]; then
+              echo "✅ generated reference files are up to date"
+            else
+              echo "❌ generated reference files are out of date. Run locally and commit the result:"
+              echo "   npm run generate-cli-reference && npm run generate-cli-reference-json && npm run generate-cli-reference-docs && npm run generate-cli-skill && npm run generate-core-aspects-ids"
+              git --no-pager diff -I'Bit version: [0-9]' --stat -- $GENERATED
+              exit 1
+            fi
+
   # ========== Documentation & Notifications ==========
   generate_docs:
     <<: *defaults
@@ -1303,6 +1351,12 @@ workflows:
       - generate_and_check_types:
           requires:
             - setup_harmony
+      - check_generated_reference:
+          requires:
+            - setup_harmony
+          filters:
+            branches:
+              ignore: master
       - generate_docs:
           <<: *semver_tags_only_filters
           requires:


### PR DESCRIPTION
Adds a PR-side `check_generated_reference` job that regenerates the CLI-reference, claude-skill, and `core-aspects-ids` files and fails if the working tree differs — shifting their generation *left* into the PR instead of relying on the post-merge `bit_merge` commit on master.

These files are component sources, so they belong in the PR. This is also a prerequisite for moving `bit ci merge` to `--no-bitmap-commit` (so master stops receiving post-merge commits) ahead of enabling the GitHub merge queue.

**Rollout is intentionally conservative:**
- The job mirrors the environment `bit_merge` already uses to run `bit cli generate`.
- It starts **non-required**, and the existing post-merge generation in `bit_merge` stays as a safety net — so there's no regression risk if an author forgets to regenerate.
- Once it proves stable and CI/local output parity is confirmed, we promote it to a required status check and drop the post-merge generation.

Note: a red on this new check on *this* PR just means the committed files differ from CI's regeneration (a one-time parity bootstrap), not a blocker — it's non-required by design.