### PR TITLE
test(e2e): fix mocha-tester broken by @babel/preset-env v8

### DIFF
--- a/components/legacy/e2e-helper/excluded-fixtures/extensions/mocha-only-test-env/mocha-only-test-env.bit-env.ts
+++ b/components/legacy/e2e-helper/excluded-fixtures/extensions/mocha-only-test-env/mocha-only-test-env.bit-env.ts
@@ -4,7 +4,11 @@ import { Pipeline } from '@teambit/builder';
 
 const presets = [
   require.resolve('@babel/preset-typescript'),
-  require.resolve('@babel/preset-env')
+  // force CommonJS output: the mocha tester loads spec files through @babel/register (a CommonJS
+  // require hook), so ESM imports must be down-leveled to require(). since @babel/preset-env v8 the
+  // default "modules: auto" preserves ESM, which makes Node treat the spec as ESM and fail to
+  // resolve extension-less relative imports (e.g. "./foo").
+  [require.resolve('@babel/preset-env'), { modules: 'commonjs' }]
 ];
 
 export class MochaOnlyTestEnv {

--- a/e2e/harmony/mocha-tester.e2e.ts
+++ b/e2e/harmony/mocha-tester.e2e.ts
@@ -15,6 +15,7 @@ describe('Mocha Tester', function () {
       '@teambit/typescript.typescript-compiler',
       '@teambit/defender.mocha-tester',
       'chai',
+      'chai-fs',
       '@babel/preset-typescript',
       '@babel/preset-env',
     ]);


### PR DESCRIPTION
## Problem

`mocha-tester.e2e.ts` started failing on master and open PRs simultaneously, with no related code change. The trigger was external: **`@babel/preset-env@8.0.0` was published on 2026-06-16** and the version-less dependency in the test env resolves to it.

In v8 the default `modules: 'auto'` **preserves ESM** instead of down-leveling `import`→`require` (v7 converted to CommonJS). The mocha tester loads spec files through `@babel/register`, a CommonJS `require` hook, so the un-converted ESM made Node treat each spec as an ES module and route through its native ESM resolver — which doesn't add extensions — failing on `import { addOne } from './foo'` with `Cannot find module '.../comp1/foo'`. This surfaced as the `bit test` throw at `mocha-tester.e2e.ts:139`.

## Fix

- Force `modules: 'commonjs'` on `@babel/preset-env` in the mocha test env fixture, so specs are down-leveled to CJS as `@babel/register` requires.
- Declare `chai-fs` (imported by the TS spec fixture but never a declared dep) in the env install list, so it resolves in the workspace regardless of environment.

## Verification

- Full `mocha-tester.e2e.ts` suite: 19 passing, 0 failing (test + build, JS + TS, `.only`, single-file).
- `babel.e2e.ts` uses preset-env via the babel compiler (a different path) and still passes — no change needed there.
- `npm run lint`: clean.