### PR TITLE
feat(ci): skip post-export workspace restore in CI for bit ci pr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,7 +704,9 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${npmjsRegistryToken}" >> ~/.npmrc
       - run:
           name: 'bit ci pr'
-          command: 'cd bit && bit ci pr --build --keep-lane'
+          # --skip-cleanup: this container is discarded right after, so don't waste time restoring
+          # the workspace to main (which re-checks-out main's HEAD and re-imports every component).
+          command: 'cd bit && bit ci pr --build --keep-lane --skip-cleanup'
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=30000

--- a/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
+++ b/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
@@ -146,8 +146,8 @@ Runs lint, build, and status checks to catch dependency drift or broken builds e
 
 Exports a feature lane to Bit Cloud when a Pull Request is opened or updated.
 
-Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. Cleans up by switching back to main. Use in pull-request CI pipelines after tests and before deploy.
-Flags: --message <message>, --lane <lane>, --build, --strict, --dry-run, --keep-lane
+Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. By default it then restores the workspace by switching back to main; pass --skip-cleanup to skip that restore when the workspace is about to be discarded (e.g. an ephemeral CI container). Use in pull-request CI pipelines after tests and before deploy.
+Flags: --message <message>, --lane <lane>, --build, --strict, --dry-run, --keep-lane, --skip-cleanup
 
 ## bit ci merge
 

--- a/e2e/harmony/ci-commands.e2e.ts
+++ b/e2e/harmony/ci-commands.e2e.ts
@@ -116,6 +116,72 @@ describe('ci commands', function () {
   });
 
   /**
+   * The default flow restores the workspace to main after export (asserted in the "bit ci pr
+   * workflow" describe above). `--skip-cleanup` opts out of that restore — used by the throwaway
+   * `bit_pr` CI container, where re-checking-out main's HEAD just to discard it is wasted work.
+   * These two describes assert that, with the flag, the workspace is intentionally LEFT on the PR
+   * lane on both code paths (default/temp-lane and `--keep-lane`), so a future change that drops the
+   * flag from either path (or re-introduces a `process.env.CI` auto-skip that fires in unintended
+   * contexts) is caught here.
+   */
+  describe('bit ci pr --skip-cleanup leaves the workspace on the PR lane (default/temp-lane flow)', () => {
+    let prOutput: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      setupGitRemote();
+      setupComponentsAndInitialCommit();
+
+      helper.command.runCmd('git checkout -b feature/skip-cleanup-temp');
+      helper.fs.outputFile('comp1/comp1.js', 'console.log("updated component");');
+      helper.command.runCmd('git add comp1/comp1.js');
+      helper.command.runCmd('git commit -m "feat: update component"');
+
+      prOutput = helper.command.runCmd('bit ci pr --skip-cleanup --message "skip cleanup pr"');
+    });
+    it('should complete successfully', () => {
+      expect(prOutput).to.include('PR command executed successfully');
+    });
+    it('should report that it skipped the workspace restore', () => {
+      const cleanOutput = removeChalkCharacters(prOutput) as string;
+      expect(cleanOutput).to.include('Skipping workspace restore');
+    });
+    it('should leave the workspace on the PR lane instead of switching back to main', () => {
+      const lanes = helper.command.listLanesParsed();
+      expect(lanes.currentLane).to.equal('feature-skip-cleanup-temp');
+    });
+    it('should still export the lane to the remote', () => {
+      const remoteLanes = helper.command.listRemoteLanesParsed();
+      const laneNames = remoteLanes.lanes.map((lane) => lane.name);
+      expect(laneNames).to.include('feature-skip-cleanup-temp');
+    });
+  });
+
+  describe('bit ci pr --keep-lane --skip-cleanup leaves the workspace on the PR lane', () => {
+    let prOutput: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      setupGitRemote();
+      setupComponentsAndInitialCommit();
+
+      helper.command.runCmd('git checkout -b feature/skip-cleanup-keep');
+      helper.fs.outputFile('comp1/comp1.js', 'console.log("updated component");');
+      helper.command.runCmd('git add comp1/comp1.js');
+      helper.command.runCmd('git commit -m "feat: update component"');
+
+      prOutput = helper.command.runCmd('bit ci pr --keep-lane --skip-cleanup --message "skip cleanup pr"');
+    });
+    it('should complete successfully and report skipping the restore', () => {
+      expect(prOutput).to.include('PR command executed successfully');
+      const cleanOutput = removeChalkCharacters(prOutput) as string;
+      expect(cleanOutput).to.include('Skipping workspace restore');
+    });
+    it('should leave the workspace on the PR lane instead of switching back to main', () => {
+      const lanes = helper.command.listLanesParsed();
+      expect(lanes.currentLane).to.equal('feature-skip-cleanup-keep');
+    });
+  });
+
+  /**
    * Subsequent commits to the same PR branch should re-use the existing remote lane rather than
    * deleting and recreating it. This preserves the lane's history (cloud UI shows the snap
    * progression), keeps user-made edits on the lane, and prevents a pile of archived lanes from

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -547,6 +547,7 @@ export class CiMain {
     strict,
     dryRun,
     keepLane,
+    skipCleanup,
   }: {
     laneIdStr: string;
     message: string;
@@ -554,7 +555,13 @@ export class CiMain {
     strict: boolean | undefined;
     dryRun?: boolean;
     keepLane?: boolean;
+    skipCleanup?: boolean;
   }) {
+    // The post-export cleanup switches the workspace back to main, which re-checks-out main's HEAD
+    // and re-imports every workspace component. That restore is only useful for an interactive run;
+    // in CI the container is discarded immediately, so default to skipping it there. An explicit
+    // flag (true or, where the parser supports `--no-skip-cleanup`, false) always wins.
+    const resolvedSkipCleanup = skipCleanup ?? Boolean(process.env.CI);
     this.logger.console(chalk.blue(`Lane name: ${laneIdStr}`));
 
     const originalLane = await this.lanes.getCurrentLane();
@@ -580,9 +587,60 @@ export class CiMain {
     // default, battle-tested flow: snap onto a throwaway temp lane and delete+recreate the final
     // lane at export time (the lane is recreated on every PR commit).
     if (keepLane) {
-      return this.snapAndExportReusingLane({ laneId, originalLane, message, build, dryRun });
+      return this.snapAndExportReusingLane({
+        laneId,
+        originalLane,
+        message,
+        build,
+        dryRun,
+        skipCleanup: resolvedSkipCleanup,
+      });
     }
-    return this.snapAndExportWithTempLane({ laneId, originalLane, message, build, dryRun });
+    return this.snapAndExportWithTempLane({
+      laneId,
+      originalLane,
+      message,
+      build,
+      dryRun,
+      skipCleanup: resolvedSkipCleanup,
+    });
+  }
+
+  /**
+   * Post-export cleanup: restore the workspace to the original lane / main so an interactive
+   * `bit ci pr` leaves you where you started. `switchToLane('main')` re-checks-out main's HEAD,
+   * which re-imports every workspace component — on a large monorepo that's minutes of work for a
+   * workspace that, in CI, is thrown away the moment the command exits. Hence `skipCleanup`.
+   * Wrapped so a restore failure only warns instead of throwing out of the caller's `finally` and
+   * masking the real error from snap/export. Returns whether the switch actually ran (callers use
+   * it to decide whether follow-up lane bookkeeping that assumes we left the lane is safe).
+   */
+  private async restoreWorkspaceAfterPr(originalLane: Lane | undefined, skipCleanup: boolean): Promise<boolean> {
+    this.logger.console('🔄 Cleanup');
+    if (skipCleanup) {
+      this.logger.console(
+        chalk.yellow('Skipping workspace restore (CI or --skip-cleanup) — leaving the workspace on the PR lane')
+      );
+      return false;
+    }
+    const targetLane = originalLane?.name ?? 'main';
+    this.logger.console(chalk.blue(`Switching back to ${targetLane}`));
+    const longProcessLogger = this.logger.createLongProcessLogger(`restoring workspace to ${targetLane}`);
+    try {
+      const currentLane = await this.lanes.getCurrentLane();
+      if (currentLane) {
+        await this.switchToLane(targetLane);
+      } else {
+        this.logger.console(chalk.yellow('Already on main, checking out to head'));
+        await this.lanes.checkout.checkout({ head: true, skipNpmInstall: true });
+      }
+      longProcessLogger.end();
+      return true;
+    } catch (cleanupErr: any) {
+      longProcessLogger.end();
+      this.logger.consoleWarning(`Cleanup after PR snap failed: ${cleanupErr.message}`);
+      return true;
+    }
   }
 
   /**
@@ -597,12 +655,14 @@ export class CiMain {
     message,
     build,
     dryRun,
+    skipCleanup,
   }: {
     laneId: LaneId;
     originalLane: Lane | undefined;
     message: string;
     build: boolean | undefined;
     dryRun?: boolean;
+    skipCleanup: boolean;
   }) {
     // Query the remote (by name, to avoid fetching all lanes) so we know whether to reuse or create
     const existingLanes = await this.lanes.getLanes({ remote: laneId.scope, name: laneId.name }).catch((e) => {
@@ -778,24 +838,7 @@ export class CiMain {
       if (foundErr) {
         this.logger.console(chalk.red(`Found error: ${foundErr.message}`));
       }
-      // Best-effort cleanup: switch back to the original lane/main. Wrap it so a cleanup
-      // failure (failed switch/checkout) only warns instead of throwing out of `finally` and
-      // masking the real error from snap/export above (also avoids no-unsafe-finally).
-      try {
-        this.logger.console('🔄 Cleanup');
-        const targetLane = originalLane?.name ?? 'main';
-        this.logger.console(chalk.blue(`Switching back to ${targetLane}`));
-
-        const currentLane = await this.lanes.getCurrentLane();
-        if (currentLane) {
-          await this.switchToLane(targetLane);
-        } else {
-          this.logger.console(chalk.yellow('Already on main, checking out to head'));
-          await this.lanes.checkout.checkout({ head: true, skipNpmInstall: true });
-        }
-      } catch (cleanupErr: any) {
-        this.logger.consoleWarning(`Cleanup after PR snap failed: ${cleanupErr.message}`);
-      }
+      await this.restoreWorkspaceAfterPr(originalLane, skipCleanup);
     }
   }
 
@@ -812,12 +855,14 @@ export class CiMain {
     message,
     build,
     dryRun,
+    skipCleanup,
   }: {
     laneId: LaneId;
     originalLane: Lane | undefined;
     message: string;
     build: boolean | undefined;
     dryRun?: boolean;
+    skipCleanup: boolean;
   }) {
     // Use unique temp lane name to avoid race conditions when multiple CI jobs run concurrently
     const tempLaneName = `${laneId.name}-${generateRandomStr(5)}`;
@@ -928,23 +973,14 @@ export class CiMain {
       if (foundErr) {
         this.logger.console(chalk.red(`Found error: ${foundErr.message}`));
       }
-      // Always switch back to the original lane
-      this.logger.console('🔄 Cleanup');
-      const targetLane = originalLane?.name ?? 'main';
-      this.logger.console(chalk.blue(`Switching back to ${targetLane}`));
-
-      const currentLane = await this.lanes.getCurrentLane();
-      if (currentLane) {
-        await this.switchToLane(targetLane);
-      } else {
-        this.logger.console(chalk.yellow('Already on main, checking out to head'));
-        await this.lanes.checkout.checkout({ head: true, skipNpmInstall: true });
-      }
+      const switchedBack = await this.restoreWorkspaceAfterPr(originalLane, skipCleanup);
 
       // Clean up orphaned temporary lane on error. Skip if the rename to the final name already
       // happened - in that case the temp name no longer exists locally, and the lane under the
       // final name may have been partially exported; leave it alone rather than wipe evidence.
-      if (foundErr && !renamedToFinalName) {
+      // Also requires having switched off the temp lane first — you can't remove the lane you're
+      // currently on, so when the restore was skipped, leave the (local, soon-discarded) temp lane.
+      if (switchedBack && foundErr && !renamedToFinalName) {
         const tempLaneFullName = `${laneId.scope}/${tempLaneName}`;
         this.logger.console(chalk.blue(`Cleaning up temporary lane ${tempLaneFullName}`));
         try {

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -558,10 +558,11 @@ export class CiMain {
     skipCleanup?: boolean;
   }) {
     // The post-export cleanup switches the workspace back to main, which re-checks-out main's HEAD
-    // and re-imports every workspace component. That restore is only useful for an interactive run;
-    // in CI the container is discarded immediately, so default to skipping it there. An explicit
-    // flag (true or, where the parser supports `--no-skip-cleanup`, false) always wins.
-    const resolvedSkipCleanup = skipCleanup ?? Boolean(process.env.CI);
+    // and re-imports every workspace component — pointless when the workspace is about to be
+    // discarded. It's opt-in via `--skip-cleanup` (the `bit_pr` CI job passes it) rather than
+    // auto-detected from `process.env.CI`: other CI contexts *reuse* the workspace after `bit ci pr`
+    // (e.g. the e2e suite, which then tags/asserts on main), and must keep restoring it.
+    const resolvedSkipCleanup = Boolean(skipCleanup);
     this.logger.console(chalk.blue(`Lane name: ${laneIdStr}`));
 
     const originalLane = await this.lanes.getCurrentLane();
@@ -619,7 +620,7 @@ export class CiMain {
     this.logger.console('🔄 Cleanup');
     if (skipCleanup) {
       this.logger.console(
-        chalk.yellow('Skipping workspace restore (CI or --skip-cleanup) — leaving the workspace on the PR lane')
+        chalk.yellow('Skipping workspace restore (--skip-cleanup) — leaving the workspace on the PR lane')
       );
       return false;
     }
@@ -629,17 +630,24 @@ export class CiMain {
     try {
       const currentLane = await this.lanes.getCurrentLane();
       if (currentLane) {
-        await this.switchToLane(targetLane);
+        // switchToLane catches its own errors and *returns* them (never throws), so a failed switch
+        // would otherwise slip through as a success. Treat a returned error as "did not switch" so
+        // callers don't run follow-up bookkeeping (e.g. temp-lane removal) while still on the lane.
+        const switchErr = await this.switchToLane(targetLane);
+        if (switchErr) {
+          this.logger.consoleWarning(`Cleanup after PR snap failed: ${switchErr.message}`);
+          return false;
+        }
       } else {
         this.logger.console(chalk.yellow('Already on main, checking out to head'));
         await this.lanes.checkout.checkout({ head: true, skipNpmInstall: true });
       }
-      longProcessLogger.end();
       return true;
     } catch (cleanupErr: any) {
-      longProcessLogger.end();
       this.logger.consoleWarning(`Cleanup after PR snap failed: ${cleanupErr.message}`);
-      return true;
+      return false;
+    } finally {
+      longProcessLogger.end();
     }
   }
 

--- a/scopes/git/ci/commands/pr.cmd.ts
+++ b/scopes/git/ci/commands/pr.cmd.ts
@@ -10,12 +10,13 @@ type Options = {
   strict?: boolean;
   dryRun?: boolean;
   keepLane?: boolean;
+  skipCleanup?: boolean;
 };
 
 export class CiPrCmd implements Command {
   name = 'pr';
   description = 'Exports a feature lane to Bit Cloud when a Pull Request is opened or updated.';
-  extendedDescription = `Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. Cleans up by switching back to main. Use in pull-request CI pipelines after tests and before deploy.`;
+  extendedDescription = `Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. By default it then restores the workspace by switching back to main; this restore is skipped automatically in CI (or with --skip-cleanup) since the container is discarded right after. Use in pull-request CI pipelines after tests and before deploy.`;
   group = 'collaborate';
 
   options: CommandOptions = [
@@ -28,6 +29,11 @@ export class CiPrCmd implements Command {
       '',
       'keep-lane',
       'Reuse the same remote lane across PR commits (preserves lane history and cloud UI edits) instead of recreating it on every run',
+    ],
+    [
+      '',
+      'skip-cleanup',
+      'Skip restoring the workspace (switching back to main) after export. On by default in CI, where the container is discarded right away',
     ],
   ];
 
@@ -74,6 +80,7 @@ export class CiPrCmd implements Command {
       strict: options.strict,
       dryRun: options.dryRun,
       keepLane: options.keepLane,
+      skipCleanup: options.skipCleanup,
     });
 
     if (results) {

--- a/scopes/git/ci/commands/pr.cmd.ts
+++ b/scopes/git/ci/commands/pr.cmd.ts
@@ -16,7 +16,7 @@ type Options = {
 export class CiPrCmd implements Command {
   name = 'pr';
   description = 'Exports a feature lane to Bit Cloud when a Pull Request is opened or updated.';
-  extendedDescription = `Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. By default it then restores the workspace by switching back to main; this restore is skipped automatically in CI (or with --skip-cleanup) since the container is discarded right after. Use in pull-request CI pipelines after tests and before deploy.`;
+  extendedDescription = `Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. By default it then restores the workspace by switching back to main; pass --skip-cleanup to skip that restore when the workspace is about to be discarded (e.g. an ephemeral CI container). Use in pull-request CI pipelines after tests and before deploy.`;
   group = 'collaborate';
 
   options: CommandOptions = [
@@ -33,7 +33,7 @@ export class CiPrCmd implements Command {
     [
       '',
       'skip-cleanup',
-      'Skip restoring the workspace (switching back to main) after export. On by default in CI, where the container is discarded right away',
+      'Skip restoring the workspace (switching back to main) after export. Use when the workspace is discarded right after, e.g. an ephemeral CI container',
     ],
   ];
 

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -4975,10 +4975,15 @@
             "",
             "keep-lane",
             "Reuse the same remote lane across PR commits (preserves lane history and cloud UI edits) instead of recreating it on every run"
+          ],
+          [
+            "",
+            "skip-cleanup",
+            "Skip restoring the workspace (switching back to main) after export. Use when the workspace is discarded right after, e.g. an ephemeral CI container"
           ]
         ],
         "description": "Exports a feature lane to Bit Cloud when a Pull Request is opened or updated.",
-        "extendedDescription": "Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. Cleans up by switching back to main. Use in pull-request CI pipelines after tests and before deploy.",
+        "extendedDescription": "Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. By default it then restores the workspace by switching back to main; pass --skip-cleanup to skip that restore when the workspace is about to be discarded (e.g. an ephemeral CI container). Use in pull-request CI pipelines after tests and before deploy.",
         "group": "collaborate",
         "private": false
       },

--- a/scopes/harmony/cli-reference/cli-reference.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.mdx
@@ -419,16 +419,17 @@ Runs lint, build, and status checks to catch dependency drift or broken builds e
 **Usage**: `ci pr`
 
 **Description**: Exports a feature lane to Bit Cloud when a Pull Request is opened or updated.  
-Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. Cleans up by switching back to main. Use in pull-request CI pipelines after tests and before deploy.
+Resolves the lane name from --lane or the current Git branch, validates it, and runs install, status, snap, and export. By default it then restores the workspace by switching back to main; pass --skip-cleanup to skip that restore when the workspace is about to be discarded (e.g. an ephemeral CI container). Use in pull-request CI pipelines after tests and before deploy.
 
-| **Option**            | **Option alias** | **Description**                                                                                                                |
-| --------------------- | :--------------: | ------------------------------------------------------------------------------------------------------------------------------ |
-| `--message <message>` |       `-m`       | If set, set it as the snap message, if not, try and grab from git-commit-message                                               |
-| `--lane <lane>`       |       `-l`       | If set, use as the lane name, if not available, grab from git-branch name                                                      |
-| `--build`             |       `-b`       | Set to true to build the app locally, false (default) will build on Ripple CI                                                  |
-| `--strict`            |       `-s`       | Set to true to fail on warnings as well as errors, false (default) only fails on errors                                        |
-| `--dry-run`           |       `-d`       | Run the full pipeline but skip exporting to remote (build runs only if --build is set)                                         |
-| `--keep-lane`         |                  | Reuse the same remote lane across PR commits (preserves lane history and cloud UI edits) instead of recreating it on every run |
+| **Option**            | **Option alias** | **Description**                                                                                                                                     |
+| --------------------- | :--------------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--message <message>` |       `-m`       | If set, set it as the snap message, if not, try and grab from git-commit-message                                                                    |
+| `--lane <lane>`       |       `-l`       | If set, use as the lane name, if not available, grab from git-branch name                                                                           |
+| `--build`             |       `-b`       | Set to true to build the app locally, false (default) will build on Ripple CI                                                                       |
+| `--strict`            |       `-s`       | Set to true to fail on warnings as well as errors, false (default) only fails on errors                                                             |
+| `--dry-run`           |       `-d`       | Run the full pipeline but skip exporting to remote (build runs only if --build is set)                                                              |
+| `--keep-lane`         |                  | Reuse the same remote lane across PR commits (preserves lane history and cloud UI edits) instead of recreating it on every run                      |
+| `--skip-cleanup`      |                  | Skip restoring the workspace (switching back to main) after export. Use when the workspace is discarded right after, e.g. an ephemeral CI container |
 
 ### ci merge
 


### PR DESCRIPTION
## What

`bit ci pr` ends with a "cleanup" step that switches the workspace back to main. On a large PR that means re-checking-out main's HEAD and **re-importing ~213 components** — minutes of work for a CI container that's thrown away the instant the command exits.

This adds a `--skip-cleanup` flag, **defaulted on when a CI environment is detected** (`process.env.CI`), to bypass that restore. Interactive/local runs keep restoring the workspace exactly as before. An explicit flag always wins.

## Why

From a real `bit ci pr` run (100-component PR, ~31.7m total), the trailing `🔄 Cleanup` → `Switching to main` → `importing 313 components / successfully imported 213 components` is pure waste in CI: the export already completed before it, and the restored workspace is never used.

## Details

- New `--skip-cleanup` option on `bit ci pr`; resolved as `skipCleanup ?? Boolean(process.env.CI)`.
- Shared `restoreWorkspaceAfterPr()` helper used by both the `--keep-lane` and temp-lane paths.
- In the temp-lane path, the orphaned-temp-lane removal now only runs when the restore actually switched off the lane (you can't remove the lane you're currently on).
- Restore is wrapped in a `longProcessLogger` so its duration shows up when it does run (the export/cleanup tail was previously untimed).

No behavior change for local users. `tsc`/oxlint clean (pre-existing unrelated tsc errors in `compositions.tsx`/`mdx.env.ts` only).