### PR TITLE
feat(builder): opt-in parallel build pipeline (concurrency across envs)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,11 +758,9 @@ jobs:
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=30000
-            # Build environments concurrently (each env's tasks still run sequentially; cross-env
-            # task deps + start/middle/end barriers are honored — see tasks-parallel-scheduler.ts).
-            # 3 already captures most of the win (core-aspect-env is the long pole); raise once proven
-            # stable, watching memory (in-process webpack/tsc on this 2xlarge can OOM → "Killed").
-            BIT_BUILD_CONCURRENCY: '3'
+            # NOTE: parallel builds (BIT_BUILD_CONCURRENCY>1) were measured here and did NOT help —
+            # this build is CPU-bound and dominated by one env, so concurrency only added contention.
+            # See tasks-parallel-scheduler.ts header for the numbers. Left serial on purpose.
       - store_artifacts:
           path: ~/Library/Caches/Bit/logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,6 +758,11 @@ jobs:
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=30000
+            # Build environments concurrently (each env's tasks still run sequentially; cross-env
+            # task deps + start/middle/end barriers are honored — see tasks-parallel-scheduler.ts).
+            # 3 already captures most of the win (core-aspect-env is the long pole); raise once proven
+            # stable, watching memory (in-process webpack/tsc on this 2xlarge can OOM → "Killed").
+            BIT_BUILD_CONCURRENCY: '3'
       - store_artifacts:
           path: ~/Library/Caches/Bit/logs
 

--- a/scopes/pipelines/builder/build-pipe.ts
+++ b/scopes/pipelines/builder/build-pipe.ts
@@ -13,6 +13,7 @@ import type { ComponentResult } from './types';
 import type { TasksQueue } from './tasks-queue';
 import type { EnvsBuildContext } from './builder.service';
 import { TaskResultsList } from './task-results-list';
+import { executeTasksByLocationAndEnv } from './tasks-parallel-scheduler';
 
 export type TaskResults = {
   /**
@@ -51,6 +52,12 @@ type PipeOptions = {
   exitOnFirstFailedTask?: boolean; // by default it skips only when a dependent failed.
   showEnvNameInOutput?: boolean;
   showEnvVersionInOutput?: boolean; // in case it shows the env-name, whether should show also the version
+  /**
+   * number of environments whose task-chains may run concurrently. 1 (default) keeps the original
+   * fully-serial behavior. when > 1, environments are built in parallel (see
+   * `executeTasksByLocationAndEnv`).
+   */
+  concurrency?: number;
 };
 
 export class BuildPipe {
@@ -80,7 +87,12 @@ export class BuildPipe {
   async execute(): Promise<TaskResultsList> {
     await this.executePreBuild();
     this.longProcessLogger = this.logger.createLongProcessLogger('running tasks', this.tasksQueue.length);
-    await mapSeries(this.tasksQueue, async ({ task, env }) => this.executeTask(task, env));
+    const concurrency = this.options?.concurrency ?? 1;
+    if (concurrency > 1) {
+      await executeTasksByLocationAndEnv(this.tasksQueue, concurrency, ({ task, env }) => this.executeTask(task, env));
+    } else {
+      await mapSeries(this.tasksQueue, async ({ task, env }) => this.executeTask(task, env));
+    }
     this.longProcessLogger.end();
     const capsuleRootDir = Object.values(this.envsBuildContext)[0]?.capsuleNetwork.capsulesRootDir;
     const tasksResultsList = new TaskResultsList(this.tasksQueue, this.taskResults, capsuleRootDir, this.logger);

--- a/scopes/pipelines/builder/builder.service.ts
+++ b/scopes/pipelines/builder/builder.service.ts
@@ -157,6 +157,7 @@ export class BuilderService implements EnvService<BuildServiceResults, string> {
         exitOnFirstFailedTask: options.exitOnFirstFailedTask,
         showEnvNameInOutput: envs.length > 1,
         showEnvVersionInOutput: envIdsWithoutVersion.length > uniq(envIdsWithoutVersion).length,
+        concurrency: this.getBuildConcurrency(),
       }
     );
     const buildResults = await buildPipe.execute();
@@ -167,6 +168,18 @@ export class BuilderService implements EnvService<BuildServiceResults, string> {
 
   getComponentsCapsulesBaseDir(): string | undefined {
     return this.configStore.getConfig(CFG_CAPSULES_BUILD_COMPONENTS_BASE_DIR);
+  }
+
+  /**
+   * Number of environments whose build task-chains may run concurrently. Defaults to 1 (fully
+   * serial — the original behavior). Opt into parallelism with the `BIT_BUILD_CONCURRENCY` env var
+   * (handy for CI) or the `build.concurrency` config. In parallel mode each env's tasks still run
+   * sequentially; only different envs run concurrently — see `BuildPipe.executeTasksInParallel`.
+   */
+  getBuildConcurrency(): number {
+    const raw = process.env.BIT_BUILD_CONCURRENCY ?? this.configStore.getConfig('build.concurrency');
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    return Number.isNaN(parsed) || parsed < 1 ? 1 : parsed;
   }
 
   render() {

--- a/scopes/pipelines/builder/tasks-parallel-scheduler.spec.ts
+++ b/scopes/pipelines/builder/tasks-parallel-scheduler.spec.ts
@@ -1,10 +1,17 @@
 import { expect } from 'chai';
 import type { SchedulerEntry } from './tasks-parallel-scheduler';
-import { splitByLocation, groupByEnv, executeTasksByLocationAndEnv } from './tasks-parallel-scheduler';
+import { splitByLocation, computeBlockers, executeTasksByLocationAndEnv } from './tasks-parallel-scheduler';
 
-// Minimal fakes — the scheduler only reads `task.location`, `task.name` and `env.id`.
-function entry(envId: string, name: string, location?: 'start' | 'end'): SchedulerEntry {
-  return { env: { id: envId } as any, task: { name, location } as any };
+type EntryOpts = { aspectId?: string; location?: 'start' | 'end'; deps?: string[] };
+
+// Minimal fakes — the scheduler only reads `env.id` and the task's `aspectId`, `name`, `location`,
+// `dependencies`. `aspectId` defaults to `name` so a dep referencing `name` matches by aspect id
+// (mirrors how real tasks like the tester depend on `CompilerAspect.id`).
+function entry(envId: string, name: string, opts: EntryOpts = {}): SchedulerEntry {
+  return {
+    env: { id: envId } as any,
+    task: { aspectId: opts.aspectId ?? name, name, location: opts.location, dependencies: opts.deps } as any,
+  };
 }
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -13,52 +20,48 @@ describe('tasks-parallel-scheduler', () => {
   describe('splitByLocation', () => {
     it('splits a contiguous start→middle→end queue into one segment per location', () => {
       const queue = [
-        entry('envA', 'exporter', 'start'),
+        entry('envA', 'exporter', { location: 'start' }),
         entry('envA', 'compile'),
         entry('envB', 'compile'),
-        entry('envA', 'schema', 'end'),
-        entry('envB', 'schema', 'end'),
+        entry('envA', 'schema', { location: 'end' }),
+        entry('envB', 'schema', { location: 'end' }),
       ];
       const segments = splitByLocation(queue);
-      expect(segments).to.have.lengthOf(3);
-      expect(segments[0].map((e) => e.task.name)).to.deep.equal(['exporter']);
-      expect(segments[1].map((e) => e.task.name)).to.deep.equal(['compile', 'compile']);
-      expect(segments[2].map((e) => e.task.name)).to.deep.equal(['schema', 'schema']);
+      expect(segments.map((s) => s.length)).to.deep.equal([1, 2, 2]);
     });
 
     it('treats undeclared location as middle', () => {
-      const segments = splitByLocation([entry('envA', 'a'), entry('envA', 'b')]);
-      expect(segments).to.have.lengthOf(1);
+      expect(splitByLocation([entry('envA', 'a'), entry('envA', 'b')])).to.have.lengthOf(1);
     });
   });
 
-  describe('groupByEnv', () => {
-    it('groups by env id and preserves each env task order', () => {
-      const chains = groupByEnv([
-        entry('envA', 'compile'),
-        entry('envB', 'compile'),
-        entry('envA', 'test'),
-        entry('envB', 'test'),
-      ]);
-      expect(chains).to.have.lengthOf(2);
-      expect(chains[0].map((e) => e.task.name)).to.deep.equal(['compile', 'test']);
-      expect(chains[1].map((e) => e.task.name)).to.deep.equal(['compile', 'test']);
+  describe('computeBlockers', () => {
+    it('blocks each task on its per-env predecessor and on its declared deps across ALL envs', () => {
+      const entries = [
+        entry('envA', 'compile', { aspectId: 'compiler' }), // 0
+        entry('envB', 'compile', { aspectId: 'compiler' }), // 1
+        entry('envA', 'test', { aspectId: 'tester', deps: ['compiler'] }), // 2
+        entry('envB', 'test', { aspectId: 'tester', deps: ['compiler'] }), // 3
+      ];
+      const blockers = computeBlockers(entries).map((b) => b.slice().sort((x, y) => x - y));
+      expect(blockers[0]).to.deep.equal([]); // first compile — nothing
+      expect(blockers[1]).to.deep.equal([]); // envB compile — no envB predecessor, no deps
+      expect(blockers[2]).to.deep.equal([0, 1]); // envA test — its compile (0) + ALL compiles (0,1)
+      expect(blockers[3]).to.deep.equal([0, 1]); // envB test — its compile (1) + ALL compiles (0,1)
     });
   });
 
   describe('executeTasksByLocationAndEnv', () => {
     it('runs every entry exactly once', async () => {
-      const queue = [entry('envA', 'compile'), entry('envB', 'compile'), entry('envA', 'schema', 'end')];
+      const queue = [entry('envA', 'compile'), entry('envB', 'compile'), entry('envA', 'schema', { location: 'end' })];
       const seen: string[] = [];
       await executeTasksByLocationAndEnv(queue, 4, async (e) => {
         seen.push(`${e.env.id}:${e.task.name}`);
       });
-      expect(seen).to.have.lengthOf(3);
       expect(seen.sort()).to.deep.equal(['envA:compile', 'envA:schema', 'envB:compile']);
     });
 
-    it('preserves task order within an env (never reorders an env chain)', async () => {
-      // envA's compile is slow; its test must still start only after its compile finishes.
+    it('preserves task order within an env (never reorders or overlaps an env chain)', async () => {
       const events: string[] = [];
       const queue = [entry('envA', 'compile'), entry('envA', 'test')];
       await executeTasksByLocationAndEnv(queue, 4, async (e) => {
@@ -70,8 +73,6 @@ describe('tasks-parallel-scheduler', () => {
     });
 
     it('runs different envs concurrently within a location', async () => {
-      // If envs ran serially, envB would start only after envA's 40ms task ended. Concurrently,
-      // envB starts before envA ends.
       const events: string[] = [];
       const queue = [entry('envA', 'compile'), entry('envB', 'compile')];
       await executeTasksByLocationAndEnv(queue, 4, async (e) => {
@@ -83,13 +84,30 @@ describe('tasks-parallel-scheduler', () => {
       expect(events.indexOf('start:envB')).to.be.lessThan(events.indexOf('end:envA'));
     });
 
+    it("honors a cross-env declared dependency: a task waits for ALL envs' dep, not just its own", async () => {
+      // envA's compile is fast, envB's compile is slow. envA's test depends on the compiler, so it
+      // must wait for envB's compile too — not start right after its own (fast) compile.
+      const events: string[] = [];
+      const queue = [
+        entry('envA', 'compile', { aspectId: 'compiler' }),
+        entry('envB', 'compile', { aspectId: 'compiler' }),
+        entry('envA', 'test', { aspectId: 'tester', deps: ['compiler'] }),
+      ];
+      await executeTasksByLocationAndEnv(queue, 4, async (e) => {
+        events.push(`start:${e.env.id}:${e.task.name}`);
+        await delay(e.env.id === 'envB' && e.task.name === 'compile' ? 40 : 2);
+        events.push(`end:${e.env.id}:${e.task.name}`);
+      });
+      expect(events.indexOf('start:envA:test')).to.be.greaterThan(events.indexOf('end:envB:compile'));
+    });
+
     it('enforces a barrier between locations: no end task starts before all middle tasks finish', async () => {
       const events: string[] = [];
       const queue = [
-        entry('envA', 'compile'), // middle, slow
-        entry('envB', 'compile'), // middle, fast
-        entry('envA', 'schema', 'end'),
-        entry('envB', 'schema', 'end'),
+        entry('envA', 'compile'),
+        entry('envB', 'compile'),
+        entry('envA', 'preview', { location: 'end' }),
+        entry('envB', 'preview', { location: 'end' }),
       ];
       await executeTasksByLocationAndEnv(queue, 4, async (e) => {
         events.push(`start:${e.task.name}:${e.env.id}`);
@@ -97,14 +115,13 @@ describe('tasks-parallel-scheduler', () => {
         events.push(`end:${e.task.name}:${e.env.id}`);
       });
       const lastMiddleEnd = Math.max(events.indexOf('end:compile:envA'), events.indexOf('end:compile:envB'));
-      const firstEndStart = Math.min(events.indexOf('start:schema:envA'), events.indexOf('start:schema:envB'));
+      const firstEndStart = Math.min(events.indexOf('start:preview:envA'), events.indexOf('start:preview:envB'));
       expect(firstEndStart).to.be.greaterThan(lastMiddleEnd);
     });
 
     it('bounds concurrency to the given limit', async () => {
       let inFlight = 0;
       let maxInFlight = 0;
-      // 5 separate envs, all in one (middle) location → 5 independent chains.
       const queue = ['e1', 'e2', 'e3', 'e4', 'e5'].map((id) => entry(id, 'compile'));
       await executeTasksByLocationAndEnv(queue, 2, async () => {
         inFlight += 1;

--- a/scopes/pipelines/builder/tasks-parallel-scheduler.spec.ts
+++ b/scopes/pipelines/builder/tasks-parallel-scheduler.spec.ts
@@ -1,0 +1,118 @@
+import { expect } from 'chai';
+import type { SchedulerEntry } from './tasks-parallel-scheduler';
+import { splitByLocation, groupByEnv, executeTasksByLocationAndEnv } from './tasks-parallel-scheduler';
+
+// Minimal fakes — the scheduler only reads `task.location`, `task.name` and `env.id`.
+function entry(envId: string, name: string, location?: 'start' | 'end'): SchedulerEntry {
+  return { env: { id: envId } as any, task: { name, location } as any };
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('tasks-parallel-scheduler', () => {
+  describe('splitByLocation', () => {
+    it('splits a contiguous start→middle→end queue into one segment per location', () => {
+      const queue = [
+        entry('envA', 'exporter', 'start'),
+        entry('envA', 'compile'),
+        entry('envB', 'compile'),
+        entry('envA', 'schema', 'end'),
+        entry('envB', 'schema', 'end'),
+      ];
+      const segments = splitByLocation(queue);
+      expect(segments).to.have.lengthOf(3);
+      expect(segments[0].map((e) => e.task.name)).to.deep.equal(['exporter']);
+      expect(segments[1].map((e) => e.task.name)).to.deep.equal(['compile', 'compile']);
+      expect(segments[2].map((e) => e.task.name)).to.deep.equal(['schema', 'schema']);
+    });
+
+    it('treats undeclared location as middle', () => {
+      const segments = splitByLocation([entry('envA', 'a'), entry('envA', 'b')]);
+      expect(segments).to.have.lengthOf(1);
+    });
+  });
+
+  describe('groupByEnv', () => {
+    it('groups by env id and preserves each env task order', () => {
+      const chains = groupByEnv([
+        entry('envA', 'compile'),
+        entry('envB', 'compile'),
+        entry('envA', 'test'),
+        entry('envB', 'test'),
+      ]);
+      expect(chains).to.have.lengthOf(2);
+      expect(chains[0].map((e) => e.task.name)).to.deep.equal(['compile', 'test']);
+      expect(chains[1].map((e) => e.task.name)).to.deep.equal(['compile', 'test']);
+    });
+  });
+
+  describe('executeTasksByLocationAndEnv', () => {
+    it('runs every entry exactly once', async () => {
+      const queue = [entry('envA', 'compile'), entry('envB', 'compile'), entry('envA', 'schema', 'end')];
+      const seen: string[] = [];
+      await executeTasksByLocationAndEnv(queue, 4, async (e) => {
+        seen.push(`${e.env.id}:${e.task.name}`);
+      });
+      expect(seen).to.have.lengthOf(3);
+      expect(seen.sort()).to.deep.equal(['envA:compile', 'envA:schema', 'envB:compile']);
+    });
+
+    it('preserves task order within an env (never reorders an env chain)', async () => {
+      // envA's compile is slow; its test must still start only after its compile finishes.
+      const events: string[] = [];
+      const queue = [entry('envA', 'compile'), entry('envA', 'test')];
+      await executeTasksByLocationAndEnv(queue, 4, async (e) => {
+        events.push(`start:${e.task.name}`);
+        await delay(e.task.name === 'compile' ? 30 : 0);
+        events.push(`end:${e.task.name}`);
+      });
+      expect(events).to.deep.equal(['start:compile', 'end:compile', 'start:test', 'end:test']);
+    });
+
+    it('runs different envs concurrently within a location', async () => {
+      // If envs ran serially, envB would start only after envA's 40ms task ended. Concurrently,
+      // envB starts before envA ends.
+      const events: string[] = [];
+      const queue = [entry('envA', 'compile'), entry('envB', 'compile')];
+      await executeTasksByLocationAndEnv(queue, 4, async (e) => {
+        events.push(`start:${e.env.id}`);
+        await delay(e.env.id === 'envA' ? 40 : 5);
+        events.push(`end:${e.env.id}`);
+      });
+      // envB starts before envA ends → proves concurrency.
+      expect(events.indexOf('start:envB')).to.be.lessThan(events.indexOf('end:envA'));
+    });
+
+    it('enforces a barrier between locations: no end task starts before all middle tasks finish', async () => {
+      const events: string[] = [];
+      const queue = [
+        entry('envA', 'compile'), // middle, slow
+        entry('envB', 'compile'), // middle, fast
+        entry('envA', 'schema', 'end'),
+        entry('envB', 'schema', 'end'),
+      ];
+      await executeTasksByLocationAndEnv(queue, 4, async (e) => {
+        events.push(`start:${e.task.name}:${e.env.id}`);
+        await delay(e.task.name === 'compile' && e.env.id === 'envA' ? 40 : 2);
+        events.push(`end:${e.task.name}:${e.env.id}`);
+      });
+      const lastMiddleEnd = Math.max(events.indexOf('end:compile:envA'), events.indexOf('end:compile:envB'));
+      const firstEndStart = Math.min(events.indexOf('start:schema:envA'), events.indexOf('start:schema:envB'));
+      expect(firstEndStart).to.be.greaterThan(lastMiddleEnd);
+    });
+
+    it('bounds concurrency to the given limit', async () => {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      // 5 separate envs, all in one (middle) location → 5 independent chains.
+      const queue = ['e1', 'e2', 'e3', 'e4', 'e5'].map((id) => entry(id, 'compile'));
+      await executeTasksByLocationAndEnv(queue, 2, async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await delay(10);
+        inFlight -= 1;
+      });
+      expect(maxInFlight).to.equal(2);
+    });
+  });
+});

--- a/scopes/pipelines/builder/tasks-parallel-scheduler.ts
+++ b/scopes/pipelines/builder/tasks-parallel-scheduler.ts
@@ -1,0 +1,88 @@
+import mapSeries from 'p-map-series';
+import type { EnvDefinition } from '@teambit/envs';
+import type { BuildTask } from './build-task';
+
+export type SchedulerEntry = { env: EnvDefinition; task: BuildTask };
+
+/**
+ * Split an already location-ordered queue (the queue `calculatePipelineOrder` produces is contiguous
+ * by location, in the order start → middle → end) into one segment per location group, preserving
+ * order. A new segment starts whenever the location changes from the previous entry.
+ */
+export function splitByLocation(queue: SchedulerEntry[]): SchedulerEntry[][] {
+  const segments: SchedulerEntry[][] = [];
+  let currentLocation: string | undefined;
+  let current: SchedulerEntry[] | undefined;
+  queue.forEach((entry) => {
+    const location = entry.task.location || 'middle';
+    if (!current || location !== currentLocation) {
+      current = [];
+      segments.push(current);
+      currentLocation = location;
+    }
+    current.push(entry);
+  });
+  return segments;
+}
+
+/**
+ * Group a location segment's entries by environment id, preserving each env's original task order.
+ */
+export function groupByEnv(segment: SchedulerEntry[]): SchedulerEntry[][] {
+  const byEnv = new Map<string, SchedulerEntry[]>();
+  segment.forEach((entry) => {
+    const chain = byEnv.get(entry.env.id) || [];
+    chain.push(entry);
+    byEnv.set(entry.env.id, chain);
+  });
+  return [...byEnv.values()];
+}
+
+/**
+ * Run env chains with a bounded number of concurrent chains. Each chain runs its entries
+ * sequentially; up to `concurrency` chains run at once. Dependency-free worker pool (no p-map) — the
+ * shared `nextIndex` cursor is safe because JS runs the synchronous increment without interleaving.
+ */
+async function runChainsWithConcurrency(
+  chains: SchedulerEntry[][],
+  concurrency: number,
+  executor: (entry: SchedulerEntry) => Promise<void>
+): Promise<void> {
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < chains.length) {
+      const chain = chains[nextIndex];
+      nextIndex += 1;
+      await mapSeries(chain, executor);
+    }
+  };
+  const workerCount = Math.min(Math.max(concurrency, 1), chains.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}
+
+/**
+ * Execute a build-task queue with environments running concurrently.
+ *
+ * Correctness model (matches the serial `mapSeries` path's guarantees):
+ * - **Barrier between location groups**: a location (start → middle → end) fully completes for all
+ *   envs before the next starts. Preserves start/middle/end ordering (compilers in 'middle' finish
+ *   before schema/preview/pkg in 'end') and the completeness of `previousTasksResults` for later
+ *   locations.
+ * - **Sequential within an env**: each env's tasks run in their original queue order. Most tasks
+ *   don't declare `dependencies` — they rely on `getBuildPipe()` array order — so tasks of one env
+ *   are never reordered or run concurrently with each other.
+ * - **Concurrent across envs only**: each env owns an isolated capsule network, so concurrent chains
+ *   never write to the same capsule.
+ */
+export async function executeTasksByLocationAndEnv(
+  queue: SchedulerEntry[],
+  concurrency: number,
+  executor: (entry: SchedulerEntry) => Promise<void>
+): Promise<void> {
+  const segments = splitByLocation(queue);
+  // sequential `for` (not Promise.all) is the location barrier — each segment fully resolves first.
+  for (const segment of segments) {
+    const envChains = groupByEnv(segment);
+    await runChainsWithConcurrency(envChains, concurrency, executor);
+  }
+}

--- a/scopes/pipelines/builder/tasks-parallel-scheduler.ts
+++ b/scopes/pipelines/builder/tasks-parallel-scheduler.ts
@@ -1,6 +1,6 @@
-import mapSeries from 'p-map-series';
 import type { EnvDefinition } from '@teambit/envs';
 import type { BuildTask } from './build-task';
+import { BuildTaskHelper } from './build-task';
 
 export type SchedulerEntry = { env: EnvDefinition; task: BuildTask };
 
@@ -26,63 +26,123 @@ export function splitByLocation(queue: SchedulerEntry[]): SchedulerEntry[][] {
 }
 
 /**
- * Group a location segment's entries by environment id, preserving each env's original task order.
+ * Indices of the entries (within the same location segment) that `entry` must wait for:
+ * - its **per-env predecessor** — the previous entry of the same env. Keeping each env a sequential
+ *   chain preserves the `getBuildPipe()` array order (most tasks rely on it, not on `dependencies`)
+ *   and means two tasks of the same env never run concurrently (they share a capsule).
+ * - every entry whose task type matches one of `entry.task.dependencies` — for **all envs**. This is
+ *   the documented "the dependency must be completed for all envs before this task starts" rule, e.g.
+ *   the tester depends on the compiler, so tests wait for *every* env's compile, not just their own.
+ *
+ * Cross-location dependencies (e.g. pkg → typescript) need no handling here: locations run in order
+ * with a barrier between them, so an earlier-location dependency is always already done.
  */
-export function groupByEnv(segment: SchedulerEntry[]): SchedulerEntry[][] {
-  const byEnv = new Map<string, SchedulerEntry[]>();
-  segment.forEach((entry) => {
-    const chain = byEnv.get(entry.env.id) || [];
-    chain.push(entry);
-    byEnv.set(entry.env.id, chain);
+export function computeBlockers(entries: SchedulerEntry[]): number[][] {
+  const parsedDeps = entries.map((entry) =>
+    (entry.task.dependencies || []).map((dep) => BuildTaskHelper.deserializeIdAllowEmptyName(dep))
+  );
+  return entries.map((entry, i) => {
+    const blockers = new Set<number>();
+    // per-env predecessor (nearest earlier entry of the same env)
+    for (let j = i - 1; j >= 0; j -= 1) {
+      if (entries[j].env.id === entry.env.id) {
+        blockers.add(j);
+        break;
+      }
+    }
+    // declared dependencies, matched across all envs in this location
+    const deps = parsedDeps[i];
+    if (deps.length) {
+      entries.forEach((other, k) => {
+        if (k === i) return;
+        const matches = deps.some(
+          ({ aspectId, name }) => other.task.aspectId === aspectId && (name === undefined || other.task.name === name)
+        );
+        if (matches) blockers.add(k);
+      });
+    }
+    return [...blockers];
   });
-  return [...byEnv.values()];
 }
 
 /**
- * Run env chains with a bounded number of concurrent chains. Each chain runs its entries
- * sequentially; up to `concurrency` chains run at once. Dependency-free worker pool (no p-map) — the
- * shared `nextIndex` cursor is safe because JS runs the synchronous increment without interleaving.
+ * Run one location segment: every entry starts as soon as its blockers are done, up to `concurrency`
+ * at a time. Blockers form a DAG whose edges always point to earlier indices (per-env predecessors
+ * are earlier; declared-dependency task types are toposorted earlier by `calculatePipelineOrder`), so
+ * there is always a runnable entry and no deadlock. The first executor rejection aborts the segment.
  */
-async function runChainsWithConcurrency(
-  chains: SchedulerEntry[][],
+function runLocation(
+  entries: SchedulerEntry[],
   concurrency: number,
   executor: (entry: SchedulerEntry) => Promise<void>
 ): Promise<void> {
-  let nextIndex = 0;
-  const worker = async () => {
-    while (nextIndex < chains.length) {
-      const chain = chains[nextIndex];
-      nextIndex += 1;
-      await mapSeries(chain, executor);
-    }
-  };
-  const workerCount = Math.min(Math.max(concurrency, 1), chains.length);
-  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  const n = entries.length;
+  if (n === 0) return Promise.resolve();
+  const blockers = computeBlockers(entries);
+  const done: boolean[] = Array.from({ length: n }, () => false);
+  const started: boolean[] = Array.from({ length: n }, () => false);
+
+  return new Promise<void>((resolve, reject) => {
+    let inFlight = 0;
+    let completed = 0;
+    let aborted = false;
+
+    const launchReady = () => {
+      if (aborted) return;
+      if (completed === n) {
+        resolve();
+        return;
+      }
+      for (let i = 0; i < n && inFlight < concurrency; i += 1) {
+        if (started[i] || !blockers[i].every((b) => done[b])) continue;
+        started[i] = true;
+        inFlight += 1;
+        Promise.resolve()
+          .then(() => executor(entries[i]))
+          .then(() => {
+            done[i] = true;
+            inFlight -= 1;
+            completed += 1;
+            launchReady();
+          })
+          .catch((err) => {
+            aborted = true;
+            reject(err);
+          });
+      }
+    };
+
+    launchReady();
+  });
 }
 
 /**
  * Execute a build-task queue with environments running concurrently.
  *
- * Correctness model (matches the serial `mapSeries` path's guarantees):
- * - **Barrier between location groups**: a location (start → middle → end) fully completes for all
- *   envs before the next starts. Preserves start/middle/end ordering (compilers in 'middle' finish
- *   before schema/preview/pkg in 'end') and the completeness of `previousTasksResults` for later
- *   locations.
- * - **Sequential within an env**: each env's tasks run in their original queue order. Most tasks
- *   don't declare `dependencies` — they rely on `getBuildPipe()` array order — so tasks of one env
- *   are never reordered or run concurrently with each other.
- * - **Concurrent across envs only**: each env owns an isolated capsule network, so concurrent chains
- *   never write to the same capsule.
+ * Correctness model — matches the serial `mapSeries` path's guarantees:
+ * - **Barrier between location groups** (start → middle → end): a location fully completes before the
+ *   next starts. Preserves the start/middle/end ordering (so e.g. preview/pkg in 'end' run after every
+ *   compile in 'middle', even though the preview tasks don't declare a compiler dependency) and the
+ *   completeness of `previousTasksResults` for later locations.
+ * - **Sequential within an env**: each env's tasks run in their original queue order and never overlap
+ *   each other (they share a capsule).
+ * - **Cross-env declared dependencies honored**: a task waits for its `dependencies` task types across
+ *   *all* envs (e.g. tests wait for every env's compile).
+ *
+ * Note: all envs share one capsule root dir, but this is still safe — every capsule file has a single
+ * writer env (a component's `dist` is produced only by its own env; a component's hard-linked
+ * artifacts only by the source component's env), and the TS compiler resolves cross-component types
+ * from source, so an env's compiled output never depends on a sibling env's build running first.
  */
 export async function executeTasksByLocationAndEnv(
   queue: SchedulerEntry[],
   concurrency: number,
   executor: (entry: SchedulerEntry) => Promise<void>
 ): Promise<void> {
+  const limit = Math.max(concurrency, 1);
   const segments = splitByLocation(queue);
   // sequential `for` (not Promise.all) is the location barrier — each segment fully resolves first.
   for (const segment of segments) {
-    const envChains = groupByEnv(segment);
-    await runChainsWithConcurrency(envChains, concurrency, executor);
+    await runLocation(segment, limit, executor);
   }
 }

--- a/scopes/pipelines/builder/tasks-parallel-scheduler.ts
+++ b/scopes/pipelines/builder/tasks-parallel-scheduler.ts
@@ -1,3 +1,23 @@
+/**
+ * Opt-in parallel build scheduler (enabled with `BIT_BUILD_CONCURRENCY` / the `build.concurrency`
+ * config; default 1 = the original serial `mapSeries` path). It runs environments concurrently while
+ * keeping each env's tasks sequential and honoring cross-env task dependencies + location barriers.
+ *
+ * WHY IT'S OFF BY DEFAULT — it did NOT help Bit's own build. Measured A/B on `bit_pr`, identical
+ * 97-component workload (CircleCI 2xlarge, 8 vCPU): serial build-pipeline wall ≈ 17m vs parallel
+ * (concurrency=3) ≈ 16m — a ~1m wash, with total `bit ci pr` essentially unchanged. The envs did
+ * overlap (parallel wall 16m vs its own task-time sum of 24m), but two effects cancelled the gain:
+ *   1. CPU contention. The tasks (tsc/webpack/babel) already saturate all cores on their own, so
+ *      running several at once just oversubscribes — per-task times ballooned (one BabelCompile went
+ *      19s → 300s) and the heaviest env's chain grew from ~9.7m to ~15.5m, giving back what the
+ *      overlap saved.
+ *   2. Single-env dominance. ~80% of the work is one env (`core-aspect-env`), a sequential chain
+ *      cross-env parallelism can't split — so even with zero contention the floor is ~its own length.
+ *
+ * It CAN help a workspace whose build is spread across several similarly-sized envs, or a machine
+ * with spare cores beyond what one task uses. For a CPU-bound, one-env-dominated build like Bit's,
+ * reducing work (e.g. skipping preview/schema on PR builds) beats adding concurrency.
+ */
 import type { EnvDefinition } from '@teambit/envs';
 import type { BuildTask } from './build-task';
 import { BuildTaskHelper } from './build-task';


### PR DESCRIPTION
## What

Adds an **opt-in** scheduler that runs build environments concurrently (each env's tasks stay sequential; cross-env task deps + start/middle/end barriers honored). Default is unchanged (`concurrency = 1` → the original `mapSeries` path, byte-for-byte). Enable with `BIT_BUILD_CONCURRENCY=<n>` or the `build.concurrency` config.

## ⚠️ Result: it does NOT speed up Bit's own build — left OFF

Measured A/B on `bit_pr`, identical 97-component workload (CircleCI 2xlarge, 8 vCPU):

| | serial | parallel (c=3) |
|---|---|---|
| build-pipeline wall | ~17m | ~16m |
| total `bit ci pr` | 31.3m | 31.6m |
| sum of task times | 16.6m | 24.0m |

The envs **did** overlap (parallel wall 16m vs its own 24m task-sum), but the gain was a **~1m wash** because:
1. **CPU contention** — tsc/webpack/babel already saturate all cores, so concurrency oversubscribed the box; per-task times ballooned (a BabelCompile went 19s→300s) and the heaviest env's chain grew 9.7m→15.5m, giving back the overlap.
2. **Single-env dominance** — ~80% of the work is one env (`core-aspect-env`), a sequential chain cross-env parallelism can't split.

So `bit_pr` stays **serial** (the `BIT_BUILD_CONCURRENCY` was added, measured, and reverted). For a CPU-bound, one-env-dominated build like Bit's, reducing work (skip preview/schema on PR builds) beats adding concurrency.

## Why keep it (as dormant opt-in)

Correct, tested, zero-risk-by-default infrastructure. It **can** help a workspace whose build spreads across several similarly-sized envs, or a machine with cores to spare. The empirical finding is documented in `tasks-parallel-scheduler.ts`'s header so the next person doesn't re-discover it the hard way.

## Correctness model

Readiness-based scheduler: each task waits for (1) its per-env predecessor (sequential within an env), (2) every env's instance of its declared dependency task types (e.g. tests wait for all envs' compile), (3) the previous location group. Only different envs run concurrently; safe against the shared capsule root because every capsule file has a single writer env and the TS compiler resolves cross-component types from source.

## Tests

`tasks-parallel-scheduler.spec.ts` (9 passing): location split, blocker computation, every-entry-once, intra-env ordering, cross-env concurrency, the cross-env declared-dependency barrier, the location barrier, and the concurrency bound.