### PR TITLE
ci: stop committing versions to master on merge (--no-bitmap-commit + bitmapAutoSync)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,16 +794,15 @@ jobs:
                 circleci-agent step halt
               fi
             fi
-      - run: cd bit && npm run generate-cli-reference
-      - run: cd bit && npm run generate-cli-reference-json
-      - run: cd bit && npm run generate-cli-reference-docs
-      - run: cd bit && npm run generate-cli-skill
-      - run: cd bit && bit status # just to make sure that the new cli-reference.mdx file is valid
-      - run: cd bit && npm run generate-core-aspects-ids
+      # CLI-reference / core-aspects-ids files are verified and committed in the PR by the
+      # check_generated_reference job, so they are no longer regenerated here. Combined with
+      # --no-bitmap-commit below, bit ci merge no longer pushes any commit to the default
+      # branch: new versions live in the scope and are reconciled into each workspace's
+      # .bitmap via `bitmapAutoSync: true` (workspace.jsonc).
       - run:
           name: 'bit ci merge'
-          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual ${BIT_CI_MERGE_EXTRA_FLAGS}'
-          # command: 'cd bit && bit ci merge --build --auto-merge-resolve manual --increment-by 2 ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual --no-bitmap-commit ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          # command: 'cd bit && bit ci merge --build --auto-merge-resolve manual --no-bitmap-commit --increment-by 2 ${BIT_CI_MERGE_EXTRA_FLAGS}'
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=30000

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -7,7 +7,12 @@
     "defaultDirectory": "components",
     // Setting this to false since the external core aspect env uses the core aspects
     // so we need it to be installed in a capsule
-    "resolveEnvsFromRoots": false
+    "resolveEnvsFromRoots": false,
+    // CI merges with `bit ci merge --no-bitmap-commit`, so .bitmap version pointers are
+    // never committed to the default branch. Every command on the main lane reconciles
+    // .bitmap against the latest exported scope HEAD instead (the scope is the source of
+    // truth for versions); see reconcileBitmapWithScopeIfNeeded in workspace.ts.
+    "bitmapAutoSync": true
   },
   "teambit.dependencies/dependency-resolver": {
     "allowScripts": {


### PR DESCRIPTION
**Draft** — the core change that lets `bit_merge` stop pushing commits to `master`, which is the prerequisite for enabling the GitHub merge queue. Do not merge until the two prerequisites below are met.

### What it does
- `bit ci merge --no-bitmap-commit` — after tag/export, no `git add/commit/push` to the default branch. New component versions live only in the scope.
- `bitmapAutoSync: true` (workspace.jsonc) — every command on the main lane reconciles the local `.bitmap` from the latest exported scope HEAD, so a "stale" committed `.bitmap` self-corrects at runtime. The scope becomes the single source of truth for versions, replacing the old post-merge bump commit.
- Removes `bit_merge`'s `generate-cli-reference*` / `generate-core-aspects-ids` steps — they're now verified and committed in PRs by `check_generated_reference` (#10428), and `--no-bitmap-commit` would discard their output anyway.

### Why
Today every merge pushes a `.bitmap` version-bump commit to `master`. That commit is the thing the next PR must consume (or collide on), and it's a post-merge mutation the merge queue can't coordinate with. Removing it dissolves both the existing inter-PR version race and the merge-queue blocker. The existing `serial-group: bit-merge-operations` remains the interlock that prevents two concurrent exports minting the same version.

### Prerequisites before this can merge
1. **Bake `check_generated_reference`** (currently advisory) on real PR traffic — confirm it doesn't go red on PRs that *don't* touch the CLI (that would signal nightly bit-version drift; we'd pin the generation version before requiring it).
2. **Promote `check_generated_reference` to a required check** at merge time. This PR removes the post-merge generation safety net, so the PR check becomes the *sole* guarantee the reference stays current — it must block.

### Known consequences (by design)
- `.bitmap` and `pnpm-lock.yaml` are no longer auto-committed to `master` post-merge; PRs carry their own changes and `bitmapAutoSync` reconciles versions. `mergePr` already checks out with `skipNpmInstall`, so it wasn't meaningfully updating the lockfile anyway.
- The committed `.bitmap` on `master` will intentionally lag the scope; this is reconciled per-workspace at runtime.

### Rollout note
Recommend merging this and letting `master` merges run on it for a while (verify exports still land and `bitmapAutoSync` logs `synced N component(s)`) **before** the CircleCI `gh-readonly-queue.*` allowlist + enabling the queue, so the version-decoupling is validated independently of the queue switch.