### PR TITLE
test(e2e): scope verdaccio registry to workspace config

### DIFF
--- a/components/legacy/e2e-helper/npm-ci-registry.ts
+++ b/components/legacy/e2e-helper/npm-ci-registry.ts
@@ -50,6 +50,16 @@ export class NpmCiRegistry {
   }
 
   /**
+   * set the default registry in the workspace config (workspace.jsonc) rather than the global bit
+   * config, so running the tests locally doesn't leak the local Verdaccio registry into other
+   * workspaces.
+   * note: must be re-applied after `reInitWorkspace()`, which wipes the workspace dir (workspace.jsonc).
+   */
+  setRegistry() {
+    this.helper.command.setConfig('registry', this.getRegistryUrl(), '--local-track');
+  }
+
+  /**
    * makes sure to kill the server process, otherwise, the tests will continue forever and never exit
    */
   destroy() {

--- a/e2e/harmony/dependencies/allow-scripts.e2e.ts
+++ b/e2e/harmony/dependencies/allow-scripts.e2e.ts
@@ -16,11 +16,10 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.command.install('@pnpm.e2e/pre-and-postinstall-scripts-example');
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
@@ -48,7 +47,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('allowScripts', {
         '@pnpm.e2e/failing-postinstall': false,
         '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
@@ -58,7 +57,6 @@ chai.use(chaiFs);
       helper.command.install('@pnpm.e2e/failing-postinstall @pnpm.e2e/pre-and-postinstall-scripts-example');
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
@@ -87,14 +85,15 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       // The installation below would fail if we didn't explicitly disallow
       // @pnpm.e2e/failing-postinstall in allowScripts.
-      helper.command.install('@pnpm.e2e/failing-postinstall @pnpm.e2e/pre-and-postinstall-scripts-example --disallow-scripts=@pnpm.e2e/failing-postinstall --allow-scripts=@pnpm.e2e/pre-and-postinstall-scripts-example');
+      helper.command.install(
+        '@pnpm.e2e/failing-postinstall @pnpm.e2e/pre-and-postinstall-scripts-example --disallow-scripts=@pnpm.e2e/failing-postinstall --allow-scripts=@pnpm.e2e/pre-and-postinstall-scripts-example'
+      );
       workspaceJsonc = helper.workspaceJsonc.read();
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
@@ -129,25 +128,29 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('allowScripts', {
         '@pnpm.e2e/failing-postinstall': true,
         '@pnpm.e2e/pre-and-postinstall-scripts-example': false,
       });
       // The installation below would fail if we didn't explicitly disallow
       // @pnpm.e2e/failing-postinstall in allowScripts.
-      helper.command.install('@pnpm.e2e/failing-postinstall @pnpm.e2e/pre-and-postinstall-scripts-example', undefined, undefined, {
-        envVariables: {
-          BIT_ALLOW_SCRIPTS: JSON.stringify({
-            '@pnpm.e2e/failing-postinstall': false,
-            '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
-          }),
-        },
-      });
+      helper.command.install(
+        '@pnpm.e2e/failing-postinstall @pnpm.e2e/pre-and-postinstall-scripts-example',
+        undefined,
+        undefined,
+        {
+          envVariables: {
+            BIT_ALLOW_SCRIPTS: JSON.stringify({
+              '@pnpm.e2e/failing-postinstall': false,
+              '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
+            }),
+          },
+        }
+      );
       workspaceJsonc = helper.workspaceJsonc.read();
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });

--- a/e2e/harmony/dependencies/allow-scripts.e2e.ts
+++ b/e2e/harmony/dependencies/allow-scripts.e2e.ts
@@ -16,7 +16,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.command.install('@pnpm.e2e/pre-and-postinstall-scripts-example');
     });
     after(() => {
@@ -47,7 +47,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('allowScripts', {
         '@pnpm.e2e/failing-postinstall': false,
         '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
@@ -85,7 +85,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       // The installation below would fail if we didn't explicitly disallow
       // @pnpm.e2e/failing-postinstall in allowScripts.
       helper.command.install(
@@ -128,7 +128,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('allowScripts', {
         '@pnpm.e2e/failing-postinstall': true,
         '@pnpm.e2e/pre-and-postinstall-scripts-example': false,

--- a/e2e/harmony/dependencies/never-built-dependencies.e2e.ts
+++ b/e2e/harmony/dependencies/never-built-dependencies.e2e.ts
@@ -16,7 +16,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('dangerouslyAllowAllScripts', true);
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('neverBuiltDependencies', [
         '@pnpm.e2e/pre-and-postinstall-scripts-example',
@@ -24,7 +24,6 @@ chai.use(chaiFs);
       helper.command.install('@pnpm.e2e/pre-and-postinstall-scripts-example');
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
@@ -56,14 +55,13 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('neverBuiltDependencies', [
         '@pnpm.e2e/pre-and-postinstall-scripts-example',
       ]);
       helper.command.install('@pnpm.e2e/pre-and-postinstall-scripts-example');
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });

--- a/e2e/harmony/dependencies/never-built-dependencies.e2e.ts
+++ b/e2e/harmony/dependencies/never-built-dependencies.e2e.ts
@@ -16,7 +16,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('dangerouslyAllowAllScripts', true);
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('neverBuiltDependencies', [
         '@pnpm.e2e/pre-and-postinstall-scripts-example',
@@ -55,7 +55,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('neverBuiltDependencies', [
         '@pnpm.e2e/pre-and-postinstall-scripts-example',
       ]);

--- a/e2e/harmony/deps-graph-isolation.e2e.ts
+++ b/e2e/harmony/deps-graph-isolation.e2e.ts
@@ -45,7 +45,7 @@ chai.use(chaiFs);
         npmCiRegistry = new NpmCiRegistry(helper);
         npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
         await npmCiRegistry.init();
-        helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+        npmCiRegistry.setRegistry();
         helper.env.setCustomNewEnv(
           undefined,
           undefined,
@@ -80,6 +80,7 @@ chai.use(chaiFs);
 
         helper.scopeHelper.reInitWorkspace();
         helper.scopeHelper.addRemoteScope();
+        npmCiRegistry.setRegistry();
         helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
         helper.command.import(`${helper.scopes.remote}/comp1@latest`);
         lockfile = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));
@@ -206,7 +207,7 @@ chai.use(chaiFs);
         npmCiRegistry = new NpmCiRegistry(helper);
         npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
         await npmCiRegistry.init();
-        helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+        npmCiRegistry.setRegistry();
         helper.fixtures.populateComponents(1);
         helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
         helper.command.install();

--- a/e2e/harmony/deps-graph-isolation.e2e.ts
+++ b/e2e/harmony/deps-graph-isolation.e2e.ts
@@ -45,7 +45,7 @@ chai.use(chaiFs);
         npmCiRegistry = new NpmCiRegistry(helper);
         npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
         await npmCiRegistry.init();
-        helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+        helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
         helper.env.setCustomNewEnv(
           undefined,
           undefined,
@@ -86,7 +86,6 @@ chai.use(chaiFs);
       });
       after(() => {
         npmCiRegistry.destroy();
-        helper.command.delConfig('registry');
         helper.scopeHelper.destroy();
       });
       it('should record the dev-only dependency in the graph with lifecycle=dev', () => {
@@ -207,7 +206,7 @@ chai.use(chaiFs);
         npmCiRegistry = new NpmCiRegistry(helper);
         npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
         await npmCiRegistry.init();
-        helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+        helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
         helper.fixtures.populateComponents(1);
         helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
         helper.command.install();
@@ -222,7 +221,6 @@ chai.use(chaiFs);
       });
       after(() => {
         npmCiRegistry.destroy();
-        helper.command.delConfig('registry');
         helper.scopeHelper.destroy();
       });
       it('should attach the dependencies graph to the snap by default', () => {

--- a/e2e/harmony/deps-graph-reimport.e2e.ts
+++ b/e2e/harmony/deps-graph-reimport.e2e.ts
@@ -36,7 +36,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -74,7 +74,6 @@ chai.use(chaiFs);
     });
     after(() => {
       npmCiRegistry.destroy();
-      helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
     // Regression coverage: re-importing comp1 must not regenerate the lockfile from
@@ -95,7 +94,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -157,7 +156,6 @@ chai.use(chaiFs);
     });
     after(() => {
       npmCiRegistry.destroy();
-      helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
     it('should restore the lockfile from the merged graphs', () => {

--- a/e2e/harmony/deps-graph-reimport.e2e.ts
+++ b/e2e/harmony/deps-graph-reimport.e2e.ts
@@ -36,7 +36,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -64,6 +64,7 @@ chai.use(chaiFs);
 
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
       helper.command.import(`${helper.scopes.remote}/comp1@0.0.1 ${helper.scopes.remote}/comp2@latest`);
 
@@ -94,7 +95,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -126,6 +127,7 @@ chai.use(chaiFs);
       await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' });
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.fs.createFile('foo', 'foo.js', `require("@pnpm.e2e/abc"); require("@ci/${randomStr}.bar");`);
       helper.command.addComponent('foo');
       helper.extensions.addExtensionToVariant('foo', `${helper.scopes.remote}/custom-env/env@0.0.1`, {});
@@ -140,6 +142,7 @@ chai.use(chaiFs);
       await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' });
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.fs.createFile('baz', 'baz.js', `require("@pnpm.e2e/abc"); require("@ci/${randomStr}.bar");`);
       helper.command.addComponent('baz');
       helper.extensions.addExtensionToVariant('baz', `${helper.scopes.remote}/custom-env/env@0.0.1`, {});
@@ -149,6 +152,7 @@ chai.use(chaiFs);
 
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.command.import(
         `${helper.scopes.remote}/foo@latest ${helper.scopes.remote}/bar@latest ${helper.scopes.remote}/baz@latest`
       );

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -33,7 +33,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
 
       helper.env.setCustomNewEnv(
         undefined,
@@ -99,7 +99,6 @@ chai.use(chaiFs);
     });
     after(() => {
       npmCiRegistry.destroy();
-      helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
     it('should save dependencies graph to the model of comp1', () => {
@@ -175,7 +174,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -234,7 +233,6 @@ chai.use(chaiFs);
     });
     after(() => {
       npmCiRegistry.destroy();
-      helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
   });
@@ -254,7 +252,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -291,7 +289,6 @@ chai.use(chaiFs);
     });
     after(() => {
       npmCiRegistry.destroy();
-      helper.command.delConfig('registry');
       helper.scopeHelper.destroy();
     });
     it('first import should restore the lockfile from comp1 graph', () => {

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -33,7 +33,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
 
       helper.env.setCustomNewEnv(
         undefined,
@@ -148,6 +148,7 @@ chai.use(chaiFs);
       before(async () => {
         helper.scopeHelper.reInitWorkspace();
         helper.scopeHelper.addRemoteScope();
+        npmCiRegistry.setRegistry();
         await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' });
         await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' });
         helper.command.import(`${helper.scopes.remote}/comp2@latest`);
@@ -174,7 +175,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -206,6 +207,7 @@ chai.use(chaiFs);
       await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' });
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.fs.createFile('foo', 'foo.js', `require("@pnpm.e2e/abc"); require("@ci/${randomStr}.bar");`);
       helper.command.addComponent('foo');
       helper.extensions.addExtensionToVariant('foo', `${helper.scopes.remote}/custom-env/env@0.0.1`, {});
@@ -215,6 +217,7 @@ chai.use(chaiFs);
 
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.command.import(`${helper.scopes.remote}/foo@latest ${helper.scopes.remote}/bar@latest`);
     });
     let lockfile: any;
@@ -252,7 +255,7 @@ chai.use(chaiFs);
       npmCiRegistry = new NpmCiRegistry(helper);
       npmCiRegistry.configureCustomNameInPackageJsonHarmony(name);
       await npmCiRegistry.init();
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.env.setCustomNewEnv(
         undefined,
         undefined,
@@ -276,6 +279,7 @@ chai.use(chaiFs);
 
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
+      npmCiRegistry.setRegistry();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
       helper.command.import(`${helper.scopes.remote}/comp1@latest`);
       initialLockfile = yaml.load(fs.readFileSync(path.join(helper.scopes.localPath, 'pnpm-lock.yaml'), 'utf8'));

--- a/e2e/harmony/install.e2e.ts
+++ b/e2e/harmony/install.e2e.ts
@@ -132,11 +132,10 @@ describe('install generator configured envs', function () {
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       helper.command.install('@pnpm.e2e/pkg-with-good-optional --no-optional');
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
@@ -160,7 +159,7 @@ describe('install generator configured envs', function () {
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl());
+      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
       await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.0.0', distTag: 'latest' });
       await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' });
       helper.command.install('@pnpm.e2e/dep-of-pkg-with-1-dep @pnpm.e2e/parent-of-pkg-with-1-dep');
@@ -169,7 +168,6 @@ describe('install generator configured envs', function () {
       helper.command.install('--update');
     });
     after(() => {
-      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });

--- a/e2e/harmony/install.e2e.ts
+++ b/e2e/harmony/install.e2e.ts
@@ -132,7 +132,7 @@ describe('install generator configured envs', function () {
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       helper.command.install('@pnpm.e2e/pkg-with-good-optional --no-optional');
     });
     after(() => {
@@ -159,7 +159,7 @@ describe('install generator configured envs', function () {
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
 
-      helper.command.setConfig('registry', npmCiRegistry.getRegistryUrl(), '--local-track');
+      npmCiRegistry.setRegistry();
       await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.0.0', distTag: 'latest' });
       await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' });
       helper.command.install('@pnpm.e2e/dep-of-pkg-with-1-dep @pnpm.e2e/parent-of-pkg-with-1-dep');


### PR DESCRIPTION
E2E tests set the npm registry with `bit config set registry <verdaccio-url>`, which defaults to Bit's **global** config store. When the suite runs locally, the local verdaccio URL leaks into every other Bit workspace, so unrelated installs try to reach the (now-dead) local registry.

Pass `--local-track` so the registry is written to the test workspace's `workspace.jsonc` (origin `workspace`) instead of the global config. `getConfig` still reads it during install, but it's confined to the throwaway test workspace. Also removed the now-redundant `delConfig('registry')` cleanup calls.