### PR TITLE
fix(diff): avoid phantom peer-dependency change for component-level peers

### DIFF
--- a/components/legacy/component-diff/components-object-diff.ts
+++ b/components/legacy/component-diff/components-object-diff.ts
@@ -1,7 +1,7 @@
 import arrayDifference from 'array-difference';
 import tempy from 'tempy';
 import chalk from 'chalk';
-import type { ComponentIdList } from '@teambit/component-id';
+import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import Table from 'cli-table';
 import normalize from 'normalize-path';
 import diff from 'object-diff';
@@ -143,6 +143,31 @@ function componentToPrintableForDiffCommand(component: Component, verbose = fals
   return comp;
 }
 
+const DEPENDENCY_RESOLVER_ASPECT_ID = 'teambit.dependencies/dependency-resolver';
+
+/**
+ * Component-level peer dependencies are not persisted in the legacy `peerDependencies` array of the
+ * Version model (`Version.fromComponent` doesn't serialize them) - they live only in the
+ * dependency-resolver aspect data. As a result, a component reconstructed from the model has an
+ * empty legacy peer array, while the same component loaded from the workspace has it populated by
+ * the dependencies-loader. Comparing the legacy arrays directly therefore produces a phantom
+ * "peer added" diff even when nothing actually changed (and `bit status` correctly shows no diff).
+ *
+ * To avoid that, derive the component peers from the authoritative dependency-resolver aspect data
+ * (present on both the model and the workspace component) and union it with the legacy array (still
+ * relevant for old components tagged before peers were moved to the aspect data).
+ */
+function getComponentPeerDepsIds(component: Component): ComponentIdList {
+  const legacyPeerIds = component.depsIdsGroupedByType.peerDependencies;
+  const depResolverData = component.extensions?.findCoreExtension(DEPENDENCY_RESOLVER_ASPECT_ID)?.data;
+  const serializedDeps: Array<{ id: string; __type?: string; lifecycle?: string }> =
+    depResolverData?.dependencies || [];
+  const peerComponentIds = serializedDeps
+    .filter((dep) => dep.__type === 'component' && dep.lifecycle === 'peer')
+    .map((dep) => ComponentID.fromString(dep.id));
+  return ComponentIdList.uniqFromArray([...legacyPeerIds, ...peerComponentIds]);
+}
+
 export async function diffBetweenComponentsObjects(
   componentLeft: Component,
   componentRight: Component,
@@ -260,8 +285,14 @@ export async function diffBetweenComponentsObjects(
   };
 
   const componentDependenciesOutput = (fieldName: string): string | null => {
-    const dependenciesLeft: ComponentIdList = componentLeft.depsIdsGroupedByType[fieldName];
-    const dependenciesRight: ComponentIdList = componentRight.depsIdsGroupedByType[fieldName];
+    const dependenciesLeft: ComponentIdList =
+      fieldName === 'peerDependencies'
+        ? getComponentPeerDepsIds(componentLeft)
+        : componentLeft.depsIdsGroupedByType[fieldName];
+    const dependenciesRight: ComponentIdList =
+      fieldName === 'peerDependencies'
+        ? getComponentPeerDepsIds(componentRight)
+        : componentRight.depsIdsGroupedByType[fieldName];
     if (isEmpty(dependenciesLeft) && isEmpty(dependenciesRight)) return null;
     const diffsLeft = dependenciesLeft.reduce<DepDiff[]>((acc, dependencyLeft) => {
       const dependencyRight = dependenciesRight.searchWithoutVersion(dependencyLeft);

--- a/components/legacy/component-diff/components-object-diff.ts
+++ b/components/legacy/component-diff/components-object-diff.ts
@@ -160,11 +160,17 @@ const DEPENDENCY_RESOLVER_ASPECT_ID = 'teambit.dependencies/dependency-resolver'
 function getComponentPeerDepsIds(component: Component): ComponentIdList {
   const legacyPeerIds = component.depsIdsGroupedByType.peerDependencies;
   const depResolverData = component.extensions?.findCoreExtension(DEPENDENCY_RESOLVER_ASPECT_ID)?.data;
-  const serializedDeps: Array<{ id: string; __type?: string; lifecycle?: string }> =
+  const serializedDeps: Array<{ id: string; version?: string; __type?: string; lifecycle?: string }> =
     depResolverData?.dependencies || [];
   const peerComponentIds = serializedDeps
     .filter((dep) => dep.__type === 'component' && dep.lifecycle === 'peer')
-    .map((dep) => ComponentID.fromString(dep.id));
+    .map((dep) => {
+      // the `id` string may be versionless; `version` is the authoritative field. apply it so that
+      // peer version upgrades/downgrades are surfaced by the version comparison in
+      // `componentDependenciesOutput()`.
+      const componentId = ComponentID.fromString(dep.id);
+      return dep.version ? componentId.changeVersion(dep.version) : componentId;
+    });
   return ComponentIdList.uniqFromArray([...legacyPeerIds, ...peerComponentIds]);
 }
 

--- a/e2e/harmony/diff-component-peer.e2e.ts
+++ b/e2e/harmony/diff-component-peer.e2e.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+// A component-level peer dependency (a bit-component set as a peer of another component) is stored
+// only in the dependency-resolver aspect data, not in the legacy `peerDependencies` array of the
+// Version model. As a result, a component reconstructed from the model has an empty legacy peer
+// array, while the workspace component has it populated. `bit diff` used to compare the legacy
+// arrays directly and therefore printed a phantom "peer added" line even though nothing changed
+// (and `bit status` correctly reported no modification).
+describe('bit diff with a component-level peer dependency', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.scopeHelper.reInitWorkspace();
+    helper.fixtures.populateComponents(2);
+    // mark comp2 as a peer. since comp1 depends on comp2, comp2 becomes a component-level peer
+    // dependency of comp1 (lifecycle=peer, type=component), which is stored only in the
+    // dependency-resolver aspect data and not in the legacy peerDependencies array.
+    helper.command.setPeer('comp2', '0');
+    helper.command.install();
+    helper.command.tagAllWithoutBuild();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  it('bit status should not show the component as modified', () => {
+    expect(helper.command.statusComponentIsModified(`${helper.scopes.remote}/comp1`)).to.be.false;
+  });
+  it('bit diff should not show a phantom peer-dependency change', () => {
+    const diff = helper.command.diff('comp1');
+    expect(diff).to.not.include('peerDependencies');
+  });
+});


### PR DESCRIPTION
## Problem

`bit diff` printed a phantom `+ <component>@<version>` under `peerDependencies` for component-level peers, even though `bit status` reported no modification and re-tagging didn't help.

## Root cause

Component-level peer dependencies are never persisted in the legacy `Version` model — `Version.fromComponent` doesn't serialize them; they live only in the dependency-resolver aspect data. So a component reconstructed from the model (`toConsumerComponent`) comes back with an empty legacy `peerDependencies` array, while the workspace component has it populated by the dependencies-loader. `bit diff` compared the legacy arrays directly → empty (model) vs `[peer]` (workspace) → phantom `+`.

`bit status`/`tag` were unaffected because modification detection relies on the dep-resolver aspect data, which is identical on both sides.

## Fix

In the diff layer, the `peerDependencies` field now derives component peers from the authoritative dependency-resolver aspect data (present on both the model and workspace component), unioned with the legacy array for backward compatibility. Symmetric data → no phantom, while real peer changes still show.

## Test

Added an e2e test reproducing the scenario via `set-peer`; it fails without the fix (identical phantom output) and passes with it, plus asserts `bit status` shows the component as unmodified.
