### PR TITLE
fix(deps-graph): scrub resolution-less workspace-component snaps from generated lockfile

### DIFF
--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -837,8 +837,7 @@ describe('convertGraphToLockfile on invalid graph', () => {
     expect(lockfile.snapshots!['foo@1.0.0']).to.eql({});
   });
 
-  // Reported on att-bit/duc (bit 1.13.226, already carrying #10380): a
-  // workspace-component snap reaches lockfile validation with no resolution
+  // A workspace-component snap reaches lockfile validation with no resolution
   // even though resolve() never threw NO_MATCHING_VERSION, because
   // getPkgsToResolve skips any pkgId whose name+version matches a manifest in
   // the sign/capsule set. The snap is a seeder being signed, so it is in the
@@ -846,9 +845,9 @@ describe('convertGraphToLockfile on invalid graph', () => {
   // `packages['...button-base@0.0.0-<snap>'] entry doesn't have a "resolution"
   // field`. It must be scrubbed so pnpm links it from the manifest instead.
   it('should drop workspace-component snaps skipped by the resolver (seeder in manifests)', async () => {
-    const snapPkgId = '@att-bit/duc.components.button-base@0.0.0-e1613079b55eabc19ad484478b769d929986c124';
+    const snapPkgId = '@my-org/my-scope.components.button-base@0.0.0-e1613079b55eabc19ad484478b769d929986c124';
     const packages: PackagesMap = new Map([
-      [snapPkgId, { component: { scope: 'att-bit.duc', name: 'components/button-base' } } as any],
+      [snapPkgId, { component: { scope: 'my-org.my-scope', name: 'components/button-base' } } as any],
       ['foo@1.0.0', { resolution: { integrity: 'sha512-aaa' } } as any],
     ]);
     const edges: DependencyEdge[] = [
@@ -868,7 +867,7 @@ describe('convertGraphToLockfile on invalid graph', () => {
         // button-base is a seeder being signed, so it appears in the manifests
         // with its snap version — getPkgsToResolve skips it for that reason.
         [path.resolve('comps/button-base')]: {
-          name: '@att-bit/duc.components.button-base',
+          name: '@my-org/my-scope.components.button-base',
           version: '0.0.0-e1613079b55eabc19ad484478b769d929986c124',
         },
         [path.resolve('comps/comp1')]: { dependencies: { foo: '1.0.0' } },
@@ -890,9 +889,9 @@ describe('convertGraphToLockfile on invalid graph', () => {
   // integrity (e.g. a directory/git resolution). The pkg then stays
   // resolution-less and must be scrubbed rather than failing validation.
   it('should drop workspace-component pkgs whose resolution has no integrity', async () => {
-    const snapPkgId = '@att-bit/duc.components.button-base@0.0.0-e1613079';
+    const snapPkgId = '@my-org/my-scope.components.button-base@0.0.0-e1613079';
     const packages: PackagesMap = new Map([
-      [snapPkgId, { component: { scope: 'att-bit.duc', name: 'components/button-base' } } as any],
+      [snapPkgId, { component: { scope: 'my-org.my-scope', name: 'components/button-base' } } as any],
       ['foo@1.0.0', { resolution: { integrity: 'sha512-aaa' } } as any],
     ]);
     const edges: DependencyEdge[] = [

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -837,6 +837,84 @@ describe('convertGraphToLockfile on invalid graph', () => {
     expect(lockfile.snapshots!['foo@1.0.0']).to.eql({});
   });
 
+  // Reported on att-bit/duc (bit 1.13.226, already carrying #10380): a
+  // workspace-component snap reaches lockfile validation with no resolution
+  // even though resolve() never threw NO_MATCHING_VERSION, because
+  // getPkgsToResolve skips any pkgId whose name+version matches a manifest in
+  // the sign/capsule set. The snap is a seeder being signed, so it is in the
+  // manifests, never sent to the resolver, and would surface as
+  // `packages['...button-base@0.0.0-<snap>'] entry doesn't have a "resolution"
+  // field`. It must be scrubbed so pnpm links it from the manifest instead.
+  it('should drop workspace-component snaps skipped by the resolver (seeder in manifests)', async () => {
+    const snapPkgId = '@att-bit/duc.components.button-base@0.0.0-e1613079b55eabc19ad484478b769d929986c124';
+    const packages: PackagesMap = new Map([
+      [snapPkgId, { component: { scope: 'att-bit.duc', name: 'components/button-base' } } as any],
+      ['foo@1.0.0', { resolution: { integrity: 'sha512-aaa' } } as any],
+    ]);
+    const edges: DependencyEdge[] = [
+      {
+        id: DependenciesGraph.ROOT_EDGE_ID,
+        neighbours: [{ id: 'foo@1.0.0', name: 'foo', specifier: '1.0.0', lifecycle: 'runtime' }],
+      },
+      {
+        id: 'foo@1.0.0',
+        neighbours: [{ id: snapPkgId, optional: false }],
+      },
+      { id: snapPkgId, neighbours: [] },
+    ];
+    let resolverCalled = false;
+    const lockfile = await convertGraphToLockfile(new DependenciesGraph(new DependenciesGraph({ packages, edges })), {
+      manifests: {
+        // button-base is a seeder being signed, so it appears in the manifests
+        // with its snap version — getPkgsToResolve skips it for that reason.
+        [path.resolve('comps/button-base')]: {
+          name: '@att-bit/duc.components.button-base',
+          version: '0.0.0-e1613079b55eabc19ad484478b769d929986c124',
+        },
+        [path.resolve('comps/comp1')]: { dependencies: { foo: '1.0.0' } },
+      },
+      rootDir: process.cwd(),
+      resolve: () => {
+        resolverCalled = true;
+        return { resolution: { integrity: '0000' } } as any;
+      },
+    });
+    expect(resolverCalled).to.equal(false);
+    expect(Object.keys(lockfile.packages!).sort()).to.eql(['foo@1.0.0']);
+    expect(Object.keys(lockfile.snapshots!).sort()).to.eql(['foo@1.0.0']);
+    expect(lockfile.snapshots!['foo@1.0.0']).to.eql({});
+  });
+
+  // Sibling of the above: even when the resolver IS called for a
+  // workspace-component snap, it may succeed yet return a resolution with no
+  // integrity (e.g. a directory/git resolution). The pkg then stays
+  // resolution-less and must be scrubbed rather than failing validation.
+  it('should drop workspace-component pkgs whose resolution has no integrity', async () => {
+    const snapPkgId = '@att-bit/duc.components.button-base@0.0.0-e1613079';
+    const packages: PackagesMap = new Map([
+      [snapPkgId, { component: { scope: 'att-bit.duc', name: 'components/button-base' } } as any],
+      ['foo@1.0.0', { resolution: { integrity: 'sha512-aaa' } } as any],
+    ]);
+    const edges: DependencyEdge[] = [
+      {
+        id: DependenciesGraph.ROOT_EDGE_ID,
+        neighbours: [{ id: 'foo@1.0.0', name: 'foo', specifier: '1.0.0', lifecycle: 'runtime' }],
+      },
+      { id: 'foo@1.0.0', neighbours: [{ id: snapPkgId, optional: false }] },
+      { id: snapPkgId, neighbours: [] },
+    ];
+    const lockfile = await convertGraphToLockfile(new DependenciesGraph(new DependenciesGraph({ packages, edges })), {
+      manifests: {
+        [path.resolve('comps/comp1')]: { dependencies: { foo: '1.0.0' } },
+      },
+      rootDir: process.cwd(),
+      // Resolver succeeds but returns no integrity for the unpublished snap.
+      resolve: () => ({ resolution: {} }) as any,
+    });
+    expect(Object.keys(lockfile.packages!).sort()).to.eql(['foo@1.0.0']);
+    expect(lockfile.snapshots!['foo@1.0.0']).to.eql({});
+  });
+
   // When the resolve failure is for a regular registry package (no component
   // attribute), we still want to surface the error rather than silently drop
   // it — that path means the graph itself is genuinely broken, not just

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
@@ -382,6 +382,28 @@ export async function convertGraphToLockfile(
       }
     })
   );
+  // A workspace-component snap can still be missing a resolution here even
+  // when resolve() never threw ERR_PNPM_NO_MATCHING_VERSION. Its directory
+  // resolution was stripped at graph-build time (see buildPackages), and the
+  // resolve pass above leaves it null in two cases the throw-handler doesn't
+  // see: getPkgsToResolve skips any pkgId whose name+version matches a
+  // manifest in the sign/capsule set (so the resolver is never called for a
+  // component that is itself a seeder being signed), and a resolver can also
+  // return a resolution that carries no integrity. Either way the snap-version
+  // was never published, so it can't carry a valid lockfile entry. Sweep every
+  // still-resolution-less workspace-component pkg into the scrub set so pnpm
+  // re-resolves the dep from the installing manifest's specifier (linking the
+  // workspace component) instead of failing validation and aborting the whole
+  // install. Non-component registry pkgs with no resolution are left to fail
+  // validation below — that path means the graph itself is genuinely broken.
+  for (const [pkgId, pkg] of Object.entries(lockfile.packages)) {
+    if (
+      (pkg.resolution == null || Object.keys(pkg.resolution).length === 0) &&
+      graph.packages.get(pkgId)?.component != null
+    ) {
+      failedWorkspaceComponentPkgs.add(pkgId);
+    }
+  }
   if (failedWorkspaceComponentPkgs.size > 0) {
     scrubPkgsFromLockfile(lockfile, failedWorkspaceComponentPkgs);
   }


### PR DESCRIPTION
## Problem

#10380 recovers unpublishable workspace-component snaps from a saved deps graph, but only when the registry `resolve()` call **throws `ERR_PNPM_NO_MATCHING_VERSION`**. A snap can still reach lockfile validation with no resolution via two paths that handler never sees, both surfacing as:

```
Failed to generate a valid lockfile. The "packages['@my-org/my-scope.components.button-base@0.0.0-...'] entry doesn't have a "resolution" field.
```

(reported by a user running 1.13.226, which already carries #10380).

A workspace-component snap has its `directory` resolution stripped and a `component` attribute set at graph-build time (`buildPackages`). It then stays resolution-less when:

1. **The resolver is never called for it** — `getPkgsToResolve` skips any pkgId whose name+version matches a manifest in the install set. During `sign`, the component is one of the seeders being signed, so it's in the manifests → skipped → never resolved.
2. **The resolver succeeds but returns a resolution with no integrity** (e.g. a directory/git resolution).

Either way validation throws and aborts the whole install. In the normal install path the failure is caught and the lockfile is regenerated during install, but the `fusepm` sign path calls `dependenciesGraphToLockfile` directly, so it's fatal.

## Fix

After the resolve pass, sweep **every** still-resolution-less workspace-component pkg (`graph.packages.get(pkgId)?.component != null`) into the existing scrub set — not just the ones whose `resolve()` threw. pnpm then re-resolves/links the dep from the installing manifest's specifier. Non-component registry packages with no resolution still fail validation (a genuinely broken graph).

## Tests

Added two regression tests covering both bypass paths:
- workspace-component snap skipped by the resolver because it's a seeder in the manifests
- workspace-component pkg whose resolution comes back without an integrity

All 21 converter tests pass; `npm run lint` clean.
