### PR TITLE
feat(deprecation): support component-pattern in deprecate/undeprecate

### DIFF
--- a/components/legacy/bit-map/component-map.ts
+++ b/components/legacy/bit-map/component-map.ts
@@ -312,6 +312,15 @@ export class ComponentMap {
     if (!deprecationConf) return false;
     return deprecationConf !== '-' && deprecationConf.deprecate === false;
   }
+  /**
+   * a range-deprecation is stored with `deprecate: false` (only specific versions are deprecated),
+   * so it's not isDeprecated(), yet it still needs clearing on undeprecate. detect it explicitly.
+   */
+  isDeprecatedByRange() {
+    const deprecationConf = this.config?.[Extensions.deprecation];
+    if (!deprecationConf || deprecationConf === '-') return false;
+    return Boolean(deprecationConf.range);
+  }
   isInternal() {
     const internalizeConf = this.config?.[Extensions.internalize];
     if (!internalizeConf) return false;

--- a/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
+++ b/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
@@ -218,11 +218,11 @@ show components that depend on the specified component
 displays components from both workspace and scope that depend on the specified component. useful for understanding impact before making changes to a component or when planning refactoring. shows both direct and transitive dependents organized by their origin (workspace vs scope).
 Flags: --json
 
-## bit deprecate <component-name>
+## bit deprecate <component-pattern>
 
-mark a component as deprecated to discourage its use
+mark components as deprecated to discourage their use
 
-marks a component as deprecated locally, then after snap/tag and export it becomes deprecated in the remote scope. optionally specify a replacement component or deprecate only specific version ranges. deprecated components remain available but display warnings when installed or imported.
+marks components as deprecated locally, then after snap/tag and export they become deprecated in the remote scope. the pattern can match multiple components, so several can be deprecated at once. optionally specify a replacement component (single component only) or deprecate only specific version ranges. deprecated components remain available but display warnings when installed or imported.
 Flags: --new-id <string>, --range <string>
 
 ## bit deps <sub-command>
@@ -955,11 +955,11 @@ run component tests
 executes tests using the testing framework configured by each component's environment (Jest, Mocha, etc.). by default only runs tests for new and modified components. use --unmodified to test all components. to run specific test files only, pass their paths instead of a component pattern, e.g. "bit test path/to/comp/my-comp.spec.ts". supports watch mode, coverage reporting, and debug mode for development workflows.
 Flags: --watch, --debug, --unmodified, --junit <filepath>, --coverage, --env <id>, --update-snapshot, --json, --verbose, --summary
 
-## bit undeprecate <id>
+## bit undeprecate <component-pattern>
 
-remove the deprecation status from a component
+remove the deprecation status from components
 
-reverses the deprecation of a component, removing warnings and allowing normal use again.
+reverses the deprecation of components, removing warnings and allowing normal use again. the pattern can match multiple components, so several can be undeprecated at once.
 
 ## bit uninstall [packages...]
 

--- a/contrib/claude-skill-bit-cli/SKILL.md
+++ b/contrib/claude-skill-bit-cli/SKILL.md
@@ -53,8 +53,8 @@ remote - manage remote scopes for self-hosted environments
 Subcommands: add, del, list
 ripple <sub-command> - manage Ripple CI jobs on bit.cloud
 Subcommands: list, log, errors, retry, stop
-deprecate <component-name> - mark a component as deprecated to discourage its use
-undeprecate <id> - remove the deprecation status from a component
+deprecate <component-pattern> - mark components as deprecated to discourage their use
+undeprecate <component-pattern> - remove the deprecation status from components
 import [component-patterns...] - bring components from remote scopes into your workspace
 delete <component-pattern> - soft-delete components from remote scopes
 recover <component-pattern> - restore soft-deleted components

--- a/e2e/harmony/deprecate.e2e.ts
+++ b/e2e/harmony/deprecate.e2e.ts
@@ -116,6 +116,49 @@ describe('bit deprecate and undeprecate commands', function () {
       });
     });
   });
+  describe('deprecate and undeprecate multiple components by pattern', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+    });
+    describe('deprecating all components with a wildcard pattern', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.deprecateComponent('"**"');
+      });
+      it('should indicate that multiple components were deprecated', () => {
+        expect(output).to.have.string('3 component');
+      });
+      it('should mark all matched components as deprecated', () => {
+        ['comp1', 'comp2', 'comp3'].forEach((id) => {
+          const deprecationData = helper.command.showAspectConfig(id, Extensions.deprecation);
+          expect(deprecationData.config.deprecate).to.be.true;
+        });
+      });
+    });
+    describe('undeprecating multiple components with a wildcard pattern', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.undeprecateComponent('"**"');
+      });
+      it('should indicate that multiple components were undeprecated', () => {
+        expect(output).to.have.string('3 component');
+      });
+      it('should remove the deprecation status from all of them', () => {
+        ['comp1', 'comp2', 'comp3'].forEach((id) => {
+          const deprecationData = helper.command.showAspectConfig(id, Extensions.deprecation);
+          expect(deprecationData.config.deprecate).to.be.false;
+        });
+      });
+    });
+    describe('using --new-id when the pattern matches more than one component', () => {
+      it('should throw an error', () => {
+        const cmd = () => helper.command.deprecateComponent('"**"', '--new-id comp1');
+        expect(cmd).to.throw();
+      });
+    });
+  });
   describe('reverting the deprecation by "bit checkout reset"', () => {
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();

--- a/e2e/harmony/deprecate.e2e.ts
+++ b/e2e/harmony/deprecate.e2e.ts
@@ -175,6 +175,25 @@ describe('bit deprecate and undeprecate commands', function () {
       expect(status.modifiedComponents).to.have.lengthOf(0);
     });
   });
+  describe('undeprecating a range-deprecation by pattern', () => {
+    let output: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      // range-deprecations are stored with "deprecate: false", so undeprecate must still clear them
+      helper.command.deprecateComponent('comp1', '--range "<1.0.0"');
+      output = helper.command.undeprecateComponent('"**"');
+    });
+    it('should undeprecate the range-deprecated component (not bucket it as "not deprecated")', () => {
+      expect(output).to.have.string('undeprecated successfully');
+    });
+    it('should clear the range from the deprecation config', () => {
+      const deprecationData = helper.command.showAspectConfig('comp1', Extensions.deprecation);
+      expect(deprecationData.config.deprecate).to.be.false;
+      expect(deprecationData.config).to.not.have.property('range');
+    });
+  });
   describe('reverting the deprecation by "bit checkout reset"', () => {
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();

--- a/e2e/harmony/deprecate.e2e.ts
+++ b/e2e/harmony/deprecate.e2e.ts
@@ -159,6 +159,22 @@ describe('bit deprecate and undeprecate commands', function () {
       });
     });
   });
+  describe('undeprecating components that are not deprecated by pattern', () => {
+    let output: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      output = helper.command.undeprecateComponent('"**"');
+    });
+    it('should indicate that no changes were made', () => {
+      expect(output).to.have.string('no changes have been made');
+    });
+    it('should not write a deprecation config nor mark the components as modified', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+    });
+  });
   describe('reverting the deprecation by "bit checkout reset"', () => {
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();

--- a/scopes/component/deprecation/deprecate-cmd.ts
+++ b/scopes/component/deprecation/deprecate-cmd.ts
@@ -1,5 +1,5 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections, successSymbol } from '@teambit/cli';
+import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { DeprecationMain } from './deprecation.main.runtime';
 
@@ -56,7 +56,7 @@ deprecated components remain available but display warnings when installed or im
       formatSection(
         'deprecated',
         '',
-        deprecated.map((id) => formatItem(id.toString(), successSymbol()))
+        deprecated.map((id) => formatItem(id.toString()))
       ),
       formatSection(
         'already deprecated',

--- a/scopes/component/deprecation/deprecate-cmd.ts
+++ b/scopes/component/deprecation/deprecate-cmd.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { DeprecationMain } from './deprecation.main.runtime';
+import { formatPatternResult } from './format-pattern-result';
 
 export class DeprecateCmd implements Command {
   name = 'deprecate <component-pattern>';
@@ -40,30 +40,10 @@ deprecated components remain available but display warnings when installed or im
 
   async report([pattern]: [string], { newId, range }: { newId?: string; range?: string }): Promise<string> {
     const { deprecated, alreadyDeprecated } = await this.deprecation.deprecateByPattern(pattern, newId, range);
-
-    // preserve the familiar single-line message when only one component is affected
-    if (deprecated.length === 1 && !alreadyDeprecated.length) {
-      return formatSuccessSummary(`the component "${deprecated[0].toString()}" has been deprecated successfully`);
-    }
-    if (!deprecated.length) {
-      return formatHint(
-        `all ${alreadyDeprecated.length} component(s) matching "${pattern}" are already deprecated. no changes have been made`
-      );
-    }
-
-    const sections = [
-      formatSuccessSummary(`${deprecated.length} component(s) have been deprecated successfully`),
-      formatSection(
-        'deprecated',
-        '',
-        deprecated.map((id) => formatItem(id.toString()))
-      ),
-      formatSection(
-        'already deprecated',
-        'no changes were made to these',
-        alreadyDeprecated.map((id) => formatItem(id.toString()))
-      ),
-    ];
-    return joinSections(sections);
+    return formatPatternResult(pattern, deprecated, alreadyDeprecated, {
+      verb: 'deprecated',
+      unchangedTitle: 'already deprecated',
+      unchangedState: 'already deprecated',
+    });
   }
 }

--- a/scopes/component/deprecation/deprecate-cmd.ts
+++ b/scopes/component/deprecation/deprecate-cmd.ts
@@ -1,13 +1,15 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatSuccessSummary, formatHint } from '@teambit/cli';
+import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections, successSymbol } from '@teambit/cli';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { DeprecationMain } from './deprecation.main.runtime';
 
 export class DeprecateCmd implements Command {
-  name = 'deprecate <component-name>';
-  arguments = [{ name: 'component-name', description: 'component name or component id' }];
-  description = 'mark a component as deprecated to discourage its use';
-  extendedDescription = `marks a component as deprecated locally, then after snap/tag and export it becomes deprecated in the remote scope.
-optionally specify a replacement component or deprecate only specific version ranges.
+  name = 'deprecate <component-pattern>';
+  arguments = [{ name: 'component-pattern', description: COMPONENT_PATTERN_HELP }];
+  description = 'mark components as deprecated to discourage their use';
+  extendedDescription = `marks components as deprecated locally, then after snap/tag and export they become deprecated in the remote scope.
+the pattern can match multiple components, so several can be deprecated at once.
+optionally specify a replacement component (single component only) or deprecate only specific version ranges.
 deprecated components remain available but display warnings when installed or imported.`;
   group = 'collaborate';
   skipWorkspace = true;
@@ -16,7 +18,7 @@ deprecated components remain available but display warnings when installed or im
     [
       '',
       'new-id <string>',
-      'if replaced by another component, enter the new component id. alternatively use "bit rename --deprecate" to do this automatically',
+      'if replaced by another component, enter the new component id. alternatively use "bit rename --deprecate" to do this automatically. only valid when the pattern matches a single component',
     ],
     [
       '',
@@ -27,18 +29,41 @@ deprecated components remain available but display warnings when installed or im
   loader = true;
   remoteOp = true;
   helpUrl = 'reference/components/removing-components';
+  examples = [
+    {
+      cmd: 'deprecate "ui/**"',
+      description: 'deprecate all components whose id starts with "ui/"',
+    },
+  ];
 
   constructor(private deprecation: DeprecationMain) {}
 
-  async report([id]: [string], { newId, range }: { newId?: string; range?: string }): Promise<string> {
-    const result = await this.deprecate(id, newId, range);
-    if (result) {
-      return formatSuccessSummary(`the component "${id}" has been deprecated successfully`);
-    }
-    return formatHint(`the component "${id}" is already deprecated. no changes have been made`);
-  }
+  async report([pattern]: [string], { newId, range }: { newId?: string; range?: string }): Promise<string> {
+    const { deprecated, alreadyDeprecated } = await this.deprecation.deprecateByPattern(pattern, newId, range);
 
-  private async deprecate(id: string, newId?: string, range?: string): Promise<boolean> {
-    return this.deprecation.deprecateByCLIValues(id, newId, range);
+    // preserve the familiar single-line message when only one component is affected
+    if (deprecated.length === 1 && !alreadyDeprecated.length) {
+      return formatSuccessSummary(`the component "${deprecated[0].toString()}" has been deprecated successfully`);
+    }
+    if (!deprecated.length) {
+      return formatHint(
+        `all ${alreadyDeprecated.length} component(s) matching "${pattern}" are already deprecated. no changes have been made`
+      );
+    }
+
+    const sections = [
+      formatSuccessSummary(`${deprecated.length} component(s) have been deprecated successfully`),
+      formatSection(
+        'deprecated',
+        '',
+        deprecated.map((id) => formatItem(id.toString(), successSymbol()))
+      ),
+      formatSection(
+        'already deprecated',
+        'no changes were made to these',
+        alreadyDeprecated.map((id) => formatItem(id.toString()))
+      ),
+    ];
+    return joinSections(sections);
   }
 }

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -217,14 +217,19 @@ run the command per-component to use --new-id, or remove it to deprecate them al
 
   /**
    * whether the component has any deprecation that an undeprecate should clear. unlike isDeprecated(),
-   * this also treats a range-deprecation (stored locally with deprecate:false) as clearable, so
-   * "bit undeprecate" can revert a prior "bit deprecate --range".
+   * this also treats a range-deprecation as clearable (whether it lives in the local .bitmap or is
+   * already baked into the model), so "bit undeprecate" can revert a prior "bit deprecate --range" even
+   * when the head version is outside the range and thus not "currently" deprecated.
    */
   private async hasDeprecationToClear(componentId: ComponentID): Promise<boolean> {
     const bitmapEntry = this.workspace.bitMap.getBitmapEntryIfExist(componentId, { ignoreVersion: true });
     if (bitmapEntry?.isDeprecated() || bitmapEntry?.isDeprecatedByRange()) return true;
     if (bitmapEntry?.isUndeprecated()) return false;
-    return this.isDeprecatedByIdWithoutLoadingComponent(componentId);
+    // no decisive local config — consult the model. use getDeprecationInfo (which reports the configured
+    // range regardless of the head version) rather than the version-specific isDeprecated() check.
+    const component = await this.workspace.get(componentId);
+    const { isDeprecate, range } = await this.getDeprecationInfo(component);
+    return isDeprecate || Boolean(range);
   }
 
   private setDeprecateConfig(componentId: ComponentID, newId?: ComponentID, range?: string): boolean {

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -22,11 +22,34 @@ import type { DependencyResolverMain } from '@teambit/dependency-resolver';
 import { DependencyResolverAspect } from '@teambit/dependency-resolver';
 import { compact } from 'lodash';
 import { IssuesClasses } from '@teambit/component-issues';
+import { BitError } from '@teambit/bit-error';
 
 export type DeprecationInfo = {
   isDeprecate: boolean;
   newId?: string;
   range?: string;
+};
+
+export type DeprecateByPatternResult = {
+  /**
+   * components that were deprecated as a result of this operation.
+   */
+  deprecated: ComponentID[];
+  /**
+   * components that matched the pattern but were already deprecated (no changes made).
+   */
+  alreadyDeprecated: ComponentID[];
+};
+
+export type UnDeprecateByPatternResult = {
+  /**
+   * components whose deprecation status was removed as a result of this operation.
+   */
+  undeprecated: ComponentID[];
+  /**
+   * components that matched the pattern but were not deprecated (no changes made).
+   */
+  notDeprecated: ComponentID[];
 };
 
 export type DeprecationMetadata = {
@@ -94,11 +117,7 @@ export class DeprecationMain {
    * @returns boolean whether or not the component has been deprecated
    */
   async deprecate(componentId: ComponentID, newId?: ComponentID, range?: string): Promise<boolean> {
-    const results = this.workspace.bitMap.addComponentConfig(componentId, DeprecationAspect.id, {
-      deprecate: !range,
-      newId: newId?.toObject(),
-      range,
-    });
+    const results = this.setDeprecateConfig(componentId, newId, range);
     await this.workspace.bitMap.write(`deprecate ${componentId.toString()}`);
 
     return results;
@@ -110,19 +129,78 @@ export class DeprecationMain {
     return this.deprecate(componentId, newComponentId, range);
   }
 
+  /**
+   * deprecate all components matching the given pattern. the pattern can match multiple components.
+   * see `COMPONENT_PATTERN_HELP` for the supported pattern syntax.
+   */
+  async deprecateByPattern(pattern: string, newId?: string, range?: string): Promise<DeprecateByPatternResult> {
+    const componentIds = await this.workspace.idsByPattern(pattern);
+    const newComponentId = newId ? await this.workspace.resolveComponentId(newId) : undefined;
+    if (newComponentId && componentIds.length > 1) {
+      throw new BitError(
+        `--new-id sets a single replacement component, but the pattern "${pattern}" matched ${componentIds.length} components.
+run the command per-component to use --new-id, or remove it to deprecate them all`
+      );
+    }
+    const deprecated: ComponentID[] = [];
+    const alreadyDeprecated: ComponentID[] = [];
+    componentIds.forEach((componentId) => {
+      const changed = this.setDeprecateConfig(componentId, newComponentId, range);
+      if (changed) deprecated.push(componentId);
+      else alreadyDeprecated.push(componentId);
+    });
+    if (deprecated.length) {
+      await this.workspace.bitMap.write(`deprecate ${pattern}`);
+    }
+
+    return { deprecated, alreadyDeprecated };
+  }
+
   async unDeprecateByCLIValues(id: string): Promise<boolean> {
     const componentId = await this.workspace.resolveComponentId(id);
     return this.unDeprecate(componentId);
   }
 
   async unDeprecate(componentId: ComponentID) {
-    const results = this.workspace.bitMap.addComponentConfig(componentId, DeprecationAspect.id, {
-      deprecate: false,
-      newId: '',
-    });
+    const results = this.setUnDeprecateConfig(componentId);
     await this.workspace.bitMap.write(`undeprecate ${componentId.toString()}`);
 
     return results;
+  }
+
+  /**
+   * remove the deprecation status from all components matching the given pattern.
+   * the pattern can match multiple components. see `COMPONENT_PATTERN_HELP` for the supported pattern syntax.
+   */
+  async unDeprecateByPattern(pattern: string): Promise<UnDeprecateByPatternResult> {
+    const componentIds = await this.workspace.idsByPattern(pattern);
+    const undeprecated: ComponentID[] = [];
+    const notDeprecated: ComponentID[] = [];
+    componentIds.forEach((componentId) => {
+      const changed = this.setUnDeprecateConfig(componentId);
+      if (changed) undeprecated.push(componentId);
+      else notDeprecated.push(componentId);
+    });
+    if (undeprecated.length) {
+      await this.workspace.bitMap.write(`undeprecate ${pattern}`);
+    }
+
+    return { undeprecated, notDeprecated };
+  }
+
+  private setDeprecateConfig(componentId: ComponentID, newId?: ComponentID, range?: string): boolean {
+    return this.workspace.bitMap.addComponentConfig(componentId, DeprecationAspect.id, {
+      deprecate: !range,
+      newId: newId?.toObject(),
+      range,
+    });
+  }
+
+  private setUnDeprecateConfig(componentId: ComponentID): boolean {
+    return this.workspace.bitMap.addComponentConfig(componentId, DeprecationAspect.id, {
+      deprecate: false,
+      newId: '',
+    });
   }
 
   async addDeprecatedDependenciesIssues(components: Component[]) {

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -144,10 +144,17 @@ run the command per-component to use --new-id, or remove it to deprecate them al
     }
     const deprecated: ComponentID[] = [];
     const alreadyDeprecated: ComponentID[] = [];
-    componentIds.forEach((componentId) => {
-      const changed = this.setDeprecateConfig(componentId, newComponentId, range);
-      if (changed) deprecated.push(componentId);
-      else alreadyDeprecated.push(componentId);
+    await pMapSeries(componentIds, async (componentId) => {
+      // when the component is already deprecated and there's no replacement/range to (re)set, there's
+      // nothing to change. bucketing by the actual deprecated-state (bitmap + model) rather than by the
+      // bitmap config-diff avoids re-writing redundant config (e.g. for "$deprecated" matches) and
+      // reporting already-deprecated components as newly deprecated.
+      if (!newComponentId && !range && (await this.isDeprecated(componentId))) {
+        alreadyDeprecated.push(componentId);
+        return;
+      }
+      this.setDeprecateConfig(componentId, newComponentId, range);
+      deprecated.push(componentId);
     });
     if (deprecated.length) {
       await this.workspace.bitMap.write(`deprecate ${pattern}`);
@@ -176,16 +183,33 @@ run the command per-component to use --new-id, or remove it to deprecate them al
     const componentIds = await this.workspace.idsByPattern(pattern);
     const undeprecated: ComponentID[] = [];
     const notDeprecated: ComponentID[] = [];
-    componentIds.forEach((componentId) => {
-      const changed = this.setUnDeprecateConfig(componentId);
-      if (changed) undeprecated.push(componentId);
-      else notDeprecated.push(componentId);
+    await pMapSeries(componentIds, async (componentId) => {
+      // only undeprecate components that are actually deprecated. bucketing by the actual deprecated-state
+      // (bitmap + model) rather than by the bitmap config-diff avoids writing a redundant "deprecate: false"
+      // config (and marking the component as modified) for components that were never deprecated.
+      if (!(await this.isDeprecated(componentId))) {
+        notDeprecated.push(componentId);
+        return;
+      }
+      this.setUnDeprecateConfig(componentId);
+      undeprecated.push(componentId);
     });
     if (undeprecated.length) {
       await this.workspace.bitMap.write(`undeprecate ${pattern}`);
     }
 
     return { undeprecated, notDeprecated };
+  }
+
+  /**
+   * whether the component is currently deprecated, considering both the pending local .bitmap config
+   * (authoritative when present) and the persisted model/scope state.
+   */
+  private async isDeprecated(componentId: ComponentID): Promise<boolean> {
+    const bitmapEntry = this.workspace.bitMap.getBitmapEntryIfExist(componentId, { ignoreVersion: true });
+    if (bitmapEntry?.isDeprecated()) return true;
+    if (bitmapEntry?.isUndeprecated()) return false;
+    return this.isDeprecatedByIdWithoutLoadingComponent(componentId);
   }
 
   private setDeprecateConfig(componentId: ComponentID, newId?: ComponentID, range?: string): boolean {

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -135,13 +135,15 @@ export class DeprecationMain {
    */
   async deprecateByPattern(pattern: string, newId?: string, range?: string): Promise<DeprecateByPatternResult> {
     const componentIds = await this.workspace.idsByPattern(pattern);
-    const newComponentId = newId ? await this.workspace.resolveComponentId(newId) : undefined;
-    if (newComponentId && componentIds.length > 1) {
+    // reject the invalid multi-match + --new-id combination before resolving newId, so we don't
+    // trigger registry/package-name resolution (which can fail) for a command that's already invalid.
+    if (newId && componentIds.length > 1) {
       throw new BitError(
         `--new-id sets a single replacement component, but the pattern "${pattern}" matched ${componentIds.length} components.
 run the command per-component to use --new-id, or remove it to deprecate them all`
       );
     }
+    const newComponentId = newId ? await this.workspace.resolveComponentId(newId) : undefined;
     const deprecated: ComponentID[] = [];
     const alreadyDeprecated: ComponentID[] = [];
     await pMapSeries(componentIds, async (componentId) => {
@@ -184,10 +186,11 @@ run the command per-component to use --new-id, or remove it to deprecate them al
     const undeprecated: ComponentID[] = [];
     const notDeprecated: ComponentID[] = [];
     await pMapSeries(componentIds, async (componentId) => {
-      // only undeprecate components that are actually deprecated. bucketing by the actual deprecated-state
-      // (bitmap + model) rather than by the bitmap config-diff avoids writing a redundant "deprecate: false"
-      // config (and marking the component as modified) for components that were never deprecated.
-      if (!(await this.isDeprecated(componentId))) {
+      // only undeprecate components that actually have a deprecation to clear (incl. range-deprecations,
+      // which are stored with deprecate:false). bucketing by the real state rather than the bitmap
+      // config-diff avoids writing a redundant "deprecate: false" config (and marking the component as
+      // modified) for components that were never deprecated.
+      if (!(await this.hasDeprecationToClear(componentId))) {
         notDeprecated.push(componentId);
         return;
       }
@@ -208,6 +211,18 @@ run the command per-component to use --new-id, or remove it to deprecate them al
   private async isDeprecated(componentId: ComponentID): Promise<boolean> {
     const bitmapEntry = this.workspace.bitMap.getBitmapEntryIfExist(componentId, { ignoreVersion: true });
     if (bitmapEntry?.isDeprecated()) return true;
+    if (bitmapEntry?.isUndeprecated()) return false;
+    return this.isDeprecatedByIdWithoutLoadingComponent(componentId);
+  }
+
+  /**
+   * whether the component has any deprecation that an undeprecate should clear. unlike isDeprecated(),
+   * this also treats a range-deprecation (stored locally with deprecate:false) as clearable, so
+   * "bit undeprecate" can revert a prior "bit deprecate --range".
+   */
+  private async hasDeprecationToClear(componentId: ComponentID): Promise<boolean> {
+    const bitmapEntry = this.workspace.bitMap.getBitmapEntryIfExist(componentId, { ignoreVersion: true });
+    if (bitmapEntry?.isDeprecated() || bitmapEntry?.isDeprecatedByRange()) return true;
     if (bitmapEntry?.isUndeprecated()) return false;
     return this.isDeprecatedByIdWithoutLoadingComponent(componentId);
   }

--- a/scopes/component/deprecation/format-pattern-result.ts
+++ b/scopes/component/deprecation/format-pattern-result.ts
@@ -1,0 +1,47 @@
+import type { ComponentID } from '@teambit/component-id';
+import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections } from '@teambit/cli';
+
+export type PatternResultLabels = {
+  /** past-tense verb used in the success messages and the changed-section title, e.g. "deprecated" */
+  verb: string;
+  /** section title for the components that were left unchanged, e.g. "already deprecated" */
+  unchangedTitle: string;
+  /** describes the unchanged state in the "no changes" hint, e.g. "already deprecated" */
+  unchangedState: string;
+};
+
+/**
+ * shared output formatting for the pattern-based deprecate/undeprecate commands: a single-line summary
+ * for the common single-component case, a hint when nothing changed, or a sectioned summary listing the
+ * changed and unchanged components.
+ */
+export function formatPatternResult(
+  pattern: string,
+  changed: ComponentID[],
+  unchanged: ComponentID[],
+  labels: PatternResultLabels
+): string {
+  // preserve the familiar single-line message when only one component is affected
+  if (changed.length === 1 && !unchanged.length) {
+    return formatSuccessSummary(`the component "${changed[0].toString()}" has been ${labels.verb} successfully`);
+  }
+  if (!changed.length) {
+    return formatHint(
+      `all ${unchanged.length} component(s) matching "${pattern}" are ${labels.unchangedState}. no changes have been made`
+    );
+  }
+
+  return joinSections([
+    formatSuccessSummary(`${changed.length} component(s) have been ${labels.verb} successfully`),
+    formatSection(
+      labels.verb,
+      '',
+      changed.map((id) => formatItem(id.toString()))
+    ),
+    formatSection(
+      labels.unchangedTitle,
+      'no changes were made to these',
+      unchanged.map((id) => formatItem(id.toString()))
+    ),
+  ]);
+}

--- a/scopes/component/deprecation/undeprecate-cmd.ts
+++ b/scopes/component/deprecation/undeprecate-cmd.ts
@@ -17,7 +17,8 @@ the pattern can match multiple components, so several can be undeprecated at onc
   remoteOp = true;
   examples = [
     {
-      cmd: 'undeprecate "$deprecated"',
+      // single-quote "$deprecated" so the shell doesn't expand it as an env var
+      cmd: "undeprecate '$deprecated'",
       description: 'undeprecate all currently-deprecated components',
     },
   ];

--- a/scopes/component/deprecation/undeprecate-cmd.ts
+++ b/scopes/component/deprecation/undeprecate-cmd.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { DeprecationMain } from './deprecation.main.runtime';
+import { formatPatternResult } from './format-pattern-result';
 
 export class UndeprecateCmd implements Command {
   name = 'undeprecate <component-pattern>';
@@ -27,30 +27,10 @@ the pattern can match multiple components, so several can be undeprecated at onc
 
   async report([pattern]: [string]): Promise<string> {
     const { undeprecated, notDeprecated } = await this.deprecation.unDeprecateByPattern(pattern);
-
-    // preserve the familiar single-line message when only one component is affected
-    if (undeprecated.length === 1 && !notDeprecated.length) {
-      return formatSuccessSummary(`the component "${undeprecated[0].toString()}" has been undeprecated successfully`);
-    }
-    if (!undeprecated.length) {
-      return formatHint(
-        `none of the ${notDeprecated.length} component(s) matching "${pattern}" are currently deprecated. no changes have been made`
-      );
-    }
-
-    const sections = [
-      formatSuccessSummary(`${undeprecated.length} component(s) have been undeprecated successfully`),
-      formatSection(
-        'undeprecated',
-        '',
-        undeprecated.map((id) => formatItem(id.toString()))
-      ),
-      formatSection(
-        'not deprecated',
-        'no changes were made to these',
-        notDeprecated.map((id) => formatItem(id.toString()))
-      ),
-    ];
-    return joinSections(sections);
+    return formatPatternResult(pattern, undeprecated, notDeprecated, {
+      verb: 'undeprecated',
+      unchangedTitle: 'not deprecated',
+      unchangedState: 'not currently deprecated',
+    });
   }
 }

--- a/scopes/component/deprecation/undeprecate-cmd.ts
+++ b/scopes/component/deprecation/undeprecate-cmd.ts
@@ -1,5 +1,5 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections, successSymbol } from '@teambit/cli';
+import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections } from '@teambit/cli';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { DeprecationMain } from './deprecation.main.runtime';
 
@@ -42,7 +42,7 @@ the pattern can match multiple components, so several can be undeprecated at onc
       formatSection(
         'undeprecated',
         '',
-        undeprecated.map((id) => formatItem(id.toString(), successSymbol()))
+        undeprecated.map((id) => formatItem(id.toString()))
       ),
       formatSection(
         'not deprecated',

--- a/scopes/component/deprecation/undeprecate-cmd.ts
+++ b/scopes/component/deprecation/undeprecate-cmd.ts
@@ -1,25 +1,55 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import { formatSuccessSummary, formatHint } from '@teambit/cli';
+import { formatSuccessSummary, formatHint, formatSection, formatItem, joinSections, successSymbol } from '@teambit/cli';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy.constants';
 import type { DeprecationMain } from './deprecation.main.runtime';
 
 export class UndeprecateCmd implements Command {
-  name = 'undeprecate <id>';
+  name = 'undeprecate <component-pattern>';
+  arguments = [{ name: 'component-pattern', description: COMPONENT_PATTERN_HELP }];
   group = 'collaborate';
-  description = 'remove the deprecation status from a component';
-  extendedDescription = 'reverses the deprecation of a component, removing warnings and allowing normal use again.';
+  description = 'remove the deprecation status from components';
+  extendedDescription = `reverses the deprecation of components, removing warnings and allowing normal use again.
+the pattern can match multiple components, so several can be undeprecated at once.`;
   alias = '';
   options = [] as CommandOptions;
   loader = true;
   skipWorkspace = true;
   remoteOp = true;
+  examples = [
+    {
+      cmd: 'undeprecate "$deprecated"',
+      description: 'undeprecate all currently-deprecated components',
+    },
+  ];
 
   constructor(private deprecation: DeprecationMain) {}
 
-  async report([id]: [string]): Promise<string> {
-    const result = await this.deprecation.unDeprecateByCLIValues(id);
-    if (result) {
-      return formatSuccessSummary(`the component "${id}" has been undeprecated successfully`);
+  async report([pattern]: [string]): Promise<string> {
+    const { undeprecated, notDeprecated } = await this.deprecation.unDeprecateByPattern(pattern);
+
+    // preserve the familiar single-line message when only one component is affected
+    if (undeprecated.length === 1 && !notDeprecated.length) {
+      return formatSuccessSummary(`the component "${undeprecated[0].toString()}" has been undeprecated successfully`);
     }
-    return formatHint(`the component "${id}" is not currently deprecated. no changes have been made`);
+    if (!undeprecated.length) {
+      return formatHint(
+        `none of the ${notDeprecated.length} component(s) matching "${pattern}" are currently deprecated. no changes have been made`
+      );
+    }
+
+    const sections = [
+      formatSuccessSummary(`${undeprecated.length} component(s) have been undeprecated successfully`),
+      formatSection(
+        'undeprecated',
+        '',
+        undeprecated.map((id) => formatItem(id.toString(), successSymbol()))
+      ),
+      formatSection(
+        'not deprecated',
+        'no changes were made to these',
+        notDeprecated.map((id) => formatItem(id.toString()))
+      ),
+    ];
+    return joinSections(sections);
   }
 }

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -1682,13 +1682,13 @@
     ]
   },
   {
-    "name": "deprecate <component-name>",
+    "name": "deprecate <component-pattern>",
     "alias": "d",
     "options": [
       [
         "",
         "new-id <string>",
-        "if replaced by another component, enter the new component id. alternatively use \"bit rename --deprecate\" to do this automatically"
+        "if replaced by another component, enter the new component id. alternatively use \"bit rename --deprecate\" to do this automatically. only valid when the pattern matches a single component"
       ],
       [
         "",
@@ -1696,29 +1696,47 @@
         "enter a Semver range to deprecate specific versions. see https://www.npmjs.com/package/semver#ranges for the range syntax"
       ]
     ],
-    "description": "mark a component as deprecated to discourage its use",
-    "extendedDescription": "marks a component as deprecated locally, then after snap/tag and export it becomes deprecated in the remote scope.\noptionally specify a replacement component or deprecate only specific version ranges.\ndeprecated components remain available but display warnings when installed or imported.",
+    "description": "mark components as deprecated to discourage their use",
+    "extendedDescription": "marks components as deprecated locally, then after snap/tag and export they become deprecated in the remote scope.\nthe pattern can match multiple components, so several can be deprecated at once.\noptionally specify a replacement component (single component only) or deprecate only specific version ranges.\ndeprecated components remain available but display warnings when installed or imported.",
     "group": "collaborate",
     "private": false,
     "remoteOp": true,
     "skipWorkspace": true,
     "arguments": [
       {
-        "name": "component-name",
-        "description": "component name or component id"
+        "name": "component-pattern",
+        "description": "component name, component id, component pattern, or relative directory path. use component pattern to select multiple components.\nwrap the pattern with quotes. use comma to separate patterns and \"!\" to exclude. e.g. \"ui/**, !ui/button\".\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern."
+      }
+    ],
+    "examples": [
+      {
+        "cmd": "deprecate \"ui/**\"",
+        "description": "deprecate all components whose id starts with \"ui/\""
       }
     ]
   },
   {
-    "name": "undeprecate <id>",
+    "name": "undeprecate <component-pattern>",
     "alias": "",
     "options": [],
-    "description": "remove the deprecation status from a component",
-    "extendedDescription": "reverses the deprecation of a component, removing warnings and allowing normal use again.",
+    "description": "remove the deprecation status from components",
+    "extendedDescription": "reverses the deprecation of components, removing warnings and allowing normal use again.\nthe pattern can match multiple components, so several can be undeprecated at once.",
     "group": "collaborate",
     "private": false,
     "remoteOp": true,
-    "skipWorkspace": true
+    "skipWorkspace": true,
+    "arguments": [
+      {
+        "name": "component-pattern",
+        "description": "component name, component id, component pattern, or relative directory path. use component pattern to select multiple components.\nwrap the pattern with quotes. use comma to separate patterns and \"!\" to exclude. e.g. \"ui/**, !ui/button\".\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern."
+      }
+    ],
+    "examples": [
+      {
+        "cmd": "undeprecate \"$deprecated\"",
+        "description": "undeprecate all currently-deprecated components"
+      }
+    ]
   },
   {
     "name": "git <sub-command>",

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -1733,7 +1733,7 @@
     ],
     "examples": [
       {
-        "cmd": "undeprecate \"$deprecated\"",
+        "cmd": "undeprecate '$deprecated'",
         "description": "undeprecate all currently-deprecated components"
       }
     ]

--- a/scopes/harmony/cli-reference/cli-reference.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.mdx
@@ -627,21 +627,22 @@ shows both direct and transitive dependents organized by their origin (workspace
 ## deprecate
 
 **Alias**: `d`  
-**Description**: mark a component as deprecated to discourage its use  
-marks a component as deprecated locally, then after snap/tag and export it becomes deprecated in the remote scope.  
-optionally specify a replacement component or deprecate only specific version ranges.  
+**Description**: mark components as deprecated to discourage their use  
+marks components as deprecated locally, then after snap/tag and export they become deprecated in the remote scope.  
+the pattern can match multiple components, so several can be deprecated at once.  
+optionally specify a replacement component (single component only) or deprecate only specific version ranges.  
 deprecated components remain available but display warnings when installed or imported.
 
-`bit deprecate <component-name>`
+`bit deprecate <component-pattern>`
 
-| **Arg**          |        **Description**         |
-| ---------------- | :----------------------------: |
-| `component-name` | component name or component id |
+| **Arg**             |                                                                                                                                                                                                                             **Description**                                                                                                                                                                                                                              |
+| ------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `component-pattern` | component name, component id, component pattern, or relative directory path. use component pattern to select multiple components. wrap the pattern with quotes. use comma to separate patterns and "!" to exclude. e.g. "ui/\*\*, !ui/button". use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern. |
 
-| **Option**          | **Option alias** | **Description**                                                                                                                   |
-| ------------------- | :--------------: | --------------------------------------------------------------------------------------------------------------------------------- |
-| `--new-id <string>` |                  | if replaced by another component, enter the new component id. alternatively use "bit rename --deprecate" to do this automatically |
-| `--range <string>`  |                  | enter a Semver range to deprecate specific versions. see https://www.npmjs.com/package/semver#ranges for the range syntax         |
+| **Option**          | **Option alias** | **Description**                                                                                                                                                                           |
+| ------------------- | :--------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--new-id <string>` |                  | if replaced by another component, enter the new component id. alternatively use "bit rename --deprecate" to do this automatically. only valid when the pattern matches a single component |
+| `--range <string>`  |                  | enter a Semver range to deprecate specific versions. see https://www.npmjs.com/package/semver#ranges for the range syntax                                                                 |
 
 ---
 
@@ -2812,10 +2813,15 @@ supports watch mode, coverage reporting, and debug mode for development workflow
 
 ## undeprecate
 
-**Description**: remove the deprecation status from a component  
-reverses the deprecation of a component, removing warnings and allowing normal use again.
+**Description**: remove the deprecation status from components  
+reverses the deprecation of components, removing warnings and allowing normal use again.  
+the pattern can match multiple components, so several can be undeprecated at once.
 
-`bit undeprecate <id>`
+`bit undeprecate <component-pattern>`
+
+| **Arg**             |                                                                                                                                                                                                                             **Description**                                                                                                                                                                                                                              |
+| ------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `component-pattern` | component name, component id, component pattern, or relative directory path. use component pattern to select multiple components. wrap the pattern with quotes. use comma to separate patterns and "!" to exclude. e.g. "ui/\*\*, !ui/button". use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern. |
 
 ---
 


### PR DESCRIPTION
`bit deprecate` and `bit undeprecate` previously accepted only a single component id. They now accept a component-pattern, so multiple components can be (un)deprecated at once — consistent with `bit remove`, `bit tag`, etc.

- Added `deprecateByPattern` / `unDeprecateByPattern` to the deprecation runtime. They resolve the pattern via `workspace.idsByPattern()` (backward-compatible with a plain single id), loop over matches, and write `.bitmap` once.
- Commands use the canonical `COMPONENT_PATTERN_HELP`, so wildcards, comma-lists, `!`-negation and `$`-state-filters work. Output keeps the familiar single-line message for one component and a sectioned summary for many.
- `--new-id` sets a single replacement, so it throws a clear error when the pattern matches more than one component.
- Single-id runtime methods (used by `bit rename` and the IDE API) are unchanged.
- Added e2e coverage for multi-deprecate, multi-undeprecate, and the `--new-id` guard.