### PR TITLE
fix(deprecation): reflect staged deprecation in bit log

### DIFF
--- a/e2e/harmony/deprecate.e2e.ts
+++ b/e2e/harmony/deprecate.e2e.ts
@@ -208,6 +208,16 @@ describe('bit deprecate and undeprecate commands', function () {
       });
     });
   });
+  describe('deprecate with an invalid --range', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+    });
+    it('should throw a clear error instead of persisting an invalid range', () => {
+      expect(() => helper.command.deprecateComponent('comp1', '--range "not-a-range"')).to.throw('invalid');
+    });
+  });
   describe('deprecating with --range when it overlaps the current version', () => {
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();

--- a/e2e/harmony/deprecate.e2e.ts
+++ b/e2e/harmony/deprecate.e2e.ts
@@ -180,6 +180,34 @@ describe('bit deprecate and undeprecate commands', function () {
       });
     });
   });
+  describe('deprecate previous versions with --range before snapping (staged)', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild(); // 0.0.1
+      helper.fixtures.populateComponents(1, undefined, 'version2');
+      helper.command.tagAllWithoutBuild(); // 0.0.2
+      // deprecate a previous version but intentionally do NOT snap/tag afterwards
+      helper.command.deprecateComponent('comp1', '--range 0.0.1');
+    });
+    it('bit log should show the in-range version as deprecated even before snapping', () => {
+      const log = helper.command.logParsed('comp1');
+      const v1 = log.find((l) => l.tag === '0.0.1');
+      const v2 = log.find((l) => l.tag === '0.0.2');
+      expect(v1.deprecated).to.be.true;
+      expect(v2.deprecated).to.be.false;
+    });
+    describe('un-deprecating before snapping', () => {
+      before(() => {
+        helper.command.undeprecateComponent('comp1');
+      });
+      it('bit log should no longer show the version as deprecated', () => {
+        const log = helper.command.logParsed('comp1');
+        const v1 = log.find((l) => l.tag === '0.0.1');
+        expect(v1.deprecated).to.be.false;
+      });
+    });
+  });
   describe('deprecating with --range when it overlaps the current version', () => {
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();

--- a/scopes/component/component-log/component-log.main.runtime.ts
+++ b/scopes/component/component-log/component-log.main.runtime.ts
@@ -4,7 +4,9 @@ import { ComponentID } from '@teambit/component-id';
 import type { LegacyComponentLog as ComponentLog } from '@teambit/legacy-component-log';
 import path from 'path';
 import moment from 'moment';
+import semver from 'semver';
 import pMap from 'p-map';
+import { Extensions } from '@teambit/legacy.constants';
 import type { Workspace } from '@teambit/workspace';
 import { WorkspaceAspect, OutsideWorkspaceError } from '@teambit/workspace';
 import { compact } from 'lodash';
@@ -89,7 +91,26 @@ export class ComponentLogMain {
       log.date = log.date ? moment(new Date(parseInt(log.date))).format('YYYY-MM-DD HH:mm:ss') : undefined;
       log.message = shortMessage ? log.message.split('\n')[0] : log.message;
     });
+    this.applyStagedDeprecation(componentId, logs);
     return options.showHidden ? logs : logs.filter((l) => !l.hidden);
+  }
+
+  /**
+   * reflect the not-yet-snapped (staged) deprecation in the log.
+   * `bit deprecate` only writes the deprecation config to the workspace `.bitmap`; it's baked into a
+   * Version object on the next tag/snap. `collectLogs()` (which produces the `deprecated` field) reads
+   * that config from the committed head Version, so without this overlay `bit log` wouldn't show a
+   * range-deprecation until the next tag/snap. We mirror collectLogs' range logic here so the staged
+   * state (including a staged `bit undeprecate` that clears the range) matches the post-snap output.
+   */
+  private applyStagedDeprecation(componentId: ComponentID, logs: ComponentLog[]) {
+    const bitmapEntry = this.workspace?.bitMap.getBitmapEntryIfExist(componentId, { ignoreVersion: true });
+    const stagedConfig = bitmapEntry?.config?.[Extensions.deprecation];
+    if (!stagedConfig || stagedConfig === '-') return;
+    const range = (stagedConfig as { range?: string }).range;
+    logs.forEach((log) => {
+      log.deprecated = Boolean(range && log.tag && semver.satisfies(log.tag, range));
+    });
   }
 
   async getLogsWithParents(id: string, options: LogOpts) {

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -1,6 +1,7 @@
 import type { CLIMain } from '@teambit/cli';
 import { CLIAspect, MainRuntime } from '@teambit/cli';
 import semver from 'semver';
+import { BitError } from '@teambit/bit-error';
 import type { ComponentMain, Component } from '@teambit/component';
 import { ComponentAspect, ComponentID } from '@teambit/component';
 import type { ScopeMain } from '@teambit/scope';
@@ -94,6 +95,11 @@ export class DeprecationMain {
    * @returns boolean whether or not the component has been deprecated
    */
   async deprecate(componentId: ComponentID, newId?: ComponentID, range?: string): Promise<boolean> {
+    if (range && !semver.validRange(range)) {
+      throw new BitError(
+        `the range "${range}" is invalid. see https://www.npmjs.com/package/semver#ranges for the range syntax`
+      );
+    }
     const results = this.workspace.bitMap.addComponentConfig(componentId, DeprecationAspect.id, {
       deprecate: !range,
       newId: newId?.toObject(),


### PR DESCRIPTION
`bit log` only showed deprecation data after a tag/snap. Running `bit deprecate --range` and then `bit log` (before snapping) did not mark the in-range versions as deprecated.

**Cause:** the per-version `deprecated` field is computed in `ModelComponent.collectLogs()` from the committed head `Version` object. `bit deprecate` only writes the config to `.bitmap`, which is baked into a `Version` on the next tag/snap — so before snapping there's nothing for `collectLogs` to read. (`bit show` reads the live component config and reflected it immediately, hence the inconsistency.)

**Fix:** overlay the staged `.bitmap` deprecation config in `ComponentLogMain.getLogs()`, mirroring `collectLogs`' range logic, so pre-snap `bit log` matches post-snap (and a staged `bit undeprecate` clears it).

Scoped to the `--range` case; whole-component (no-range) deprecation is not surfaced per-version in `bit log` either before or after snap today, so it's left unchanged.

Added an e2e test covering staged deprecate + undeprecate before snapping.