### PR TITLE
fix(deprecation): show deprecated range in deprecate command output

### DIFF
--- a/scopes/component/deprecation/deprecate-cmd.ts
+++ b/scopes/component/deprecation/deprecate-cmd.ts
@@ -33,9 +33,15 @@ deprecated components remain available but display warnings when installed or im
   async report([id]: [string], { newId, range }: { newId?: string; range?: string }): Promise<string> {
     const result = await this.deprecate(id, newId, range);
     if (result) {
-      return formatSuccessSummary(`the component "${id}" has been deprecated successfully`);
+      const successMessage = range
+        ? `versions of "${id}" matching the range "${range}" have been deprecated successfully`
+        : `the component "${id}" has been deprecated successfully`;
+      return formatSuccessSummary(successMessage);
     }
-    return formatHint(`the component "${id}" is already deprecated. no changes have been made`);
+    const hintMessage = range
+      ? `the range "${range}" of "${id}" is already deprecated. no changes have been made`
+      : `the component "${id}" is already deprecated. no changes have been made`;
+    return formatHint(hintMessage);
   }
 
   private async deprecate(id: string, newId?: string, range?: string): Promise<boolean> {


### PR DESCRIPTION
When `bit deprecate <component> --range <semver>` was used, the output always said `the component "X" has been deprecated successfully` — identical to a full-component deprecation. This was misleading since only versions matching the range are deprecated.

The output now reflects the range:
- Success: `versions of "X" matching the range "<range>" have been deprecated successfully`
- Already deprecated: `the range "<range>" of "X" is already deprecated. no changes have been made`

Without `--range`, the messages are unchanged.