### PR TITLE
docs(host-initializer): document bit ripple in generated agent instructions

### DIFF
--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -101,7 +101,7 @@ bit validate                         # lint + type-check + tests (fast build) �
 bit test                             # run tests only
 bit lint                             # run linter only
 bit check-types                      # TypeScript type checker only
-bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — list/log/errors/retry/stop (the CI jobs that build and export components)
+bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — list/log/errors/retry/stop (jobs that build components in the cloud after export)
 ```
 
 > **Never run `bit build`** unless absolutely necessary. Always use `bit validate` instead — it's faster and sufficient.

--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -101,6 +101,7 @@ bit validate                         # lint + type-check + tests (fast build) �
 bit test                             # run tests only
 bit lint                             # run linter only
 bit check-types                      # TypeScript type checker only
+bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — list/log/errors/retry/stop (the CI jobs that build and export components)
 ```
 
 > **Never run `bit build`** unless absolutely necessary. Always use `bit validate` instead — it's faster and sufficient.
@@ -244,6 +245,8 @@ git push                                 # push your branch
 ```
 
 > Focus on development workflows: component creation, modification, testing, and local validation. Leave versioning and publishing to CI.
+
+Those CI builds run as Ripple CI jobs on bit.cloud. Use `bit ripple list` to see recent jobs, `bit ripple log` to follow one, and `bit ripple errors` to inspect build failures.
 
 ---
 

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -99,6 +99,7 @@ bit validate                         # lint + type-check + tests (fast build) �
 bit test                             # run tests only
 bit lint                             # run linter only
 bit check-types                      # TypeScript type checker only
+bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — list/log/errors/retry/stop (jobs that build components in the cloud after export)
 ```
 
 > **Never run `bit build`** unless absolutely necessary. Always use `bit validate` instead — it's faster and sufficient.
@@ -235,6 +236,8 @@ bit export                           # push lane to remote
 ```
 
 > Always run `bit lane create` first. If you're already on a non-main lane, continue using it — don't create a new one.
+
+After exporting, components are built in the cloud by Ripple CI. Use `bit ripple log` to follow the current lane's job and `bit ripple errors` to inspect any build failures (or `bit ripple retry` to re-run it).
 
 ---
 


### PR DESCRIPTION
The CLAUDE.md (and cursor/copilot) agent instructions generated during `bit init` had no mention of `bit ripple`, so AI agents working in a Bit workspace didn't know the command exists.

This adds it to both agent templates (`agents-template.md` and the Git-integrated `agents-template-git.md`):
- **Common Commands** — a one-line entry: manage Ripple CI jobs on bit.cloud (list/log/errors/retry/stop).
- **Publishing section** — a contextual note. The non-Git template points to `bit ripple log`/`errors`/`retry` after `bit export`; the Git template points to `bit ripple list`/`log`/`errors` for monitoring the CI jobs that run snap/export on merge.