### PR TITLE
fix(remove): pin deleted-on-lane deps to main version in workspace policy

### DIFF
--- a/e2e/harmony/delete.e2e.ts
+++ b/e2e/harmony/delete.e2e.ts
@@ -60,6 +60,77 @@ describe('bit delete command', function () {
       });
     }
   );
+  /**
+   * the previous test needed a manual "bit install <comp2-pkg>" so the next install wouldn't fail with
+   * "No matching version found for <comp2>@0.0.0-<snap>" (the lane snap was never published). deleting on a
+   * lane now auto-pins such components (that still have dependents in the workspace) to their main version
+   * in the workspace policy, so a plain "bit install" resolves them from main with no manual step.
+   */
+  (supportNpmCiRegistryTesting ? describe : describe.skip)(
+    'deleting a component on a lane that still has dependents in the workspace',
+    () => {
+      let comp2PkgName: string;
+      before(async () => {
+        helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+        helper.scopeHelper.setWorkspaceWithRemoteScope();
+        helper.fixtures.populateComponents(2); // comp1 -> comp2
+        comp2PkgName = helper.general.getPackageNameByCompName('comp2');
+        npmCiRegistry = new NpmCiRegistry(helper);
+        npmCiRegistry.configureCiInPackageJsonHarmony();
+        await npmCiRegistry.init();
+        helper.command.tagAllComponents(); // main: comp1@0.0.1, comp2@0.0.1
+        helper.command.export();
+        helper.command.createLane();
+        helper.command.snapAllComponentsWithoutBuild('--unmodified'); // lane snaps
+        helper.command.export();
+        helper.command.softRemoveOnLane('comp2'); // comp2 still has a dependent in the ws: comp1
+      });
+      after(() => {
+        npmCiRegistry.destroy();
+      });
+      it('should pin the deleted component to its main version in the workspace policy', () => {
+        const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+        expect(policy.dependencies).to.have.property(comp2PkgName);
+        // it should be the published main version (0.0.1), not the non-published lane snap (0.0.0-<hash>)
+        expect(policy.dependencies[comp2PkgName]).to.have.string('0.0.1');
+        expect(policy.dependencies[comp2PkgName]).to.not.have.string('0.0.0-');
+      });
+      it('a plain "bit install" should succeed without the manual "bit install <pkg>" workaround', () => {
+        expect(() => helper.command.install()).to.not.throw();
+      });
+      it('bit status should not show RemovedDependencies issues', () => {
+        helper.command.expectStatusToNotHaveIssue(IssuesClasses.RemovedDependencies.name);
+      });
+    }
+  );
+  (supportNpmCiRegistryTesting ? describe : describe.skip)(
+    'deleting a component on a lane that has no dependents in the workspace',
+    () => {
+      let comp1PkgName: string;
+      before(async () => {
+        helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+        helper.scopeHelper.setWorkspaceWithRemoteScope();
+        helper.fixtures.populateComponents(2); // comp1 -> comp2, nothing depends on comp1
+        comp1PkgName = helper.general.getPackageNameByCompName('comp1');
+        npmCiRegistry = new NpmCiRegistry(helper);
+        npmCiRegistry.configureCiInPackageJsonHarmony();
+        await npmCiRegistry.init();
+        helper.command.tagAllComponents();
+        helper.command.export();
+        helper.command.createLane();
+        helper.command.snapAllComponentsWithoutBuild('--unmodified');
+        helper.command.export();
+        helper.command.softRemoveOnLane('comp1');
+      });
+      after(() => {
+        npmCiRegistry.destroy();
+      });
+      it('should not add the deleted component to the workspace policy (no dependents to fix)', () => {
+        const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+        expect(policy?.dependencies || {}).to.not.have.property(comp1PkgName);
+      });
+    }
+  );
   describe('import a scope with deleted components', () => {
     before(() => {
       helper = new Helper();

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -189,17 +189,17 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
     const isLaneSoftDelete = Boolean(currentLane) && !updateMain && !opts.range && !opts.snaps;
     // best-effort: never let this convenience break the actual deletion. on failure the user can still
     // recover via the manual "bit install <pkg>" workaround.
-    const depsToPinToMain = isLaneSoftDelete
-      ? await this.getDeletedDepsWithWorkspaceDependents(componentIds).catch((err) => {
-          this.logger.warn(`getDeletedDepsWithWorkspaceDependents failed: ${err.message}`);
+    const packagesToPinToMain = isLaneSoftDelete
+      ? await this.getDeletedPackagesWithWorkspaceDependents(componentIds).catch((err) => {
+          this.logger.warn(`getDeletedPackagesWithWorkspaceDependents failed: ${err.message}`);
           return [];
         })
       : [];
 
     const removedComps = await this.markRemoveComps(componentIds, opts);
 
-    if (depsToPinToMain.length) {
-      await this.pinDeletedDepsToMainInWorkspacePolicy(depsToPinToMain).catch((err) => {
+    if (packagesToPinToMain.length) {
+      await this.pinDeletedDepsToMainInWorkspacePolicy(packagesToPinToMain).catch((err) => {
         this.logger.warn(`pinDeletedDepsToMainInWorkspacePolicy failed: ${err.message}`);
       });
     }
@@ -208,12 +208,10 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
   }
 
   /**
-   * out of the given deleted ids, return those that still have at least one dependent in the workspace
-   * (excluding other components being deleted in the same operation), along with their package names.
+   * out of the given deleted ids, return the package names of those that still have at least one dependent
+   * in the workspace (excluding other components being deleted in the same operation).
    */
-  private async getDeletedDepsWithWorkspaceDependents(
-    deletedIds: ComponentID[]
-  ): Promise<Array<{ id: ComponentID; packageName: string }>> {
+  private async getDeletedPackagesWithWorkspaceDependents(deletedIds: ComponentID[]): Promise<string[]> {
     const graph = await this.workspace.getGraphIds(undefined, false);
     const deletedIdList = ComponentIdList.fromArray(deletedIds);
     const idsWithDependents = deletedIds.filter((id) => {
@@ -224,21 +222,19 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
     });
     if (!idsWithDependents.length) return [];
     const comps = await this.workspace.getMany(idsWithDependents);
-    return comps.map((comp) => ({ id: comp.id, packageName: this.depResolver.getPackageName(comp) }));
+    return comps.map((comp) => this.depResolver.getPackageName(comp));
   }
 
   /**
-   * pin the given (deleted-on-lane) components to their main/published version in the workspace policy, so their
-   * dependents install them from the registry instead of the non-published lane snap version. components that were
+   * pin the given (deleted-on-lane) packages to their main/published version in the workspace policy, so their
+   * dependents install them from the registry instead of the non-published lane snap version. packages that were
    * never published to the registry (e.g. they only ever existed on the lane) are skipped.
    */
-  private async pinDeletedDepsToMainInWorkspacePolicy(
-    deps: Array<{ id: ComponentID; packageName: string }>
-  ): Promise<void> {
+  private async pinDeletedDepsToMainInWorkspacePolicy(packageNames: string[]): Promise<void> {
     const resolver = await this.depResolver.getVersionResolver();
     const entries: WorkspacePolicyEntry[] = [];
     await Promise.all(
-      deps.map(async ({ packageName }) => {
+      packageNames.map(async (packageName) => {
         const resolved = await resolver
           .resolveRemoteVersion(packageName, { rootDir: this.workspace.path })
           .catch(() => undefined);

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -1,5 +1,5 @@
 import type { CLIMain } from '@teambit/cli';
-import { CLIAspect, MainRuntime } from '@teambit/cli';
+import { CLIAspect, MainRuntime, formatSection, formatItem } from '@teambit/cli';
 import semver from 'semver';
 import type { Logger, LoggerMain } from '@teambit/logger';
 import { LoggerAspect } from '@teambit/logger';
@@ -263,9 +263,13 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
     // skipIfExisting so we never override a version the user already set explicitly in the workspace policy.
     this.depResolver.addToRootPolicy(entries, { skipIfExisting: true });
     await this.depResolver.persistConfig('delete (pin deleted-on-lane deps to main)');
+    const items = entries.map((entry) => formatItem(`${entry.dependencyId}@${entry.value.version}`));
     this.logger.console(
-      `the following deleted component(s) still have dependents in the workspace and were pinned to their main version in the workspace policy:
-${entries.map((entry) => `${entry.dependencyId}@${entry.value.version}`).join('\n')}`
+      formatSection(
+        'pinned deleted components to their main version',
+        'these components were deleted from the lane but still have dependents in the workspace, so they were added to the workspace policy to be installed from main',
+        items
+      )
     );
   }
 

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -210,6 +210,9 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
   /**
    * out of the given deleted ids, return the package names of those that still have at least one dependent
    * in the workspace (excluding other components being deleted in the same operation).
+   * envs are excluded on purpose: a deleted env surfaces as a "RemovedEnv" issue so the user can replace it
+   * explicitly (bit env replace), and we don't want to silently pin it to its main version and suppress that
+   * signal. only regular dependencies (e.g. a dependency of an env) need pinning so they install from main.
    */
   private async getDeletedPackagesWithWorkspaceDependents(deletedIds: ComponentID[]): Promise<string[]> {
     const graph = await this.workspace.getGraphIds(undefined, false);
@@ -221,7 +224,10 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
       return dependents.length > 0;
     });
     if (!idsWithDependents.length) return [];
-    const comps = await this.workspace.getMany(idsWithDependents);
+    const isEnvFlags = await Promise.all(idsWithDependents.map((id) => this.isEnvByIdWithoutLoadingComponent(id)));
+    const nonEnvIds = idsWithDependents.filter((_id, index) => !isEnvFlags[index]);
+    if (!nonEnvIds.length) return [];
+    const comps = await this.workspace.getMany(nonEnvIds);
     return comps.map((comp) => this.depResolver.getPackageName(comp));
   }
 

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -12,7 +12,7 @@ import { ImporterAspect } from '@teambit/importer';
 import { compact } from 'lodash';
 import { hasWildcard } from '@teambit/legacy.utils';
 import { BitError } from '@teambit/bit-error';
-import type { DependencyResolverMain } from '@teambit/dependency-resolver';
+import type { DependencyResolverMain, WorkspacePolicyEntry } from '@teambit/dependency-resolver';
 import { DependencyResolverAspect } from '@teambit/dependency-resolver';
 import { IssuesClasses } from '@teambit/component-issues';
 import type { IssuesMain } from '@teambit/issues';
@@ -180,7 +180,93 @@ to delete them eventually from main, use "--update-main" flag and make sure to r
         );
       }
     }
-    return this.markRemoveComps(componentIds, opts);
+
+    // when soft-deleting from a lane, components that still have dependents in the workspace will keep
+    // referencing the now-deleted lane snap version (0.0.0-<hash>), which was never published to the registry.
+    // to avoid a "No matching version found" error on the next "bit install", pin those components to their
+    // main (published) version in the workspace policy - mirroring what running "bit install <pkg>" does manually.
+    // this must be computed before the removal so the dependency graph is still intact.
+    const isLaneSoftDelete = Boolean(currentLane) && !updateMain && !opts.range && !opts.snaps;
+    // best-effort: never let this convenience break the actual deletion. on failure the user can still
+    // recover via the manual "bit install <pkg>" workaround.
+    const depsToPinToMain = isLaneSoftDelete
+      ? await this.getDeletedDepsWithWorkspaceDependents(componentIds).catch((err) => {
+          this.logger.warn(`getDeletedDepsWithWorkspaceDependents failed: ${err.message}`);
+          return [];
+        })
+      : [];
+
+    const removedComps = await this.markRemoveComps(componentIds, opts);
+
+    if (depsToPinToMain.length) {
+      await this.pinDeletedDepsToMainInWorkspacePolicy(depsToPinToMain).catch((err) => {
+        this.logger.warn(`pinDeletedDepsToMainInWorkspacePolicy failed: ${err.message}`);
+      });
+    }
+
+    return removedComps;
+  }
+
+  /**
+   * out of the given deleted ids, return those that still have at least one dependent in the workspace
+   * (excluding other components being deleted in the same operation), along with their package names.
+   */
+  private async getDeletedDepsWithWorkspaceDependents(
+    deletedIds: ComponentID[]
+  ): Promise<Array<{ id: ComponentID; packageName: string }>> {
+    const graph = await this.workspace.getGraphIds(undefined, false);
+    const deletedIdList = ComponentIdList.fromArray(deletedIds);
+    const idsWithDependents = deletedIds.filter((id) => {
+      const dependents = graph.predecessors(id.toString(), {
+        nodeFilter: (node) => this.workspace.hasId(node.attr) && !deletedIdList.hasWithoutVersion(node.attr),
+      });
+      return dependents.length > 0;
+    });
+    if (!idsWithDependents.length) return [];
+    const comps = await this.workspace.getMany(idsWithDependents);
+    return comps.map((comp) => ({ id: comp.id, packageName: this.depResolver.getPackageName(comp) }));
+  }
+
+  /**
+   * pin the given (deleted-on-lane) components to their main/published version in the workspace policy, so their
+   * dependents install them from the registry instead of the non-published lane snap version. components that were
+   * never published to the registry (e.g. they only ever existed on the lane) are skipped.
+   */
+  private async pinDeletedDepsToMainInWorkspacePolicy(
+    deps: Array<{ id: ComponentID; packageName: string }>
+  ): Promise<void> {
+    const resolver = await this.depResolver.getVersionResolver();
+    const entries: WorkspacePolicyEntry[] = [];
+    await Promise.all(
+      deps.map(async ({ packageName }) => {
+        const resolved = await resolver
+          .resolveRemoteVersion(packageName, { rootDir: this.workspace.path })
+          .catch(() => undefined);
+        if (!resolved?.version) {
+          this.logger.warn(
+            `pinDeletedDepsToMainInWorkspacePolicy: unable to resolve a published version for ${packageName}, skipping`
+          );
+          return;
+        }
+        const versionWithPrefix = this.depResolver.getVersionWithSavePrefix({
+          version: resolved.version,
+          wantedRange: resolved.wantedRange,
+        });
+        entries.push({
+          dependencyId: packageName,
+          value: { version: versionWithPrefix },
+          lifecycleType: 'runtime',
+        });
+      })
+    );
+    if (!entries.length) return;
+    // skipIfExisting so we never override a version the user already set explicitly in the workspace policy.
+    this.depResolver.addToRootPolicy(entries, { skipIfExisting: true });
+    await this.depResolver.persistConfig('delete (pin deleted-on-lane deps to main)');
+    this.logger.console(
+      `the following deleted component(s) still have dependents in the workspace and were pinned to their main version in the workspace policy:
+${entries.map((entry) => `${entry.dependencyId}@${entry.value.version}`).join('\n')}`
+    );
   }
 
   /**


### PR DESCRIPTION
### Problem
After `bit delete <comp> --lane`, a follow-up `bit install` fails with:

```
No matching version found for @org/ui.button@0.0.0-<snaphash>
```

Components that still depend on the deleted one keep referencing its **lane snap version** (`0.0.0-<hash>`), which was never published to the registry. Since the deleted component is no longer a workspace component, `bit install` tries to fetch that snap from the registry and fails. It surfaces loudly for envs because the env is isolated into the `envs-update` capsule and installed there.

The known workaround was to manually run `bit install <pkg>`, which adds the package to the workspace policy so it resolves from main — confusing and non-obvious.

### Fix
On a lane-only soft-delete, components that still have dependents in the workspace are now pinned to their **main (published) version** in the workspace policy automatically, so a plain `bit install` resolves them from main. This mirrors what `bit lane eject` already does (`deleteComps()` + `install(packages)`), minus the forced install.

- Gated to deps that actually have a surviving workspace dependent, so leaf deletions don't pollute `workspace.jsonc`.
- Skips components with no published main version.
- Best-effort: a failure never blocks the delete (manual workaround still available).

### Tests
Registry-backed e2e in `delete.e2e.ts`:
- deleted comp is pinned to its main version (not the lane snap)
- a plain `bit install` succeeds without the manual step
- `bit status` shows no `RemovedDependencies` issue
- deleting a comp with no dependents does not add it to the policy
