### PR TITLE
chore: bump @teambit/harmony to 0.4.11

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -25,9 +25,8 @@ import { CLIAspect, MainRuntime } from '@teambit/cli';
 import { ConfigAspect, ConfigRuntime } from '@teambit/config';
 import type { RuntimeDefinition, Extension, Aspect } from '@teambit/harmony';
 import { Harmony } from '@teambit/harmony';
-// TODO: expose this types from harmony (once we have a way to expose it only for node)
-import { Config } from '@teambit/harmony/dist/harmony-config';
-import { readConfigFile } from '@teambit/harmony/dist/harmony-config/config-reader';
+import { Config } from '@teambit/harmony/harmony-config';
+import { readConfigFile } from '@teambit/harmony/harmony-config/config-reader';
 import { VERSION_DELIMITER } from '@teambit/legacy-bit-id';
 import { loadConsumer } from '@teambit/legacy.consumer';
 import type { WorkspaceInfo } from '@teambit/workspace.modules.workspace-locator';

--- a/scopes/harmony/testing/load-aspect/load-aspect.ts
+++ b/scopes/harmony/testing/load-aspect/load-aspect.ts
@@ -5,9 +5,8 @@ import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 import { readdirSync, readFileSync } from 'fs';
 import type { Aspect, Extension } from '@teambit/harmony';
 import { Harmony } from '@teambit/harmony';
-// TODO: expose this types from harmony (once we have a way to expose it only for node)
-import type { ConfigOptions } from '@teambit/harmony/dist/harmony-config';
-import { Config } from '@teambit/harmony/dist/harmony-config';
+import type { ConfigOptions } from '@teambit/harmony/harmony-config';
+import { Config } from '@teambit/harmony/harmony-config';
 import { ComponentID } from '@teambit/component';
 import { CLIAspect } from '@teambit/cli';
 import { NodeAspect } from '@teambit/node';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -285,7 +285,7 @@
         "@teambit/git.modules.git-ignore": "^1.0.2",
         "@teambit/gitconfig": "2.0.10",
         "@teambit/graph.cleargraph": "0.0.11",
-        "@teambit/harmony": "0.4.10",
+        "@teambit/harmony": "0.4.11",
         "@teambit/html.modules.inject-html-element": "0.0.6",
         "@teambit/lane-id": "~0.0.312",
         "@teambit/lanes.ui.compare.lane-compare": "^0.0.206",
@@ -695,7 +695,7 @@
       "@teambit/base-react.navigation.link@2": "2.0.33",
       "lodash@4": "4.17.21",
       "trim@0": "0.0.3",
-      "@teambit/harmony": "0.4.10",
+      "@teambit/harmony": "0.4.11",
       "@types/fs-capacitor": "2.0.0",
       // @types/node is used as a peer dependency, so to reduce duplication,
       // we force the version installed in the root.

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -285,7 +285,7 @@
         "@teambit/git.modules.git-ignore": "^1.0.2",
         "@teambit/gitconfig": "2.0.10",
         "@teambit/graph.cleargraph": "0.0.11",
-        "@teambit/harmony": "0.4.7",
+        "@teambit/harmony": "0.4.8",
         "@teambit/html.modules.inject-html-element": "0.0.6",
         "@teambit/lane-id": "~0.0.312",
         "@teambit/lanes.ui.compare.lane-compare": "^0.0.206",
@@ -695,7 +695,7 @@
       "@teambit/base-react.navigation.link@2": "2.0.33",
       "lodash@4": "4.17.21",
       "trim@0": "0.0.3",
-      "@teambit/harmony": "0.4.7",
+      "@teambit/harmony": "0.4.8",
       "@types/fs-capacitor": "2.0.0",
       // @types/node is used as a peer dependency, so to reduce duplication,
       // we force the version installed in the root.

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -285,7 +285,7 @@
         "@teambit/git.modules.git-ignore": "^1.0.2",
         "@teambit/gitconfig": "2.0.10",
         "@teambit/graph.cleargraph": "0.0.11",
-        "@teambit/harmony": "0.4.9",
+        "@teambit/harmony": "0.4.10",
         "@teambit/html.modules.inject-html-element": "0.0.6",
         "@teambit/lane-id": "~0.0.312",
         "@teambit/lanes.ui.compare.lane-compare": "^0.0.206",
@@ -695,7 +695,7 @@
       "@teambit/base-react.navigation.link@2": "2.0.33",
       "lodash@4": "4.17.21",
       "trim@0": "0.0.3",
-      "@teambit/harmony": "0.4.9",
+      "@teambit/harmony": "0.4.10",
       "@types/fs-capacitor": "2.0.0",
       // @types/node is used as a peer dependency, so to reduce duplication,
       // we force the version installed in the root.

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -285,7 +285,7 @@
         "@teambit/git.modules.git-ignore": "^1.0.2",
         "@teambit/gitconfig": "2.0.10",
         "@teambit/graph.cleargraph": "0.0.11",
-        "@teambit/harmony": "0.4.8",
+        "@teambit/harmony": "0.4.9",
         "@teambit/html.modules.inject-html-element": "0.0.6",
         "@teambit/lane-id": "~0.0.312",
         "@teambit/lanes.ui.compare.lane-compare": "^0.0.206",
@@ -695,7 +695,7 @@
       "@teambit/base-react.navigation.link@2": "2.0.33",
       "lodash@4": "4.17.21",
       "trim@0": "0.0.3",
-      "@teambit/harmony": "0.4.8",
+      "@teambit/harmony": "0.4.9",
       "@types/fs-capacitor": "2.0.0",
       // @types/node is used as a peer dependency, so to reduce duplication,
       // we force the version installed in the root.


### PR DESCRIPTION
Bumps `@teambit/harmony` to `0.4.11`, which exposes `harmony-config` and `harmony-config/config-reader` as `node`-conditional subpaths in its `package.json` `exports`, and updates the two bit2 source files that were importing through the internal `./dist/...` path (with a `TODO: expose this types from harmony` comment) to use the new clean subpaths. Browser bundlers still can't pull in `harmony-config` because of the `node` condition.

- `scopes/harmony/bit/load-bit.ts`
- `scopes/harmony/testing/load-aspect/load-aspect.ts`