### PR TITLE
fix(isolator): isolate cyclic dependencies of seeders to avoid registry fetch

### DIFF
--- a/e2e/harmony/isolate-cyclic-deps.e2e.ts
+++ b/e2e/harmony/isolate-cyclic-deps.e2e.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+describe('isolating cyclic dependencies', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  // Regression for the Ripple circular-dependency build failure. Seeders-only isolation (used by
+  // `bit sign` and tag/snap-from-scope) installs non-seeder dependencies as packages from the
+  // registry. A dependency that is in a cycle with a seeder can't be installed that way — its
+  // snap-version isn't published — so the isolator must pull it into the isolation as a capsule.
+  describe('two components requiring each other, isolated seeders-only', () => {
+    let capsuleIds: string[];
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fs.outputFile('comp1/index.js', `require('@${helper.scopes.remote}/comp2');`);
+      helper.fs.outputFile('comp2/index.js', `require('@${helper.scopes.remote}/comp1');`);
+      helper.command.addComponent('comp1');
+      helper.command.addComponent('comp2');
+      helper.command.install();
+      helper.command.tagAllWithoutBuild('--ignore-issues="CircularDependencies"');
+      const output = helper.command.runCmd('bit capsule create comp2 --seeders-only -j');
+      capsuleIds = JSON.parse(output).map((capsule: { id: string }) => capsule.id.split('@')[0]);
+    });
+    it('should isolate the cyclic dependency as a capsule, not only the seeder', () => {
+      expect(capsuleIds).to.include(`${helper.scopes.remote}/comp1`);
+      expect(capsuleIds).to.include(`${helper.scopes.remote}/comp2`);
+    });
+  });
+});

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -438,9 +438,11 @@ export class IsolatorMain {
       // package) even when they're built and exported: a cyclic dep references back into the
       // seeders, whose snap-version package isn't published yet, so the capsule install would
       // try to fetch an unpublished snap from the registry and fail (the Ripple circular-deps
-      // build failure). Keep every component in a seeder cycle as a real capsule. (the graph is
-      // seeded with the seeders, so findCycles() already scopes to cycles that involve them.)
-      const idsInCycle = new Set(graph.findCycles().flat());
+      // build failure). Keep every component that is part of a cycle as a real capsule. The graph
+      // here only spans the seeders and their dependencies, so any cycle in it is relevant. Pass
+      // includeDeps=true so cycle detection doesn't depend on matching the (possibly versionless)
+      // seeder ids against the graph's versioned node ids.
+      const idsInCycle = new Set(graph.findCycles(undefined, true).flat());
       filteredComps = await this.filterUnmodifiedExportedDependencies(filteredComps, seeders, host, idsInCycle);
       this.logger.debug(
         `[OPTIMIZATION] Before filtering: ${componentsToInclude.length}. After filtering: ${filteredComps.length} components remaining`
@@ -467,8 +469,11 @@ export class IsolatorMain {
     const host = opts.host || this.componentAspect.getHost();
     const getGraphOpts = pick(opts, ['host']);
     const graph = await this.graph.getGraphIds(seeders, getGraphOpts);
-    // the graph is seeded with the seeders, so findCycles() returns only cycles that involve them.
-    const cyclicIds = new Set<string>(graph.findCycles().flat());
+    // the graph only spans the seeders and their dependencies, so any cycle in it is a cycle a
+    // seeder participates in. Pass includeDeps=true so detection doesn't rely on matching the
+    // (possibly versionless) seeder ids against the graph's versioned node ids — otherwise a
+    // seeder-involving cycle can be missed and its members get installed from the registry again.
+    const cyclicIds = new Set<string>(graph.findCycles(undefined, true).flat());
     if (cyclicIds.size === 0) return [];
     const alreadyIsolatedIds = new Set(alreadyIsolated.map((comp) => comp.id.toString()));
     const idsToAdd = [...cyclicIds]

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -368,10 +368,12 @@ export class IsolatorMain {
     let componentsToIsolate = opts.seedersOnly
       ? await host.getMany(seeders)
       : await this.createGraph(seeders, createGraphOpts);
-    if (opts.seedersOnly) {
-      // seedersOnly skips the dependency graph and installs deps as packages from the registry.
-      // Dependencies that are in a cycle with a seeder can't be installed that way (their
-      // snap-version isn't published yet), so pull them into the isolation as capsules.
+    // seedersOnly skips the dependency graph and installs deps as packages from the registry.
+    // A dependency in a cycle with a seeder can't be installed that way (its snap-version isn't
+    // published yet), so pull it into the isolation as a capsule. Skip this for aspect isolation:
+    // aspects are loaded from already-published packages and pulling cyclic aspect deps in only
+    // forces loading envs that aren't installed in that context.
+    if (opts.seedersOnly && !opts.context?.aspects) {
       const cyclicDeps = await this.getCyclicDependenciesOfSeeders(seeders, componentsToIsolate, createGraphOpts);
       if (cyclicDeps.length) {
         this.logger.debug(`isolateComponents, adding ${cyclicDeps.length} cyclic dependencies of the seeders`);
@@ -434,16 +436,7 @@ export class IsolatorMain {
 
     // Optimization: exclude unmodified exported dependencies from capsule creation
     if (!isFeatureEnabled(DISABLE_CAPSULE_OPTIMIZATION)) {
-      // Components participating in a dependency cycle must never be excluded (installed as a
-      // package) even when they're built and exported: a cyclic dep references back into the
-      // seeders, whose snap-version package isn't published yet, so the capsule install would
-      // try to fetch an unpublished snap from the registry and fail (the Ripple circular-deps
-      // build failure). Keep every component that is part of a cycle as a real capsule. The graph
-      // here only spans the seeders and their dependencies, so any cycle in it is relevant. Pass
-      // includeDeps=true so cycle detection doesn't depend on matching the (possibly versionless)
-      // seeder ids against the graph's versioned node ids.
-      const idsInCycle = new Set(graph.findCycles(undefined, true).flat());
-      filteredComps = await this.filterUnmodifiedExportedDependencies(filteredComps, seeders, host, idsInCycle);
+      filteredComps = await this.filterUnmodifiedExportedDependencies(filteredComps, seeders, host);
       this.logger.debug(
         `[OPTIMIZATION] Before filtering: ${componentsToInclude.length}. After filtering: ${filteredComps.length} components remaining`
       );
@@ -1545,8 +1538,7 @@ export class IsolatorMain {
   private async filterUnmodifiedExportedDependencies(
     components: Component[],
     seederIds: ComponentID[],
-    host: ComponentFactory,
-    idsInCycle: Set<string> = new Set()
+    host: ComponentFactory
   ): Promise<Component[]> {
     this.logger.debug(`filterUnmodifiedExportedDependencies: filtering ${components.length} components`);
 
@@ -1562,15 +1554,6 @@ export class IsolatorMain {
 
       if (isSeeder) {
         // Always include seeders (modified components and their dependents)
-        filtered.push(component);
-        continue;
-      }
-
-      // A dependency that is part of a dependency cycle must keep its capsule. Excluding it
-      // (to install as a package) would make the capsule install resolve the cyclic
-      // back-reference to a seeder's snap-version from the registry, where it isn't published
-      // yet — the Ripple circular-dependency build failure.
-      if (idsInCycle.has(component.id.toString())) {
         filtered.push(component);
         continue;
       }

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -365,9 +365,19 @@ export class IsolatorMain {
       )}`
     );
     const createGraphOpts = pick(opts, ['includeFromNestedHosts', 'host']);
-    const componentsToIsolate = opts.seedersOnly
+    let componentsToIsolate = opts.seedersOnly
       ? await host.getMany(seeders)
       : await this.createGraph(seeders, createGraphOpts);
+    if (opts.seedersOnly) {
+      // seedersOnly skips the dependency graph and installs deps as packages from the registry.
+      // Dependencies that are in a cycle with a seeder can't be installed that way (their
+      // snap-version isn't published yet), so pull them into the isolation as capsules.
+      const cyclicDeps = await this.getCyclicDependenciesOfSeeders(seeders, componentsToIsolate, createGraphOpts);
+      if (cyclicDeps.length) {
+        this.logger.debug(`isolateComponents, adding ${cyclicDeps.length} cyclic dependencies of the seeders`);
+        componentsToIsolate = [...componentsToIsolate, ...cyclicDeps];
+      }
+    }
     this.logger.debug(`isolateComponents, total componentsToIsolate: ${componentsToIsolate.length}`);
     const seedersWithVersions = seeders.map((seeder) => {
       if (seeder._legacy.hasVersion()) return seeder;
@@ -424,13 +434,51 @@ export class IsolatorMain {
 
     // Optimization: exclude unmodified exported dependencies from capsule creation
     if (!isFeatureEnabled(DISABLE_CAPSULE_OPTIMIZATION)) {
-      filteredComps = await this.filterUnmodifiedExportedDependencies(filteredComps, seeders, host);
+      // Components participating in a dependency cycle must never be excluded (installed as a
+      // package) even when they're built and exported: a cyclic dep references back into the
+      // seeders, whose snap-version package isn't published yet, so the capsule install would
+      // try to fetch an unpublished snap from the registry and fail (the Ripple circular-deps
+      // build failure). Keep every component in a seeder cycle as a real capsule. (the graph is
+      // seeded with the seeders, so findCycles() already scopes to cycles that involve them.)
+      const idsInCycle = new Set(graph.findCycles().flat());
+      filteredComps = await this.filterUnmodifiedExportedDependencies(filteredComps, seeders, host, idsInCycle);
       this.logger.debug(
         `[OPTIMIZATION] Before filtering: ${componentsToInclude.length}. After filtering: ${filteredComps.length} components remaining`
       );
     }
 
     return filteredComps;
+  }
+
+  /**
+   * When isolating seeders-only (e.g. `bit sign`), dependencies are normally installed as packages
+   * from the registry rather than getting a capsule. That breaks for a dependency that is part of a
+   * dependency cycle with a seeder: the cyclic component references back into a seeder whose
+   * snap-version package was never published, so the capsule install tries to fetch an unpublished
+   * snap from the registry and fails (the Ripple circular-dependency build failure). Return the
+   * dependency components that participate in a cycle with any seeder so they can be added to the
+   * isolation as real capsules and linked locally instead of installed from the registry.
+   */
+  private async getCyclicDependenciesOfSeeders(
+    seeders: ComponentID[],
+    alreadyIsolated: Component[],
+    opts: CreateGraphOptions = {}
+  ): Promise<Component[]> {
+    const host = opts.host || this.componentAspect.getHost();
+    const getGraphOpts = pick(opts, ['host']);
+    const graph = await this.graph.getGraphIds(seeders, getGraphOpts);
+    // the graph is seeded with the seeders, so findCycles() returns only cycles that involve them.
+    const cyclicIds = new Set<string>(graph.findCycles().flat());
+    if (cyclicIds.size === 0) return [];
+    const alreadyIsolatedIds = new Set(alreadyIsolated.map((comp) => comp.id.toString()));
+    const idsToAdd = [...cyclicIds]
+      .filter((idStr) => !alreadyIsolatedIds.has(idStr))
+      .map((idStr) => graph.node(idStr)?.attr)
+      .filter((id): id is ComponentID => id != null);
+    if (idsToAdd.length === 0) return [];
+    // The ids come straight from the graph we just built, so their objects are already present in
+    // the host — getMany loads them without hitting the network.
+    return host.getMany(idsToAdd);
   }
 
   private registerMoveCapsuleOnProcessExit(
@@ -1492,7 +1540,8 @@ export class IsolatorMain {
   private async filterUnmodifiedExportedDependencies(
     components: Component[],
     seederIds: ComponentID[],
-    host: ComponentFactory
+    host: ComponentFactory,
+    idsInCycle: Set<string> = new Set()
   ): Promise<Component[]> {
     this.logger.debug(`filterUnmodifiedExportedDependencies: filtering ${components.length} components`);
 
@@ -1508,6 +1557,15 @@ export class IsolatorMain {
 
       if (isSeeder) {
         // Always include seeders (modified components and their dependents)
+        filtered.push(component);
+        continue;
+      }
+
+      // A dependency that is part of a dependency cycle must keep its capsule. Excluding it
+      // (to install as a package) would make the capsule install resolve the cyclic
+      // back-reference to a seeder's snap-version from the registry, where it isn't published
+      // yet — the Ripple circular-dependency build failure.
+      if (idsInCycle.has(component.id.toString())) {
         filtered.push(component);
         continue;
       }


### PR DESCRIPTION
## Summary

Fixes the circular-dependency build failure seen consistently on Ripple, where the build tries to install a cycle member from the registry that isn't published yet:

```
GET https://node-registry.bit.cloud/@<scope>%2Fcomp1: Not Found - 404
@<scope>/comp1@0.0.0-<hash> is not in the npm registry  (ERR_PNPM_FETCH_404)
```

### Root cause

`bit sign` isolates components in **`seedersOnly`** mode — only the components being signed get capsules; every *dependency* is installed as an npm package from the registry. That breaks for a dependency in a **cycle** with a seeder: the cyclic component references back into a seeder whose snap-version package was never published, so the capsule install 404s.

It only reproduces on a real hub/lane (locally, remotes are registered and workspace components link locally), which is why it's Ripple-specific.

### Fix (`scopes/component/isolator/isolator.main.runtime.ts`)

- **seedersOnly path** — new `getCyclicDependenciesOfSeeders`: build the seeder graph, use `graph.findCycles()` (the graph is seeded, so this returns seeder-involving cycles), and pull those cyclic dependency components into `componentsToIsolate` so they become real capsules linked locally instead of fetched.
- **non-seedersOnly path** (`bit build`) — `filterUnmodifiedExportedDependencies` now takes `idsInCycle` and never excludes a component that's part of a seeder cycle from capsule creation, closing the same gap for built+exported cyclic deps.

## Test plan

- [x] `npm run lint` (tsc + oxlint) clean.
- [x] Reproduced via the sign-from-scope flow (lane, `comp1 ↔ comp2` cycle, snap both pending + export, sign one alone). **Without** the fix: `ERR_PNPM_FETCH_404` on the unpublished cyclic snap. **With** the fix: signs `succeed`, cyclic dep isolated as a capsule and linked locally.
- [x] Regression test added to the `sign` command spec ("signing one member of a circular dependency while the other is still pending"). The `sign` command lives in its own repo, so that test is committed there, not in this PR.

## Notes

`getCyclicDependenciesOfSeeders` builds the seeder graph on every seedersOnly isolation. It's cheap relative to the full sign (capsule writes + install + tasks), but can be gated behind a lighter pre-check if preferred.