### PR TITLE
fix(isolator): build unmodified deps from source when their package was never published

### DIFF
--- a/e2e/harmony/lanes/skip-publish-unpublished-dep.e2e.ts
+++ b/e2e/harmony/lanes/skip-publish-unpublished-dep.e2e.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import chai, { expect } from 'chai';
+import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/legacy.e2e-helper';
+import chaiFs from 'chai-fs';
+
+chai.use(chaiFs);
+
+/**
+ * Reproduces the `bit ci pr` (reuse-lane) failure where an unmodified dependency was BUILT but never
+ * PUBLISHED — e.g. a previous run snapped with the publish task skipped (`--skip-tasks`). The build
+ * succeeds, so the version's `buildStatus` is 'succeed', but no package reaches the registry.
+ *
+ * On a later run only the modified component is snapped+built. The capsule-creation optimization
+ * (`filterUnmodifiedExportedDependencies`) used to exclude such an unmodified exported dependency from
+ * the capsules and install it as a package from the registry — relying on `buildStatus === 'succeed'`
+ * as a proxy for "published". With publish skipped that proxy is wrong, so the install died with the
+ * cryptic `No matching version found for @scope/comp@0.0.0-<hash>`.
+ *
+ * The fix gates the exclusion on the version actually having been published (`publishedPackage` builder
+ * metadata, a local check), so an unpublished-but-built dependency is kept in the capsule set and built
+ * from source instead of fetched from the registry.
+ *
+ * Uses the npm CI registry so the unpublished snap genuinely 404s (with a local file remote the dep is
+ * filtered out of the install manifest and never fetched, so it can't reproduce).
+ */
+(supportNpmCiRegistryTesting ? describe : describe.skip)(
+  'snap+build a dependent of an unmodified, built-but-unpublished dependency',
+  function () {
+    this.timeout(0);
+    let helper: Helper;
+    let npmCiRegistry: NpmCiRegistry;
+    before(async () => {
+      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      await npmCiRegistry.init();
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+      helper.fixtures.populateComponents(2); // comp1 -> comp2
+      helper.command.createLane();
+      npmCiRegistry.setResolver();
+      // snap+build both, but SKIP the publish task. comp2 ends up with buildStatus 'succeed' yet no
+      // package on the registry — the state a `bit ci pr` run that skipped publish leaves on the lane.
+      helper.command.snapAllComponents('--skip-tasks PublishComponents');
+      helper.command.export();
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.scopeHelper.destroy();
+      helper = new Helper();
+    });
+
+    // re-snapping only comp1 makes comp2 an unmodified, non-seeder dependency. before the fix its
+    // buildStatus 'succeed' got it excluded from the capsules and installed from the registry → 404.
+    it('builds the unpublished dependency from source instead of failing to install it', () => {
+      let output = '';
+      try {
+        output = helper.command.snapComponent('comp1', 'snap-message', '--unmodified');
+      } catch (err: any) {
+        output = `${err.message || ''}${err.stdout?.toString() || ''}${err.stderr?.toString() || ''}`;
+      }
+      expect(
+        output,
+        'snap should not fail trying to fetch the unpublished dependency from the registry'
+      ).to.not.have.string('No matching version found');
+      expect(output, 'comp1 should have been snapped').to.have.string('comp1');
+    });
+  }
+);

--- a/e2e/harmony/lanes/skip-publish-unpublished-dep.e2e.ts
+++ b/e2e/harmony/lanes/skip-publish-unpublished-dep.e2e.ts
@@ -51,18 +51,12 @@ chai.use(chaiFs);
 
     // re-snapping only comp1 makes comp2 an unmodified, non-seeder dependency. before the fix its
     // buildStatus 'succeed' got it excluded from the capsules and installed from the registry → 404.
+    // snapComponent throws if `bit snap` exits non-zero, so a successful return is itself the assertion
+    // that the capsule build did NOT fail fetching the unpublished dependency. we deliberately do NOT
+    // swallow the error — a failure must fail the test rather than silently pass.
     it('builds the unpublished dependency from source instead of failing to install it', () => {
-      let output = '';
-      try {
-        output = helper.command.snapComponent('comp1', 'snap-message', '--unmodified');
-      } catch (err: any) {
-        output = `${err.message || ''}${err.stdout?.toString() || ''}${err.stderr?.toString() || ''}`;
-      }
-      expect(
-        output,
-        'snap should not fail trying to fetch the unpublished dependency from the registry'
-      ).to.not.have.string('No matching version found');
-      expect(output, 'comp1 should have been snapped').to.have.string('comp1');
+      const output = helper.command.snapComponent('comp1', 'snap-message', '--unmodified');
+      expect(output, 'comp1 should have been snapped').to.have.string('component(s) snapped');
     });
   }
 );

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -35,7 +35,12 @@ import { ComponentIdList } from '@teambit/component-id';
 import type { Scope, Scope as LegacyScope } from '@teambit/legacy.scope';
 import type { GlobalConfigMain } from '@teambit/global-config';
 import { GlobalConfigAspect } from '@teambit/global-config';
-import { DEPENDENCIES_FIELDS, PACKAGE_JSON, CFG_CAPSULES_SCOPES_ASPECTS_DATED_DIR } from '@teambit/legacy.constants';
+import {
+  DEPENDENCIES_FIELDS,
+  PACKAGE_JSON,
+  CFG_CAPSULES_SCOPES_ASPECTS_DATED_DIR,
+  Extensions,
+} from '@teambit/legacy.constants';
 import type { ConsumerComponent } from '@teambit/legacy.consumer-component';
 import type { AbstractVinyl, ArtifactVinyl } from '@teambit/component.sources';
 import {
@@ -1528,7 +1533,13 @@ export class IsolatorMain {
       const canBeInstalled =
         host.isExported(component.id) &&
         (remotes.isHub(component.id.scope) || isPublished) &&
-        component.buildStatus === 'succeed';
+        component.buildStatus === 'succeed' &&
+        // `buildStatus === 'succeed'` is not enough: a snap can build successfully but never publish its
+        // package — e.g. `bit ci pr` snapping with the publish task skipped (build succeeds, so buildStatus
+        // is set to 'succeed', but no package reaches the registry). reusing such a lane on a later run, this
+        // unmodified dependency would be excluded here and then fail to install with "No matching version
+        // found". only exclude (i.e. install from the registry) when the package was actually published.
+        this.wasPackagePublished(component);
 
       if (canBeInstalled) {
         this.logger.debug(`[OPTIMIZATION] Excluding unmodified exported dependency: ${componentIdStr}`);
@@ -1541,6 +1552,19 @@ export class IsolatorMain {
       `filterUnmodifiedExportedDependencies: kept ${filtered.length} out of ${components.length} components`
     );
     return filtered;
+  }
+
+  /**
+   * whether this exact version had its package published to the registry. the publish (pkg) build task
+   * records `publishedPackage` in the version's builder data only on a real (non-dry-run) successful
+   * publish (see publisher.ts) — so its absence means the package was never published (the task was
+   * skipped or it ran dry), even when `buildStatus` is 'succeed'. it's inline metadata on the version,
+   * loaded eagerly with the component (like `buildStatus`), so this is a local check with no network call.
+   */
+  private wasPackagePublished(component: Component): boolean {
+    const builderData = component.state._consumer.extensions.findCoreExtension(Extensions.builder)?.data;
+    const pkgData = builderData?.aspectsData?.find((aspectData) => aspectData.aspectId === Extensions.pkg);
+    return pkgData?.data?.publishedPackage != null;
   }
 }
 

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -41,6 +41,7 @@ import {
   CFG_CAPSULES_SCOPES_ASPECTS_DATED_DIR,
   Extensions,
 } from '@teambit/legacy.constants';
+import { isSnap } from '@teambit/component-version';
 import type { ConsumerComponent } from '@teambit/legacy.consumer-component';
 import type { AbstractVinyl, ArtifactVinyl } from '@teambit/component.sources';
 import {
@@ -1530,16 +1531,21 @@ export class IsolatorMain {
       }
 
       const isPublished = component.get('teambit.pkg/pkg')?.config?.packageJson?.publishConfig;
+      // `buildStatus === 'succeed'` is not enough to know the package is on the registry: a SNAP can build
+      // successfully yet never publish — e.g. `bit ci pr` snapping with the publish task skipped (build
+      // succeeds so buildStatus becomes 'succeed', but no package is published). reusing such a lane on a
+      // later run, this unmodified dependency would be excluded here and then fail to install with "No
+      // matching version found". For snaps we therefore also require evidence the package was actually
+      // published (`publishedPackage` builder metadata). We DON'T demand it for tagged (semver) releases:
+      // those are published by the release pipeline, and the metadata is not reliable as a published-marker
+      // anyway — older published versions simply don't carry it, so requiring it would wrongly rebuild
+      // installable deps from source and create duplicate package instances in the capsules.
+      const wasPublished = !isSnap(component.id.version) || this.wasPackagePublished(component);
       const canBeInstalled =
         host.isExported(component.id) &&
         (remotes.isHub(component.id.scope) || isPublished) &&
         component.buildStatus === 'succeed' &&
-        // `buildStatus === 'succeed'` is not enough: a snap can build successfully but never publish its
-        // package — e.g. `bit ci pr` snapping with the publish task skipped (build succeeds, so buildStatus
-        // is set to 'succeed', but no package reaches the registry). reusing such a lane on a later run, this
-        // unmodified dependency would be excluded here and then fail to install with "No matching version
-        // found". only exclude (i.e. install from the registry) when the package was actually published.
-        this.wasPackagePublished(component);
+        wasPublished;
 
       if (canBeInstalled) {
         this.logger.debug(`[OPTIMIZATION] Excluding unmodified exported dependency: ${componentIdStr}`);
@@ -1555,14 +1561,15 @@ export class IsolatorMain {
   }
 
   /**
-   * whether this exact version had its package published to the registry. the publish (pkg) build task
-   * records `publishedPackage` in the version's builder data only on a real (non-dry-run) successful
-   * publish (see publisher.ts) — so its absence means the package was never published (the task was
-   * skipped or it ran dry), even when `buildStatus` is 'succeed'. it's inline metadata on the version,
-   * loaded eagerly with the component (like `buildStatus`), so this is a local check with no network call.
+   * whether this exact (snap) version recorded a successful publish. the publish (pkg) build task writes
+   * `publishedPackage` into the version's builder data only on a real (non-dry-run) successful publish
+   * (see publisher.ts). it's inline metadata on the version, read here via the public component aspect
+   * API (no network). NOTE: presence proves the package was published, but ABSENCE does not prove it
+   * wasn't — older published versions don't carry this field — so callers only use it to gate snaps,
+   * where the skip-publish gap actually occurs, not tagged releases.
    */
   private wasPackagePublished(component: Component): boolean {
-    const builderData = component.state._consumer.extensions.findCoreExtension(Extensions.builder)?.data;
+    const builderData = component.get(Extensions.builder)?.data;
     const pkgData = builderData?.aspectsData?.find((aspectData) => aspectData.aspectId === Extensions.pkg);
     return pkgData?.data?.publishedPackage != null;
   }


### PR DESCRIPTION
### Problem
On a reused lane (`bit ci pr --keep-lane`), if an earlier run snapped with the **publish** task skipped, those components were built but their packages were never published to the registry. A later run that snaps only the modified components resolves an unmodified dependency to one of those built-but-unpublished snaps. The capsule-creation optimization (`filterUnmodifiedExportedDependencies`) excluded it and tried to **install it from the registry**, failing with:

```
No matching version found for @scope/comp@0.0.0-<hash>
```

The exclusion gate trusted `buildStatus === 'succeed'` as a proxy for "published", but `buildStatus` is set to `succeed` after a successful build even when the publish task was skipped.

### Fix
Also require the version to carry the `publishedPackage` builder metadata (written only on a real, non-dry-run successful publish) before excluding a dependency. Built-but-unpublished deps are kept in the capsule set and built from source instead of fetched. It's inline version metadata loaded eagerly (no network), and normally-published deps still carry it, so there's no perf regression — a false-negative only costs a rebuild from source, never a crash.

Adds an e2e (`skip-publish-unpublished-dep`) that snaps+builds on a lane with `--skip-tasks PublishComponents`, exports, then snaps a dependent and asserts it does not fail fetching the unpublished dep.