### PR TITLE
ci: revert to latest bit version via bvm upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,8 +224,8 @@ commands:
     steps:
       - run: bvm config set DEFAULT_LINK bbit
       - run: bvm config set RELEASE_TYPE nightly
-      # - run: bvm upgrade
-      - run: bvm install 1.13.240
+      - run: bvm upgrade
+      # - run: bvm install 1.13.240
       - run: bvm link --verbose
       - bit_config:
           env: "hub"


### PR DESCRIPTION
Reverts the pinned bvm install 1.13.240 back to bvm upgrade to track the latest nightly bit version.