### PR TITLE
fix(isolator): isolate & link snap-versioned cyclic deps during aspect isolation

### DIFF
--- a/e2e/harmony/isolate-cyclic-deps.e2e.ts
+++ b/e2e/harmony/isolate-cyclic-deps.e2e.ts
@@ -33,4 +33,69 @@ describe('isolating cyclic dependencies', function () {
       expect(capsuleIds).to.include(`${helper.scopes.remote}/comp2`);
     });
   });
+
+  // Regression for the Ripple failure that persisted after the seeders-only fix above: it happens
+  // in the ASPECT-loading isolation path, not the sign path. A custom env built on a lane together
+  // with a component it cycles with (the env's mounter imports the component; the component uses
+  // the env) is loaded from the scope by isolating it with `seedersOnly: true` + `context.aspects`.
+  // The cyclic dependency's snap-version was never published, so installing it as a registry
+  // package fails (`ERR_PNPM_NO_MATCHING_VERSION`). The isolator must pull the snap-versioned
+  // cyclic dep into the aspect isolation as a capsule instead.
+  describe('env in a cycle with a component, loaded from scope (aspect isolation)', () => {
+    let snapFromScopeError: Error | undefined;
+    before(async () => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const envName = helper.env.setCustomNewEnv('react-based-env');
+      const envId = `${helper.scopes.remote}/${envName}`;
+
+      // a "theme" component used by the env's mounter -> creates an env -> theme edge.
+      helper.fixtures.populateComponents(1, false);
+      helper.command.rename('comp1', 'theme');
+      helper.fs.outputFile(
+        'theme/index.tsx',
+        `import React from 'react';
+export const MyTheme = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;`
+      );
+      helper.fs.outputFile(
+        `${envName}/preview/mounter.tsx`,
+        `import React from 'react';
+import { createMounter } from '@teambit/react.mounter';
+import { MyTheme } from '@${helper.scopes.remote}/theme';
+
+export function MyReactProvider({ children }: { children: React.ReactNode }) {
+  return <MyTheme>{children}</MyTheme>;
+}
+
+export default createMounter(MyReactProvider) as any;`
+      );
+      // the theme uses the custom env -> creates the theme -> env edge, closing the cycle.
+      helper.command.setEnv('theme', envId);
+
+      // snap both on a lane and export. The snaps are never published to the registry.
+      helper.command.compile();
+      helper.command.createLane('dev');
+      helper.command.snapAllComponentsWithoutBuild(
+        '--ignore-issues "CircularDependencies,MissingPackagesDependenciesOnFs"'
+      );
+      helper.command.export();
+
+      // snap-from-scope on a bare scope forces the env to be loaded from the scope, which isolates
+      // it via the aspect path. Without the fix this fetches the unpublished cyclic snap from the
+      // registry and throws; with the fix the snap-versioned cyclic dep is isolated as a capsule.
+      const bareScope = helper.scopeHelper.getNewBareScope();
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareScope.scopePath);
+      try {
+        await helper.snapping.snapFromScope(
+          bareScope.scopePath,
+          [{ componentId: `${helper.scopes.remote}/theme`, message: 'snap from scope' }],
+          { lane: `${helper.scopes.remote}/dev` }
+        );
+      } catch (err) {
+        snapFromScopeError = err as Error;
+      }
+    });
+    it('should isolate the cyclic snap dependency as a capsule instead of fetching it from the registry', () => {
+      expect(snapFromScopeError, snapFromScopeError?.message).to.be.undefined;
+    });
+  });
 });

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -388,16 +388,22 @@ export class IsolatorMain {
     let cyclicMemberIds: Set<string> | undefined;
     if (opts.seedersOnly) {
       const onlySnaps = Boolean(opts.context?.aspects);
-      const { components: cyclicDeps, cyclicMemberIds: memberIds } = await this.getCyclicDependenciesOfSeeders(
-        seeders,
-        componentsToIsolate,
-        createGraphOpts,
-        onlySnaps
-      );
-      if (cyclicDeps.length) {
-        this.logger.debug(`isolateComponents, adding ${cyclicDeps.length} cyclic dependencies of the seeders`);
-        componentsToIsolate = [...componentsToIsolate, ...cyclicDeps];
-        cyclicMemberIds = memberIds;
+      // For aspect isolation only snap-versioned cyclic deps are ever pulled in. Building the seeder
+      // graph can trigger `scope.import` on scope hosts, so skip it entirely for the common case
+      // where no seeder even has a snap-versioned component dependency (a co-snapped cyclic member
+      // surfaces as a direct snap dep on the seeder, so a direct-deps check is sufficient here).
+      if (!onlySnaps || this.hasSnapComponentDependency(componentsToIsolate)) {
+        const { components: cyclicDeps, cyclicMemberIds: memberIds } = await this.getCyclicDependenciesOfSeeders(
+          seeders,
+          componentsToIsolate,
+          createGraphOpts,
+          onlySnaps
+        );
+        if (cyclicDeps.length) {
+          this.logger.debug(`isolateComponents, adding ${cyclicDeps.length} cyclic dependencies of the seeders`);
+          componentsToIsolate = [...componentsToIsolate, ...cyclicDeps];
+          cyclicMemberIds = memberIds;
+        }
       }
     }
     this.logger.debug(`isolateComponents, total componentsToIsolate: ${componentsToIsolate.length}`);
@@ -463,6 +469,19 @@ export class IsolatorMain {
     }
 
     return filteredComps;
+  }
+
+  /**
+   * Cheap pre-check for the aspect-isolation cyclic-dep path: do any of the given components have a
+   * direct snap-versioned component dependency? Used to avoid building the seeder graph (which can
+   * trigger network imports on scope hosts) when there can be no snap cyclic dep to pull in.
+   */
+  private hasSnapComponentDependency(components: Component[]): boolean {
+    return components.some((component) =>
+      this.dependencyResolver
+        .getComponentDependencies(component)
+        .some((dep) => dep.componentId.version != null && isSnap(dep.componentId.version))
+    );
   }
 
   /**
@@ -793,7 +812,21 @@ export class IsolatorMain {
           return existingCapsules;
         }
       } else {
-        capsules = capsules.filter((capsule) => !capsule.fs.existsSync('package.json'));
+        // Keep cached members of an activated cycle whenever any member of that cycle still needs an
+        // install, so the grouped install below receives the whole cycle and the package manager
+        // links them as siblings — otherwise a cached member would resolve its (unpublished snap)
+        // sibling from the registry and fail again. When every cyclic member is already installed
+        // they were grouped together on a previous run, so they drop out like any other cached capsule.
+        const cyclicNeedsInstall =
+          cyclicMemberIds != null &&
+          capsules.some(
+            (capsule) =>
+              cyclicMemberIds.has(capsule.component.id.toString()) && !capsule.fs.existsSync('package.json')
+          );
+        capsules = capsules.filter((capsule) => {
+          if (!capsule.fs.existsSync('package.json')) return true;
+          return cyclicNeedsInstall && (cyclicMemberIds?.has(capsule.component.id.toString()) ?? false);
+        });
         capsuleList = CapsuleList.fromArray(capsules);
       }
     }

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -382,9 +382,13 @@ export class IsolatorMain {
     // be fetched, whereas a published-tag cyclic aspect dep must stay a registry install — pulling
     // it in forces loading an env that isn't available in that context (broke `bit ci pr` / `bit
     // new react`, both of which hit published-tag cyclic aspect deps).
+    // members of dependency cycles that were pulled into the isolation. A cycle is an indivisible
+    // install unit, so these capsules must be installed together (see createCapsules) — otherwise
+    // the nesting install path resolves a cyclic member's unpublished snap dep from the registry.
+    let cyclicMemberIds: Set<string> | undefined;
     if (opts.seedersOnly) {
       const onlySnaps = Boolean(opts.context?.aspects);
-      const cyclicDeps = await this.getCyclicDependenciesOfSeeders(
+      const { components: cyclicDeps, cyclicMemberIds: memberIds } = await this.getCyclicDependenciesOfSeeders(
         seeders,
         componentsToIsolate,
         createGraphOpts,
@@ -393,6 +397,7 @@ export class IsolatorMain {
       if (cyclicDeps.length) {
         this.logger.debug(`isolateComponents, adding ${cyclicDeps.length} cyclic dependencies of the seeders`);
         componentsToIsolate = [...componentsToIsolate, ...cyclicDeps];
+        cyclicMemberIds = memberIds;
       }
     }
     this.logger.debug(`isolateComponents, total componentsToIsolate: ${componentsToIsolate.length}`);
@@ -411,7 +416,7 @@ export class IsolatorMain {
     });
     const cacheCapsulesDir = this.getCapsulesRootDir({ ...opts, useDatedDirs: false, baseDir: opts.baseDir || '' });
     opts.cacheCapsulesDir = cacheCapsulesDir;
-    const capsuleList = await this.createCapsules(componentsToIsolate, capsuleDir, opts, legacyScope);
+    const capsuleList = await this.createCapsules(componentsToIsolate, capsuleDir, opts, legacyScope, cyclicMemberIds);
     this.logger.debug(
       `creating network with base dir: ${opts.baseDir}, rootBaseDir: ${opts.rootBaseDir}. final capsule-dir: ${capsuleDir}. capsuleList: ${capsuleList.length}`
     );
@@ -469,16 +474,22 @@ export class IsolatorMain {
    * dependency components that participate in a cycle with any seeder so they can be added to the
    * isolation as real capsules and linked locally instead of installed from the registry.
    *
-   * When `onlySnaps` is set (aspect isolation), only cyclic deps on a snap version are returned.
+   * When `onlySnaps` is set (aspect isolation), only cyclic deps on a snap version are pulled in.
    * A published-tag cyclic aspect dep resolves fine from the registry, and isolating it as a
    * capsule would force loading its (possibly unavailable) env — see the caller for context.
+   *
+   * Returns the dependency `components` to add, and `cyclicMemberIds` — the ids of every member of
+   * an "activated" cycle (a cycle from which a dep was pulled in), including the seeders. The caller
+   * installs those members together (see createCapsules); a cycle has no valid nesting order, so
+   * its members must share an install root for the package manager to link them as siblings.
    */
   private async getCyclicDependenciesOfSeeders(
     seeders: ComponentID[],
     alreadyIsolated: Component[],
     opts: CreateGraphOptions = {},
     onlySnaps = false
-  ): Promise<Component[]> {
+  ): Promise<{ components: Component[]; cyclicMemberIds: Set<string> }> {
+    const empty = { components: [], cyclicMemberIds: new Set<string>() };
     const host = opts.host || this.componentAspect.getHost();
     const getGraphOpts = pick(opts, ['host']);
     const graph = await this.graph.getGraphIds(seeders, getGraphOpts);
@@ -486,20 +497,36 @@ export class IsolatorMain {
     // seeder participates in. Pass includeDeps=true so detection doesn't rely on matching the
     // (possibly versionless) seeder ids against the graph's versioned node ids — otherwise a
     // seeder-involving cycle can be missed and its members get installed from the registry again.
-    const cyclicIds = new Set<string>(graph.findCycles(undefined, true).flat());
-    if (cyclicIds.size === 0) return [];
+    const cycles = graph.findCycles(undefined, true);
+    if (cycles.length === 0) return empty;
     const alreadyIsolatedIds = new Set(alreadyIsolated.map((comp) => comp.id.toString()));
-    let idsToAdd = [...cyclicIds]
-      .filter((idStr) => !alreadyIsolatedIds.has(idStr))
+    const isSnapId = (idStr: string): boolean => {
+      const id = graph.node(idStr)?.attr;
+      return id?.version != null && isSnap(id.version);
+    };
+    const idsToAddStr = new Set<string>();
+    const cyclicMemberIds = new Set<string>();
+    for (const cycle of cycles) {
+      // the members this cycle would contribute as new capsules. In onlySnaps mode a published-tag
+      // member stays a registry install, so it neither gets pulled in nor groups the cycle.
+      const newMembers = cycle.filter((idStr) => !alreadyIsolatedIds.has(idStr));
+      const membersToAdd = onlySnaps ? newMembers.filter(isSnapId) : newMembers;
+      if (membersToAdd.length === 0) continue;
+      membersToAdd.forEach((idStr) => idsToAddStr.add(idStr));
+      // group the whole cycle (the just-added members plus the already-isolated seeders in it) so
+      // they install together. A published-tag member that wasn't pulled in stays out of the group.
+      cycle.forEach((idStr) => {
+        if (alreadyIsolatedIds.has(idStr) || idsToAddStr.has(idStr)) cyclicMemberIds.add(idStr);
+      });
+    }
+    const idsToAdd = [...idsToAddStr]
       .map((idStr) => graph.node(idStr)?.attr)
       .filter((id): id is ComponentID => id != null);
-    if (onlySnaps) {
-      idsToAdd = idsToAdd.filter((id) => id.version != null && isSnap(id.version));
-    }
-    if (idsToAdd.length === 0) return [];
+    if (idsToAdd.length === 0) return empty;
     // The ids come straight from the graph we just built, so their objects are already present in
     // the host — getMany loads them without hitting the network.
-    return host.getMany(idsToAdd);
+    const components = await host.getMany(idsToAdd);
+    return { components, cyclicMemberIds };
   }
 
   private registerMoveCapsuleOnProcessExit(
@@ -701,7 +728,8 @@ export class IsolatorMain {
     components: Component[],
     capsulesDir: string,
     opts: IsolateComponentsOptions,
-    legacyScope?: Scope
+    legacyScope?: Scope,
+    cyclicMemberIds?: Set<string>
   ): Promise<CapsuleList> {
     this.logger.debug(`createCapsules, ${components.length} components`);
 
@@ -785,39 +813,70 @@ export class IsolatorMain {
       }
       const rootLinks = await this.linkInCapsulesRoot(capsulesDir, capsuleList, linkingOptions);
       if (installOptions.useNesting) {
-        await Promise.all(
-          capsuleList.map(async (capsule, index) => {
-            const newCapsuleList = CapsuleList.fromArray([capsule]);
-            if (opts.cacheCapsulesDir && capsulesDir !== opts.cacheCapsulesDir && opts.cacheLockFileOnly) {
-              const cacheCapsuleDir = path.join(opts.cacheCapsulesDir, basename(capsule.path));
-              const lockFilePath = path.join(cacheCapsuleDir, 'pnpm-lock.yaml');
-              const lockExists = await fs.pathExists(lockFilePath);
-              if (lockExists) {
-                try {
-                  // this.logger.console(`moving lock file from ${lockFilePath} to ${capsule.path}`);
-                  await copyFile(lockFilePath, path.join(capsule.path, 'pnpm-lock.yaml'));
-                } catch (err) {
-                  // We can ignore the error, we don't want to break the flow. the file will be anyway re-generated
-                  // in the target capsule. it will only be a bit slower.
-                  this.logger.error(
-                    `failed moving lock file from cache folder path: ${lockFilePath} to local capsule at ${capsule.path} (even though the lock file seems to exist)`,
-                    err
-                  );
-                }
-              }
-            }
-            const linkedDependencies = await this.linkInCapsules(newCapsuleList, capsulesWithPackagesData);
-            if (index === 0) {
-              linkedDependencies[capsulesDir] = rootLinks;
-            }
-            await this.installInCapsules(capsule.path, newCapsuleList, installOptions, {
+        // A dependency cycle is an indivisible install unit. Nesting installs each capsule in its
+        // own root, which makes a cyclic member resolve its in-network cyclic dependency from the
+        // registry (and an unpublished snap 404s). Install all members of the activated cycles
+        // together at the shared root so the package manager links them as siblings — the same way
+        // the non-nested path below does — while every other capsule keeps its isolated nested root.
+        const cyclicCapsules = capsuleList.filter(
+          (capsule) => cyclicMemberIds?.has(capsule.component.id.toString()) ?? false
+        );
+        const cyclicCapsuleSet = new Set(cyclicCapsules.map((capsule) => capsule.component.id.toString()));
+        const nestedCapsules = capsuleList.filter(
+          (capsule) => !cyclicCapsuleSet.has(capsule.component.id.toString())
+        );
+        const installTasks: Array<Promise<void>> = [];
+        if (cyclicCapsules.length) {
+          const cyclicCapsuleList = CapsuleList.fromArray(cyclicCapsules);
+          const linkedDependencies = await this.linkInCapsules(cyclicCapsuleList, capsulesWithPackagesData);
+          linkedDependencies[capsulesDir] = rootLinks;
+          installTasks.push(
+            this.installInCapsules(capsulesDir, cyclicCapsuleList, installOptions, {
               cachePackagesOnCapsulesRoot,
               linkedDependencies,
               packageManager: opts.packageManager,
               nodeLinker: opts.nodeLinker,
-            });
-          })
-        );
+            })
+          );
+        }
+        nestedCapsules.forEach((capsule, index) => {
+          installTasks.push(
+            (async () => {
+              const newCapsuleList = CapsuleList.fromArray([capsule]);
+              if (opts.cacheCapsulesDir && capsulesDir !== opts.cacheCapsulesDir && opts.cacheLockFileOnly) {
+                const cacheCapsuleDir = path.join(opts.cacheCapsulesDir, basename(capsule.path));
+                const lockFilePath = path.join(cacheCapsuleDir, 'pnpm-lock.yaml');
+                const lockExists = await fs.pathExists(lockFilePath);
+                if (lockExists) {
+                  try {
+                    // this.logger.console(`moving lock file from ${lockFilePath} to ${capsule.path}`);
+                    await copyFile(lockFilePath, path.join(capsule.path, 'pnpm-lock.yaml'));
+                  } catch (err) {
+                    // We can ignore the error, we don't want to break the flow. the file will be anyway re-generated
+                    // in the target capsule. it will only be a bit slower.
+                    this.logger.error(
+                      `failed moving lock file from cache folder path: ${lockFilePath} to local capsule at ${capsule.path} (even though the lock file seems to exist)`,
+                      err
+                    );
+                  }
+                }
+              }
+              const linkedDependencies = await this.linkInCapsules(newCapsuleList, capsulesWithPackagesData);
+              // attach the root links to a single install. When a cyclic group install exists it owns
+              // them (its root is capsulesDir); otherwise the first nested capsule does, as before.
+              if (index === 0 && !cyclicCapsules.length) {
+                linkedDependencies[capsulesDir] = rootLinks;
+              }
+              await this.installInCapsules(capsule.path, newCapsuleList, installOptions, {
+                cachePackagesOnCapsulesRoot,
+                linkedDependencies,
+                packageManager: opts.packageManager,
+                nodeLinker: opts.nodeLinker,
+              });
+            })()
+          );
+        });
+        await Promise.all(installTasks);
       } else {
         const dependenciesGraph = opts.useDependenciesGraph
           ? await legacyScope?.getDependenciesGraphByComponentIds(capsuleList.getAllComponentIDs())

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -376,11 +376,20 @@ export class IsolatorMain {
       : await this.createGraph(seeders, createGraphOpts);
     // seedersOnly skips the dependency graph and installs deps as packages from the registry.
     // A dependency in a cycle with a seeder can't be installed that way (its snap-version isn't
-    // published yet), so pull it into the isolation as a capsule. Skip this for aspect isolation:
-    // aspects are loaded from already-published packages and pulling cyclic aspect deps in only
-    // forces loading envs that aren't installed in that context.
-    if (opts.seedersOnly && !opts.context?.aspects) {
-      const cyclicDeps = await this.getCyclicDependenciesOfSeeders(seeders, componentsToIsolate, createGraphOpts);
+    // published yet), so pull it into the isolation as a capsule.
+    // For aspect isolation, restrict this to snap-versioned cyclic deps: an unpublished snap (e.g.
+    // a lane-built env whose preview component is co-snapped and never published) genuinely can't
+    // be fetched, whereas a published-tag cyclic aspect dep must stay a registry install — pulling
+    // it in forces loading an env that isn't available in that context (broke `bit ci pr` / `bit
+    // new react`, both of which hit published-tag cyclic aspect deps).
+    if (opts.seedersOnly) {
+      const onlySnaps = Boolean(opts.context?.aspects);
+      const cyclicDeps = await this.getCyclicDependenciesOfSeeders(
+        seeders,
+        componentsToIsolate,
+        createGraphOpts,
+        onlySnaps
+      );
       if (cyclicDeps.length) {
         this.logger.debug(`isolateComponents, adding ${cyclicDeps.length} cyclic dependencies of the seeders`);
         componentsToIsolate = [...componentsToIsolate, ...cyclicDeps];
@@ -459,11 +468,16 @@ export class IsolatorMain {
    * snap from the registry and fails (the Ripple circular-dependency build failure). Return the
    * dependency components that participate in a cycle with any seeder so they can be added to the
    * isolation as real capsules and linked locally instead of installed from the registry.
+   *
+   * When `onlySnaps` is set (aspect isolation), only cyclic deps on a snap version are returned.
+   * A published-tag cyclic aspect dep resolves fine from the registry, and isolating it as a
+   * capsule would force loading its (possibly unavailable) env — see the caller for context.
    */
   private async getCyclicDependenciesOfSeeders(
     seeders: ComponentID[],
     alreadyIsolated: Component[],
-    opts: CreateGraphOptions = {}
+    opts: CreateGraphOptions = {},
+    onlySnaps = false
   ): Promise<Component[]> {
     const host = opts.host || this.componentAspect.getHost();
     const getGraphOpts = pick(opts, ['host']);
@@ -475,10 +489,13 @@ export class IsolatorMain {
     const cyclicIds = new Set<string>(graph.findCycles(undefined, true).flat());
     if (cyclicIds.size === 0) return [];
     const alreadyIsolatedIds = new Set(alreadyIsolated.map((comp) => comp.id.toString()));
-    const idsToAdd = [...cyclicIds]
+    let idsToAdd = [...cyclicIds]
       .filter((idStr) => !alreadyIsolatedIds.has(idStr))
       .map((idStr) => graph.node(idStr)?.attr)
       .filter((id): id is ComponentID => id != null);
+    if (onlySnaps) {
+      idsToAdd = idsToAdd.filter((id) => id.version != null && isSnap(id.version));
+    }
     if (idsToAdd.length === 0) return [];
     // The ids come straight from the graph we just built, so their objects are already present in
     // the host — getMany loads them without hitting the network.


### PR DESCRIPTION
## Summary

Fixes the Ripple circular-dependency build failure that **persisted after #10449**. #10449 fixed the *sign-from-scope* path; the real failure is in the **aspect-loading** isolation path (`scope-aspects-loader`, `seedersOnly: true` + `context: { aspects: true }`), which #10449 deliberately skips.

### The failure

On a lane where an env is built together with a component it cycles with (e.g. `teambit.react/react-env` ↔ `@teambit/preview.react-preview`), loading that env from the scope isolates it in the aspect path. The cyclic dep's snap-version was never published, so installing it as a registry package 404s:

```
No matching version found for @teambit/preview.react-preview@0.0.0-<snap>
This error happened while installing a direct dependency of
  /tmp/capsules-root/tmp-aspects/.../teambit.react_react-env@<snap>
```

That `react-env ↔ react-preview` is a true cycle follows from build ordering: components build in dependency order, so an env needing an *unbuilt/unpublished* snap of its own preview *at load time* means the two were built together — which only happens for a cycle.

### Fix — two parts (`scopes/component/isolator/isolator.main.runtime.ts`)

**1. Detect & pull in the cyclic snap dep (open the aspect gate).** #10449 gated cyclic-dep isolation to `!opts.context?.aspects`, because opening it broadly broke `bit ci pr` / `bit new react` — those pulled **published-tag** cyclic aspect deps (`documenter-react@0.0.1`, the `core-aspect-env` case) into capsules and forced loading unavailable envs. This PR opens the gate but restricts the aspect path to **snap versions only** (`isSnap`). An unpublished `0.0.0-<hash>` snap genuinely can't be fetched and must become a local capsule; a published-tag cyclic aspect dep resolves fine and stays a registry install. Both prior regressions were published tags, which `isSnap` excludes.

**2. Install cyclic-group capsules together (the linking half).** Detection alone is insufficient: aspect isolation installs with `useNesting`, which installs each capsule in its own root, so the dep got a capsule but was never *linked* into the dependent capsule's install — pnpm still fetched the snap. A dependency cycle is an indivisible install unit (no valid nesting order), so all members of an activated cycle are now installed **together at the shared capsules root** — the same mechanism the non-nested sign path already uses — while every other capsule keeps its isolated nested root.

## Test plan

Added `e2e/harmony/isolate-cyclic-deps.e2e.ts` (new describe) — a faithful repro: a custom env whose `preview/mounter` imports a `theme` component, `theme` uses the env (the cycle), both snapped on a lane + exported, then `snapFromScope` on a bare scope forces aspect isolation from the scope.

- [x] `npm run lint` clean.
- [x] **Without the fix** (master / #10449 gated out of aspects): the test **fails** — `@scope/theme@0.0.0-<snap>` 404 from `node-registry.bit.cloud` (the exact Ripple error).
- [x] **With the fix**: the test **passes** — the cyclic snap dep is isolated as a capsule and linked locally.
- [ ] Regression: `bit ci pr` and `bit new react` still pass (snap filter should leave their published-tag cyclic aspect deps as registry installs — please confirm in CI).

## Notes

The non-aspect sign path keeps its existing all-cyclic-deps behavior (its e2e test isolates a `0.0.1` tag). The grouped-install change is a no-op when there are no activated cycles — singletons install exactly as before.
