### PR TITLE
fix(lanes): annotate getUseLanes return type to avoid non-portable inferred type (TS2742)

### DIFF
--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -24,7 +24,7 @@ import { useQuery } from '@teambit/ui-foundation.ui.react-router.use-query';
 import { UseLaneMenu } from '@teambit/lanes.ui.menus.use-lanes-menu';
 import type { LanesHost } from '@teambit/lanes.ui.models.lanes-model';
 import { LanesModel } from '@teambit/lanes.ui.models.lanes-model';
-import type { IgnoreDerivingFromUrl } from '@teambit/lanes.hooks.use-lanes';
+import type { IgnoreDerivingFromUrl, UseLanes } from '@teambit/lanes.hooks.use-lanes';
 import { LanesProvider, useLanes } from '@teambit/lanes.hooks.use-lanes';
 import { LaneSwitcher } from '@teambit/lanes.ui.navigation.lane-switcher';
 import { useViewedLaneFromUrl } from '@teambit/lanes.hooks.use-viewed-lane-from-url';
@@ -303,7 +303,7 @@ export class LanesUI {
     return LanesProvider;
   }
 
-  getUseLanes() {
+  getUseLanes(): UseLanes {
     return useLanes;
   }
 


### PR DESCRIPTION
`bit ci merge` on master started failing with TS2742 in `teambit.lanes/lanes`:

```
lanes.ui.runtime.tsx:306:3 - error TS2742: The inferred type of 'getUseLanes' cannot be named
without a reference to '.../@teambit/lanes.hooks.use-lanes/dist'. A type annotation is necessary.
```

`getUseLanes()` had an inferred return type that TS could only name through a nested capsule path (`@teambit/lanes.hooks.use-lanes` reached via another component's `node_modules`), which isn't portable across capsules.

Fix: annotate `getUseLanes(): UseLanes` — the type `useLanes` already has — so the return type is named via the direct import instead of being inferred through a nested path.