### PR TITLE
chore(envs): migrate components from legacy core envs to modern envs

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -836,7 +836,13 @@
         "scope": "teambit.toolbox",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/hard-link-directory"
+        "rootDir": "scopes/toolbox/fs/hard-link-directory",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "fs/is-dir-empty": {
         "name": "fs/is-dir-empty",
@@ -1232,7 +1238,13 @@
         "scope": "teambit.harmony",
         "version": "0.0.41",
         "mainFile": "feature-toggle.ts",
-        "rootDir": "scopes/harmony/modules/feature-toggle"
+        "rootDir": "scopes/harmony/modules/feature-toggle",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "modules/fetch-html-from-url": {
         "name": "modules/fetch-html-from-url",
@@ -1419,7 +1431,13 @@
         "scope": "teambit.typescript",
         "version": "0.0.87",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/modules/ts-config-mutator"
+        "rootDir": "scopes/typescript/modules/ts-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "modules/workspace-locator": {
         "name": "modules/workspace-locator",

--- a/.bitmap
+++ b/.bitmap
@@ -42,7 +42,13 @@
         "scope": "teambit.toolbox",
         "version": "0.0.3",
         "mainFile": "find-duplications.ts",
-        "rootDir": "scopes/toolbox/array/duplications-finder"
+        "rootDir": "scopes/toolbox/array/duplications-finder",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "aspect": {
         "name": "aspect",
@@ -56,140 +62,260 @@
         "scope": "teambit.compilation",
         "version": "0.0.176",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/babel"
+        "rootDir": "scopes/compilation/aspect-docs/babel",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/builder": {
         "name": "aspect-docs/builder",
         "scope": "teambit.pipelines",
         "version": "0.0.176",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/aspect-docs/builder"
+        "rootDir": "scopes/pipelines/aspect-docs/builder",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/compiler": {
         "name": "aspect-docs/compiler",
         "scope": "teambit.compilation",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/compiler"
+        "rootDir": "scopes/compilation/aspect-docs/compiler",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/component": {
         "name": "aspect-docs/component",
         "scope": "teambit.component",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/aspect-docs/component"
+        "rootDir": "scopes/component/aspect-docs/component",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/compositions": {
         "name": "aspect-docs/compositions",
         "scope": "teambit.compositions",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/aspect-docs/compositions"
+        "rootDir": "scopes/compositions/aspect-docs/compositions",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/dependency-resolver": {
         "name": "aspect-docs/dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "0.0.185",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver"
+        "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/envs": {
         "name": "aspect-docs/envs",
         "scope": "teambit.envs",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/aspect-docs/envs"
+        "rootDir": "scopes/envs/aspect-docs/envs",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/generator": {
         "name": "aspect-docs/generator",
         "scope": "teambit.generator",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/aspect-docs/generator"
+        "rootDir": "scopes/generator/aspect-docs/generator",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/html": {
         "name": "aspect-docs/html",
         "scope": "teambit.html",
         "version": "0.0.132",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/aspect-docs/html"
+        "rootDir": "scopes/html/aspect-docs/html",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/logger": {
         "name": "aspect-docs/logger",
         "scope": "teambit.harmony",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-docs/logger"
+        "rootDir": "scopes/harmony/aspect-docs/logger",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/mdx": {
         "name": "aspect-docs/mdx",
         "scope": "teambit.mdx",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/aspect-docs/mdx"
+        "rootDir": "scopes/mdx/aspect-docs/mdx",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/multi-compiler": {
         "name": "aspect-docs/multi-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/multi-compiler"
+        "rootDir": "scopes/compilation/aspect-docs/multi-compiler",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/node": {
         "name": "aspect-docs/node",
         "scope": "teambit.harmony",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-docs/node"
+        "rootDir": "scopes/harmony/aspect-docs/node",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/pkg": {
         "name": "aspect-docs/pkg",
         "scope": "teambit.pkg",
         "version": "0.0.176",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/aspect-docs/pkg"
+        "rootDir": "scopes/pkg/aspect-docs/pkg",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/pnpm": {
         "name": "aspect-docs/pnpm",
         "scope": "teambit.dependencies",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/pnpm"
+        "rootDir": "scopes/dependencies/aspect-docs/pnpm",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/preview": {
         "name": "aspect-docs/preview",
         "scope": "teambit.preview",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/aspect-docs/preview"
+        "rootDir": "scopes/preview/aspect-docs/preview",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/react": {
         "name": "aspect-docs/react",
         "scope": "teambit.react",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/aspect-docs/react"
+        "rootDir": "scopes/react/aspect-docs/react",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/typescript": {
         "name": "aspect-docs/typescript",
         "scope": "teambit.typescript",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/aspect-docs/typescript"
+        "rootDir": "scopes/typescript/aspect-docs/typescript",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/variants": {
         "name": "aspect-docs/variants",
         "scope": "teambit.workspace",
         "version": "0.0.176",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/aspect-docs/variants"
+        "rootDir": "scopes/workspace/aspect-docs/variants",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-docs/yarn": {
         "name": "aspect-docs/yarn",
         "scope": "teambit.dependencies",
         "version": "0.0.175",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/yarn"
+        "rootDir": "scopes/dependencies/aspect-docs/yarn",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "aspect-loader": {
         "name": "aspect-loader",
@@ -301,21 +427,39 @@
         "scope": "teambit.toolbox",
         "version": "0.0.50",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/tables/cli-table"
+        "rootDir": "scopes/toolbox/tables/cli-table",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "cli/error": {
         "name": "cli/error",
         "scope": "teambit.legacy",
         "version": "0.0.45",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/cli/error"
+        "rootDir": "components/legacy/cli/error",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "cli/webpack-events-listener": {
         "name": "cli/webpack-events-listener",
         "scope": "teambit.preview",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/cli/webpack-events-listener"
+        "rootDir": "scopes/preview/cli/webpack-events-listener",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "cloud": {
         "name": "cloud",
@@ -497,7 +641,13 @@
         "scope": "teambit.harmony",
         "version": "2.0.1112",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli-reference"
+        "rootDir": "scopes/harmony/cli-reference",
+        "config": {
+            "teambit.mdx/mdx-env@3.0.1": {},
+            "teambit.envs/envs": {
+                "env": "teambit.mdx/mdx-env"
+            }
+        }
     },
     "crypto/sha1": {
         "name": "crypto/sha1",
@@ -896,7 +1046,13 @@
         "scope": "teambit.toolbox",
         "version": "0.0.2",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/json/jsonc-utils"
+        "rootDir": "scopes/toolbox/json/jsonc-utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "lanes": {
         "name": "lanes",
@@ -938,7 +1094,13 @@
         "scope": "teambit.mcp",
         "version": "0.0.9",
         "mainFile": "index.ts",
-        "rootDir": "components/mcp/mcp-config-writer"
+        "rootDir": "components/mcp/mcp-config-writer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -1008,7 +1170,13 @@
         "scope": "teambit.compilation",
         "version": "0.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/modules/babel-compiler"
+        "rootDir": "scopes/compilation/modules/babel-compiler",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "modules/component-package-name": {
         "name": "modules/component-package-name",
@@ -1162,7 +1330,13 @@
         "scope": "teambit.harmony",
         "version": "0.0.2",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/load-trace"
+        "rootDir": "scopes/harmony/modules/load-trace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "modules/match-pattern": {
         "name": "modules/match-pattern",
@@ -1183,7 +1357,13 @@
         "scope": "teambit.component",
         "version": "0.0.73",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/modules/merge-helper"
+        "rootDir": "scopes/component/modules/merge-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.2.10": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "modules/module-resolver": {
         "name": "modules/module-resolver",

--- a/scopes/harmony/modules/feature-toggle/feature-toggle.spec.ts
+++ b/scopes/harmony/modules/feature-toggle/feature-toggle.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { addFeature, ENV_VAR_FEATURE_TOGGLE, isFeatureEnabled } from './feature-toggle';
 
 describe('featureToggle', () => {
-  afterAll(() => {
+  after(() => {
     process.env[ENV_VAR_FEATURE_TOGGLE] = '';
   });
   describe('isFeatureEnabled', () => {

--- a/scopes/toolbox/fs/hard-link-directory/hard-link-directory.spec.ts
+++ b/scopes/toolbox/fs/hard-link-directory/hard-link-directory.spec.ts
@@ -1,126 +1,132 @@
+import { expect } from 'chai';
 import fs from 'fs-extra';
 import path from 'path';
 import { globalBitTempDir } from '@teambit/defender.fs.global-bit-temp-dir';
 import symlinkDir from 'symlink-dir';
 import { hardLinkDirectory } from './hard-link-directory';
 
-test('hardLinkDirectory()', async () => {
-  const tempDir = globalBitTempDir();
-  const srcDir = path.join(tempDir, 'source');
-  const dest1Dir = path.join(tempDir, 'dest1');
-  const dest2Dir = path.join(tempDir, 'dest2');
+describe('hardLinkDirectory()', () => {
+  it('should hard link files (excluding node_modules)', async () => {
+    const tempDir = globalBitTempDir();
+    const srcDir = path.join(tempDir, 'source');
+    const dest1Dir = path.join(tempDir, 'dest1');
+    const dest2Dir = path.join(tempDir, 'dest2');
 
-  fs.mkdirpSync(srcDir);
-  fs.mkdirpSync(dest1Dir);
-  fs.mkdirpSync(path.join(srcDir, 'node_modules'));
-  fs.mkdirpSync(path.join(srcDir, 'subdir'));
+    fs.mkdirpSync(srcDir);
+    fs.mkdirpSync(dest1Dir);
+    fs.mkdirpSync(path.join(srcDir, 'node_modules'));
+    fs.mkdirpSync(path.join(srcDir, 'subdir'));
 
-  fs.writeFileSync(path.join(srcDir, 'file.txt'), 'Hello World');
-  fs.writeFileSync(path.join(srcDir, 'subdir/file.txt'), 'Hello World');
-  fs.writeFileSync(path.join(srcDir, 'node_modules/file.txt'), 'Hello World');
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'Hello World');
+    fs.writeFileSync(path.join(srcDir, 'subdir/file.txt'), 'Hello World');
+    fs.writeFileSync(path.join(srcDir, 'node_modules/file.txt'), 'Hello World');
 
-  await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
-
-  // It should link the files from the root
-  expect(fs.readFileSync(path.join(dest1Dir, 'file.txt'), 'utf8')).toBe('Hello World');
-  expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).toBe('Hello World');
-
-  // It should link files from a subdirectory
-  expect(fs.readFileSync(path.join(dest1Dir, 'subdir/file.txt'), 'utf8')).toBe('Hello World');
-  expect(fs.readFileSync(path.join(dest2Dir, 'subdir/file.txt'), 'utf8')).toBe('Hello World');
-
-  // It should not link files from node_modules
-  expect(fs.existsSync(path.join(dest1Dir, 'node_modules/file.txt'))).toBe(false);
-  expect(fs.existsSync(path.join(dest2Dir, 'node_modules/file.txt'))).toBe(false);
-});
-
-test('hard link a directory that has a symlinked directory', async () => {
-  const tempDir = globalBitTempDir();
-  const symlinkTargetDir = path.join(tempDir, 'symlink-target');
-  const srcDir = path.join(tempDir, 'source');
-  const dest1Dir = path.join(tempDir, 'dest1');
-  const dest2Dir = path.join(tempDir, 'dest2');
-
-  fs.mkdirpSync(symlinkTargetDir);
-  fs.writeFileSync(path.join(symlinkTargetDir, 'file.txt'), 'Hello World');
-  fs.mkdirpSync(srcDir);
-  fs.mkdirpSync(dest1Dir);
-  await symlinkDir(symlinkTargetDir, path.join(srcDir, 'symlinked-dir'));
-
-  await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
-
-  expect(fs.readFileSync(path.join(dest1Dir, 'symlinked-dir', 'file.txt'), 'utf8')).toBe('Hello World');
-  expect(fs.readFileSync(path.join(dest2Dir, 'symlinked-dir', 'file.txt'), 'utf8')).toBe('Hello World');
-});
-
-test('copy symlinked files', async () => {
-  const tempDir = globalBitTempDir();
-  const symlinkTargetDir = path.join(tempDir, 'symlink-target');
-  const srcDir = path.join(tempDir, 'source');
-  const dest1Dir = path.join(tempDir, 'dest1');
-  const dest2Dir = path.join(tempDir, 'dest2');
-
-  fs.mkdirpSync(symlinkTargetDir);
-  fs.mkdirpSync(srcDir);
-  fs.mkdirpSync(dest1Dir);
-  const symlinkTargetFile = path.join(symlinkTargetDir, 'file.txt');
-  fs.writeFileSync(symlinkTargetFile, 'Hello World');
-  await symlinkDir(symlinkTargetFile, path.join(srcDir, 'file.txt'));
-
-  await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
-
-  expect(fs.readFileSync(path.join(dest1Dir, 'file.txt'), 'utf8')).toBe('Hello World');
-  expect(fs.lstatSync(path.join(dest1Dir, 'file.txt')).isSymbolicLink()).toBeFalsy();
-  expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).toBe('Hello World');
-  expect(fs.lstatSync(path.join(dest2Dir, 'file.txt')).isSymbolicLink()).toBeFalsy();
-});
-
-test('fall back to copying when hard linking fails with EXDEV', async () => {
-  const tempDir = globalBitTempDir();
-  const srcDir = path.join(tempDir, 'source');
-  const dest1Dir = path.join(tempDir, 'dest1');
-  const dest2Dir = path.join(tempDir, 'dest2');
-
-  fs.mkdirpSync(srcDir);
-  fs.mkdirpSync(dest1Dir);
-  fs.mkdirpSync(dest2Dir);
-  fs.writeFileSync(path.join(srcDir, 'file.txt'), 'Hello World');
-
-  const linkSpy = jest.spyOn(fs, 'link').mockImplementation(() => {
-    const err = new Error('EXDEV: cross-device link not permitted');
-    (err as any).code = 'EXDEV';
-    return Promise.reject(err);
-  });
-  try {
     await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
-  } finally {
-    linkSpy.mockRestore();
-  }
 
-  expect(fs.readFileSync(path.join(dest1Dir, 'file.txt'), 'utf8')).toBe('Hello World');
-  expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).toBe('Hello World');
-  // the fallback copies the file, so it must not share an inode with the source
-  expect(fs.statSync(path.join(dest1Dir, 'file.txt')).ino).not.toBe(fs.statSync(path.join(srcDir, 'file.txt')).ino);
-});
+    // It should link the files from the root
+    expect(fs.readFileSync(path.join(dest1Dir, 'file.txt'), 'utf8')).to.equal('Hello World');
+    expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).to.equal('Hello World');
 
-test('skip broken symlink', async () => {
-  const tempDir = globalBitTempDir();
-  const symlinkTargetDir = path.join(tempDir, 'symlink-target');
-  const srcDir = path.join(tempDir, 'source');
-  const dest1Dir = path.join(tempDir, 'dest1');
-  const dest2Dir = path.join(tempDir, 'dest2');
+    // It should link files from a subdirectory
+    expect(fs.readFileSync(path.join(dest1Dir, 'subdir/file.txt'), 'utf8')).to.equal('Hello World');
+    expect(fs.readFileSync(path.join(dest2Dir, 'subdir/file.txt'), 'utf8')).to.equal('Hello World');
 
-  fs.mkdirpSync(symlinkTargetDir);
-  fs.mkdirpSync(srcDir);
-  fs.mkdirpSync(dest1Dir);
-  fs.mkdirpSync(dest2Dir);
-  const symlinkTargetFile = path.join(symlinkTargetDir, 'file.txt');
-  fs.writeFileSync(symlinkTargetFile, 'Hello World');
-  await symlinkDir(symlinkTargetFile, path.join(srcDir, 'file.txt'));
-  fs.unlinkSync(symlinkTargetFile);
+    // It should not link files from node_modules
+    expect(fs.existsSync(path.join(dest1Dir, 'node_modules/file.txt'))).to.equal(false);
+    expect(fs.existsSync(path.join(dest2Dir, 'node_modules/file.txt'))).to.equal(false);
+  });
 
-  await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
+  it('hard link a directory that has a symlinked directory', async () => {
+    const tempDir = globalBitTempDir();
+    const symlinkTargetDir = path.join(tempDir, 'symlink-target');
+    const srcDir = path.join(tempDir, 'source');
+    const dest1Dir = path.join(tempDir, 'dest1');
+    const dest2Dir = path.join(tempDir, 'dest2');
 
-  expect(fs.readdirSync(dest1Dir)).toEqual([]);
-  expect(fs.readdirSync(dest2Dir)).toEqual([]);
+    fs.mkdirpSync(symlinkTargetDir);
+    fs.writeFileSync(path.join(symlinkTargetDir, 'file.txt'), 'Hello World');
+    fs.mkdirpSync(srcDir);
+    fs.mkdirpSync(dest1Dir);
+    await symlinkDir(symlinkTargetDir, path.join(srcDir, 'symlinked-dir'));
+
+    await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
+
+    expect(fs.readFileSync(path.join(dest1Dir, 'symlinked-dir', 'file.txt'), 'utf8')).to.equal('Hello World');
+    expect(fs.readFileSync(path.join(dest2Dir, 'symlinked-dir', 'file.txt'), 'utf8')).to.equal('Hello World');
+  });
+
+  it('copy symlinked files', async () => {
+    const tempDir = globalBitTempDir();
+    const symlinkTargetDir = path.join(tempDir, 'symlink-target');
+    const srcDir = path.join(tempDir, 'source');
+    const dest1Dir = path.join(tempDir, 'dest1');
+    const dest2Dir = path.join(tempDir, 'dest2');
+
+    fs.mkdirpSync(symlinkTargetDir);
+    fs.mkdirpSync(srcDir);
+    fs.mkdirpSync(dest1Dir);
+    const symlinkTargetFile = path.join(symlinkTargetDir, 'file.txt');
+    fs.writeFileSync(symlinkTargetFile, 'Hello World');
+    await symlinkDir(symlinkTargetFile, path.join(srcDir, 'file.txt'));
+
+    await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
+
+    expect(fs.readFileSync(path.join(dest1Dir, 'file.txt'), 'utf8')).to.equal('Hello World');
+    expect(fs.lstatSync(path.join(dest1Dir, 'file.txt')).isSymbolicLink()).to.equal(false);
+    expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).to.equal('Hello World');
+    expect(fs.lstatSync(path.join(dest2Dir, 'file.txt')).isSymbolicLink()).to.equal(false);
+  });
+
+  it('fall back to copying when hard linking fails with EXDEV', async () => {
+    const tempDir = globalBitTempDir();
+    const srcDir = path.join(tempDir, 'source');
+    const dest1Dir = path.join(tempDir, 'dest1');
+    const dest2Dir = path.join(tempDir, 'dest2');
+
+    fs.mkdirpSync(srcDir);
+    fs.mkdirpSync(dest1Dir);
+    fs.mkdirpSync(dest2Dir);
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'Hello World');
+
+    const originalLink = fs.link;
+    (fs as any).link = () => {
+      const err = new Error('EXDEV: cross-device link not permitted');
+      (err as any).code = 'EXDEV';
+      return Promise.reject(err);
+    };
+    try {
+      await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
+    } finally {
+      (fs as any).link = originalLink;
+    }
+
+    expect(fs.readFileSync(path.join(dest1Dir, 'file.txt'), 'utf8')).to.equal('Hello World');
+    expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).to.equal('Hello World');
+    // the fallback copies the file, so it must not share an inode with the source
+    expect(fs.statSync(path.join(dest1Dir, 'file.txt')).ino).to.not.equal(
+      fs.statSync(path.join(srcDir, 'file.txt')).ino
+    );
+  });
+
+  it('skip broken symlink', async () => {
+    const tempDir = globalBitTempDir();
+    const symlinkTargetDir = path.join(tempDir, 'symlink-target');
+    const srcDir = path.join(tempDir, 'source');
+    const dest1Dir = path.join(tempDir, 'dest1');
+    const dest2Dir = path.join(tempDir, 'dest2');
+
+    fs.mkdirpSync(symlinkTargetDir);
+    fs.mkdirpSync(srcDir);
+    fs.mkdirpSync(dest1Dir);
+    fs.mkdirpSync(dest2Dir);
+    const symlinkTargetFile = path.join(symlinkTargetDir, 'file.txt');
+    fs.writeFileSync(symlinkTargetFile, 'Hello World');
+    await symlinkDir(symlinkTargetFile, path.join(srcDir, 'file.txt'));
+    fs.unlinkSync(symlinkTargetFile);
+
+    await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
+
+    expect(fs.readdirSync(dest1Dir)).to.deep.equal([]);
+    expect(fs.readdirSync(dest2Dir)).to.deep.equal([]);
+  });
 });

--- a/scopes/typescript/modules/ts-config-mutator/ts-config-mutator.spec.ts
+++ b/scopes/typescript/modules/ts-config-mutator/ts-config-mutator.spec.ts
@@ -1,4 +1,5 @@
 // import { CompilerOptions, ModuleKind } from 'typescript';
+import { expect } from 'chai';
 import type { TypeScriptCompilerOptions } from '@teambit/typescript';
 import { TypescriptConfigMutator } from './ts-config-mutator';
 
@@ -19,32 +20,32 @@ describe('ts config mutator test', () => {
     const path = './typesPath1';
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.addTypes([path]);
-    expect(config.raw.types).toContain(path);
+    expect(config.raw.types).to.include(path);
   });
 
   it('set experimental decorators', () => {
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.setExperimentalDecorators(true);
-    expect(config.raw.tsconfig.compilerOptions.experimentalDecorators).toEqual(true);
+    expect(config.raw.tsconfig.compilerOptions.experimentalDecorators).to.equal(true);
   });
 
   it('set target', () => {
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.setTarget('ES2015');
-    expect(config.raw.tsconfig.compilerOptions.target).toEqual('ES2015');
+    expect(config.raw.tsconfig.compilerOptions.target).to.equal('ES2015');
   });
 
   it('add exclude', () => {
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.addExclude(['dist']);
-    expect(config.raw.tsconfig.exclude).toContain('dist');
+    expect(config.raw.tsconfig.exclude).to.include('dist');
   });
 
   it('add multiple excludes', () => {
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.addExclude(['dist', 'public']);
-    expect(config.raw.tsconfig.exclude).toContain('dist');
-    expect(config.raw.tsconfig.exclude).toContain('public');
+    expect(config.raw.tsconfig.exclude).to.include('dist');
+    expect(config.raw.tsconfig.exclude).to.include('public');
   });
 });
 
@@ -53,7 +54,7 @@ describe('ts config mutator combination', () => {
     const path = './typesPath1';
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.addTypes([path]).setTarget('ES2015');
-    expect(config.raw.types).toContain(path);
-    expect(config.raw.tsconfig.compilerOptions.target).toEqual('ES2015');
+    expect(config.raw.types).to.include(path);
+    expect(config.raw.tsconfig.compilerOptions.target).to.equal('ES2015');
   });
 });


### PR DESCRIPTION
Migrates workspace components off the legacy in-repo core envs onto their modern (bit-env) equivalents, ahead of the next major where the old core envs are being cleaned up.

Env mapping (via `bit env replace`/`set`, `.bitmap` + `pnpm-lock.yaml` committed together):
- `teambit.harmony/node` → `teambit.node/envs/node-babel-mocha` — 12 components
- `teambit.mdx/mdx` → `teambit.mdx/mdx-env` — 21 aspect-docs components

The specs of `feature-toggle`, `hard-link-directory`, and `ts-config-mutator` were converted from Jest to Mocha/Chai (with a dependency-free `fs.link` mock) so they run under the `node-babel-mocha` (Mocha) tester.

**React components are intentionally excluded** — the modern `react-env` pins React 18, so re-pointing them would drag the whole workspace's peer resolution from React 19 → 18. They'll be migrated once a React-19 modern env is available.
