### PR TITLE
fix(e2e): pin react-based-env fixture to react-env@1.3.5

### DIFF
--- a/components/legacy/e2e-helper/e2e-env-helper.ts
+++ b/components/legacy/e2e-helper/e2e-env-helper.ts
@@ -180,19 +180,26 @@ export default new EmptyEnv();
     id?: string
   ): string {
     const addOptions = id ? { i: id } : {};
-    // Pin the base react-env to a React 18 version. Otherwise it floats onto the latest
-    // published react-env (2.0.0+, which is on React 19), and react-dom 19 enforces an exact
-    // react/react-dom version match that breaks these tests when they override react to 16/17/18.
-    // Merge into any existing dependency pins rather than replacing them, since
-    // addPolicyToDependencyResolver shallow-assigns and would otherwise drop prior pins.
-    // Guard against a non-object `dependencies` (a few tests set it to a string, e.g. 'chai@4.1.2'),
-    // which would otherwise spread into a char-indexed object and corrupt the policy.
-    const existingDeps = this.extensions.workspaceJsonc.getPolicyFromDependencyResolver()?.dependencies;
-    const existingPolicyDeps =
-      existingDeps && typeof existingDeps === 'object' && !Array.isArray(existingDeps) ? existingDeps : {};
-    this.extensions.workspaceJsonc.addPolicyToDependencyResolver({
-      dependencies: { ...existingPolicyDeps, '@teambit/react.react-env': '1.3.5' },
-    });
+    // Pin the base react-env to a React 18 version, but only for envs that actually pull in react-env.
+    // Otherwise it floats onto the latest published react-env (2.0.0+, which is on React 19), and
+    // react-dom 19 enforces an exact react/react-dom version match that breaks these tests when they
+    // override react to 16/17/18. Skipping the pin for non-React fixtures (e.g. a mocha-only env)
+    // avoids installing react-env where it isn't used.
+    const usesReactEnv = basePackages.some(
+      (pkg) => pkg === '@teambit/react.react-env' || pkg.startsWith('@teambit/react.react-env@')
+    );
+    if (usesReactEnv) {
+      // Merge into any existing dependency pins rather than replacing them, since
+      // addPolicyToDependencyResolver shallow-assigns and would otherwise drop prior pins.
+      // Guard against a non-object `dependencies` (a few tests set it to a string, e.g. 'chai@4.1.2'),
+      // which would otherwise spread into a char-indexed object and corrupt the policy.
+      const existingDeps = this.extensions.workspaceJsonc.getPolicyFromDependencyResolver()?.dependencies;
+      const existingPolicyDeps =
+        existingDeps && typeof existingDeps === 'object' && !Array.isArray(existingDeps) ? existingDeps : {};
+      this.extensions.workspaceJsonc.addPolicyToDependencyResolver({
+        dependencies: { ...existingPolicyDeps, '@teambit/react.react-env': '1.3.5' },
+      });
+    }
     this.fixtures.copyFixtureExtensions(extensionsBaseFolder, undefined, targetFolder);
     this.command.addComponent(targetFolder || extensionsBaseFolder, addOptions);
     this.fixtures.generateEnvJsoncFile(targetFolder || extensionsBaseFolder, envJsoncOptions);

--- a/components/legacy/e2e-helper/e2e-env-helper.ts
+++ b/components/legacy/e2e-helper/e2e-env-helper.ts
@@ -185,7 +185,11 @@ export default new EmptyEnv();
     // react/react-dom version match that breaks these tests when they override react to 16/17/18.
     // Merge into any existing dependency pins rather than replacing them, since
     // addPolicyToDependencyResolver shallow-assigns and would otherwise drop prior pins.
-    const existingPolicyDeps = this.extensions.workspaceJsonc.getPolicyFromDependencyResolver()?.dependencies || {};
+    // Guard against a non-object `dependencies` (a few tests set it to a string, e.g. 'chai@4.1.2'),
+    // which would otherwise spread into a char-indexed object and corrupt the policy.
+    const existingDeps = this.extensions.workspaceJsonc.getPolicyFromDependencyResolver()?.dependencies;
+    const existingPolicyDeps =
+      existingDeps && typeof existingDeps === 'object' && !Array.isArray(existingDeps) ? existingDeps : {};
     this.extensions.workspaceJsonc.addPolicyToDependencyResolver({
       dependencies: { ...existingPolicyDeps, '@teambit/react.react-env': '1.3.5' },
     });

--- a/components/legacy/e2e-helper/e2e-env-helper.ts
+++ b/components/legacy/e2e-helper/e2e-env-helper.ts
@@ -183,8 +183,11 @@ export default new EmptyEnv();
     // Pin the base react-env to a React 18 version. Otherwise it floats onto the latest
     // published react-env (2.0.0+, which is on React 19), and react-dom 19 enforces an exact
     // react/react-dom version match that breaks these tests when they override react to 16/17/18.
+    // Merge into any existing dependency pins rather than replacing them, since
+    // addPolicyToDependencyResolver shallow-assigns and would otherwise drop prior pins.
+    const existingPolicyDeps = this.extensions.workspaceJsonc.getPolicyFromDependencyResolver()?.dependencies || {};
     this.extensions.workspaceJsonc.addPolicyToDependencyResolver({
-      dependencies: { '@teambit/react.react-env': '1.3.5' },
+      dependencies: { ...existingPolicyDeps, '@teambit/react.react-env': '1.3.5' },
     });
     this.fixtures.copyFixtureExtensions(extensionsBaseFolder, undefined, targetFolder);
     this.command.addComponent(targetFolder || extensionsBaseFolder, addOptions);

--- a/components/legacy/e2e-helper/e2e-env-helper.ts
+++ b/components/legacy/e2e-helper/e2e-env-helper.ts
@@ -173,13 +173,19 @@ export default new EmptyEnv();
    */
   setCustomNewEnv(
     extensionsBaseFolder = 'react-based-env',
-    basePackages: string[] = ['@teambit/react.react-env'],
+    basePackages: string[] = ['@teambit/react.react-env@1.3.5'],
     envJsoncOptions: GenerateEnvJsoncOptions = { policy: ENV_POLICY },
     runInstall = true,
     targetFolder?: string,
     id?: string
   ): string {
     const addOptions = id ? { i: id } : {};
+    // Pin the base react-env to a React 18 version. Otherwise it floats onto the latest
+    // published react-env (2.0.0+, which is on React 19), and react-dom 19 enforces an exact
+    // react/react-dom version match that breaks these tests when they override react to 16/17/18.
+    this.extensions.workspaceJsonc.addPolicyToDependencyResolver({
+      dependencies: { '@teambit/react.react-env': '1.3.5' },
+    });
     this.fixtures.copyFixtureExtensions(extensionsBaseFolder, undefined, targetFolder);
     this.command.addComponent(targetFolder || extensionsBaseFolder, addOptions);
     this.fixtures.generateEnvJsoncFile(targetFolder || extensionsBaseFolder, envJsoncOptions);

--- a/components/legacy/e2e-helper/e2e-workspace-jsonc-helper.ts
+++ b/components/legacy/e2e-helper/e2e-workspace-jsonc-helper.ts
@@ -84,7 +84,9 @@ export default class WorkspaceJsoncHelper {
 
   addKeyValToDependencyResolver(key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
     const workspaceJsonc = this.read(bitJsoncDir);
-    const depResolver = workspaceJsonc['teambit.dependencies/dependency-resolver'];
+    // default to {} so callers can add to a workspace that has no dependency-resolver entry yet,
+    // instead of assign() throwing on an undefined target.
+    const depResolver = workspaceJsonc['teambit.dependencies/dependency-resolver'] || {};
     assign(depResolver, { [key]: val });
     this.addKeyVal('teambit.dependencies/dependency-resolver', depResolver, bitJsoncDir);
   }
@@ -92,11 +94,13 @@ export default class WorkspaceJsoncHelper {
   getPolicyFromDependencyResolver() {
     const workspaceJsonc = this.read();
     const depResolver = workspaceJsonc['teambit.dependencies/dependency-resolver'];
-    return depResolver.policy;
+    return depResolver?.policy;
   }
 
   addPolicyToDependencyResolver(policy: Record<string, any>) {
-    const currentPolicy = this.getPolicyFromDependencyResolver();
+    // default to {} so the first policy can be added to a workspace with no existing policy,
+    // instead of assign() throwing on an undefined target.
+    const currentPolicy = this.getPolicyFromDependencyResolver() || {};
     assign(currentPolicy, policy);
     this.addKeyValToDependencyResolver('policy', currentPolicy);
   }

--- a/e2e/harmony/deps-graph.e2e.ts
+++ b/e2e/harmony/deps-graph.e2e.ts
@@ -87,8 +87,13 @@ chai.use(chaiFs);
       helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-react/env1`, {});
       helper.extensions.addExtensionToVariant('comp2', `${helper.scopes.remote}/custom-react/env2`, {});
       helper.extensions.addExtensionToVariant('custom-react', 'teambit.envs/env', {});
+      // Preserve existing policy pins (e.g. the base react-env pinned by setCustomNewEnv) instead of
+      // replacing the whole policy. Otherwise react-env floats onto React 19 and its react-dom 19
+      // trips the exact react/react-dom version check against the React 16/17 env peers above.
+      const existingPolicyDeps = helper.workspaceJsonc.getPolicyFromDependencyResolver()?.dependencies || {};
       helper.workspaceJsonc.addKeyValToDependencyResolver('policy', {
         dependencies: {
+          ...existingPolicyDeps,
           '@pnpm.e2e/foo': '^100.0.0',
           '@pnpm.e2e/bar': '^100.0.0',
         },


### PR DESCRIPTION
The `react-based-env` e2e fixture (used by `setCustomNewEnv`) extends `@teambit/react.react-env` **unpinned**, so it floats onto the latest published react-env. react-env 2.0.0 moved to React 19, whose react-dom enforces an exact react/react-dom version match — so tests that override react to 16/17/18 now fail during install with `Incompatible React versions`.

Pin the fixture's base react-env to 1.3.5 (React 18) so react-dom stays on 18 and these tests are deterministic regardless of new react-env releases.

Unblocks the e2e failures in root-components, deps-graph, env-jsonc-policies, and optional-dependencies (affecting all PRs and master).