### PR TITLE
fix(config-merger): propagate other-lane env migrations with their version

### DIFF
--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -483,6 +483,53 @@ describe('merge config scenarios', function () {
       });
     });
   });
+  describe('other lane bumped the env VERSION only, current lane kept a workspace env', () => {
+    // comp1 uses a WORKSPACE-component env. The lane never changes comp1's env; only "other" (main) bumps
+    // the env version. Because the env is a workspace component, the merge must NOT sync the other side's
+    // env version onto the lane — the workspace owns its env version. This guards the config-merger env
+    // propagation change: propagate real env *migrations* (id change), but leave workspace-env version
+    // bumps alone.
+    let envName: string;
+    let envId: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.env.setEmptyEnv(); // lightweight workspace-component env named "empty-env"
+      envName = 'empty-env';
+      envId = `${helper.scopes.remote}/${envName}`;
+      helper.command.setEnv('comp1', envId);
+      helper.command.tagAllWithoutBuild(); // envName@0.0.1, comp1@0.0.1 (env envId@0.0.1)
+      helper.command.export();
+      const base = helper.scopeHelper.cloneWorkspace();
+
+      // Lane (current): does NOT change comp1's env; just snaps an (unmodified) divergence.
+      helper.command.createLane('dev');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      const laneWs = helper.scopeHelper.cloneWorkspace();
+
+      // Main (other): bump the env to 0.0.2 and point comp1 at it, so main's comp1 uses envId@0.0.2.
+      helper.scopeHelper.getClonedWorkspace(base);
+      helper.command.tagWithoutBuild(envName, '--skip-auto-tag --unmodified'); // envName@0.0.2
+      helper.command.setEnv('comp1', `${envId}@0.0.2`);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      // Merge main into the lane, in a workspace where the env is still a tracked workspace component.
+      // --ignore-config-changes: the env component itself diverged (0.0.1 vs 0.0.2) and would otherwise
+      // block the merge asking to snap it; we only care about comp1's env config here.
+      helper.scopeHelper.getClonedWorkspace(laneWs);
+      helper.command.import();
+      helper.command.mergeLaneWithoutBuild('main', '--no-auto-snap --ignore-config-changes');
+    });
+    it("should NOT sync the other lane's env version onto the lane (keep the workspace env version)", () => {
+      // main's bumped env version must NOT be adopted onto the lane.
+      expect(helper.command.showAspectConfig('comp1', `${envId}@0.0.2`)).to.be.undefined;
+      // the lane keeps its own workspace env; teambit.envs/envs holds the id without a version.
+      const envConfig = helper.command.showAspectConfig('comp1', Extensions.envs);
+      expect(envConfig.config.env).to.equal(envId);
+    });
+  });
   // for this test, there are two workspace.
   // 1. includes a component "bar/foo" which is used as a package for the another workspace.
   // 2. has a component "comp1", which uses bar.foo pkg in different versions.

--- a/scopes/workspace/config-merger/component-config-merger.spec.ts
+++ b/scopes/workspace/config-merger/component-config-merger.spec.ts
@@ -3,6 +3,7 @@ import { ComponentID } from '@teambit/component-id';
 import { EnvsAspect } from '@teambit/envs';
 import { ExtensionDataEntry, ExtensionDataList } from '@teambit/legacy.extension-data';
 import type { Logger } from '@teambit/logger';
+import type { MergeStrategy } from '@teambit/component.modules.merge-helper';
 import { ComponentConfigMerger } from './component-config-merger';
 
 const noopLogger = { debug() {}, trace() {} } as unknown as Logger;
@@ -19,7 +20,8 @@ function mergeEnvConfig(
   current: ExtensionDataList,
   base: ExtensionDataList,
   other: ExtensionDataList,
-  workspaceIds: ComponentID[]
+  workspaceIds: ComponentID[],
+  mergeStrategy: MergeStrategy = 'ours'
 ) {
   const merger = new ComponentConfigMerger(
     'my-scope/some-comp',
@@ -31,7 +33,7 @@ function mergeEnvConfig(
     'lane',
     'main',
     noopLogger,
-    'ours'
+    mergeStrategy
   );
   return merger.merge().getSuccessfullyMergedConfig();
 }
@@ -88,6 +90,27 @@ describe('ComponentConfigMerger', () => {
     });
     it('should keep the lane env and not sync teambit.envs/envs from "other"', () => {
       expect(mergedConfig[EnvsAspect.id]).to.be.undefined;
+    });
+  });
+
+  describe('base env version is unknown (base env-aspect entry absent)', () => {
+    // base and current share the env id, but base's version is unknown (its env-aspect entry is missing).
+    // that must NOT be treated as "the current lane changed its env" — otherwise the keep-workspace-env
+    // short-circuit would fire and silently swallow the env change made on "other". Instead the normal
+    // 3-way merge applies; with 'theirs' it takes the other lane's env (with its version).
+    let mergedConfig: Record<string, any>;
+    before(() => {
+      const env = 'my-scope.envs/ws-env'; // same env id on base & current; also a workspace component.
+      const otherEnv = 'other-scope.envs/ext-env';
+      // base carries the env id but NO env-aspect entry -> its version resolves to undefined (unknown).
+      const base = new ExtensionDataList(envsEntry(env));
+      const current = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@0.0.1`));
+      const other = new ExtensionDataList(envsEntry(otherEnv), envAspectEntry(`${otherEnv}@1.0.0`));
+      const workspaceIds = [ComponentID.fromString(`${env}@0.0.1`)];
+      mergedConfig = mergeEnvConfig(current, base, other, workspaceIds, 'theirs');
+    });
+    it('should not short-circuit on the workspace env; the merge strategy decides (takes other)', () => {
+      expect(mergedConfig[EnvsAspect.id]).to.deep.equal({ env: 'other-scope.envs/ext-env@1.0.0' });
     });
   });
 });

--- a/scopes/workspace/config-merger/component-config-merger.spec.ts
+++ b/scopes/workspace/config-merger/component-config-merger.spec.ts
@@ -40,13 +40,14 @@ describe('ComponentConfigMerger', () => {
   // teambit.envs/envs is a core extension at full runtime (registered by the core aspects). Register it here
   // so the merger behaves the same inside an isolated component test, and restore the prior state afterwards
   // so we don't leak into the shared static map (which would make other tests order-dependent).
-  let hadEnvsCoreName: boolean;
+  let prevEnvsCoreName: string | undefined;
   before(() => {
-    hadEnvsCoreName = ExtensionDataList.coreExtensionsNames.has(EnvsAspect.id);
+    prevEnvsCoreName = ExtensionDataList.coreExtensionsNames.get(EnvsAspect.id);
     ExtensionDataList.coreExtensionsNames.set(EnvsAspect.id, '');
   });
   after(() => {
-    if (!hadEnvsCoreName) ExtensionDataList.coreExtensionsNames.delete(EnvsAspect.id);
+    if (prevEnvsCoreName === undefined) ExtensionDataList.coreExtensionsNames.delete(EnvsAspect.id);
+    else ExtensionDataList.coreExtensionsNames.set(EnvsAspect.id, prevEnvsCoreName);
   });
 
   describe('env migrated on "other" (main) while the current lane kept the old env', () => {

--- a/scopes/workspace/config-merger/component-config-merger.spec.ts
+++ b/scopes/workspace/config-merger/component-config-merger.spec.ts
@@ -113,4 +113,23 @@ describe('ComponentConfigMerger', () => {
       expect(mergedConfig[EnvsAspect.id]).to.deep.equal({ env: 'other-scope.envs/ext-env@1.0.0' });
     });
   });
+
+  describe('other bumped only the VERSION of the same workspace env (no id change)', () => {
+    // current and other use the SAME workspace env id; only the version differs and the current lane did not
+    // change it (base === current). A workspace env's version is owned by the workspace, so the other lane's
+    // version must NOT be synced. (Uses 'theirs' to prove it's the keep-env short-circuit, not the strategy,
+    // that prevents the sync — a plain 3-way merge with base===current would otherwise adopt other's version.)
+    let mergedConfig: Record<string, any>;
+    before(() => {
+      const env = 'my-scope.envs/ws-env'; // workspace-component env, same id on both sides.
+      const base = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@0.0.1`));
+      const current = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@0.0.1`));
+      const other = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@0.0.2`));
+      const workspaceIds = [ComponentID.fromString(`${env}@0.0.1`)];
+      mergedConfig = mergeEnvConfig(current, base, other, workspaceIds, 'theirs');
+    });
+    it("should keep the workspace env and NOT sync the other lane's version", () => {
+      expect(mergedConfig[EnvsAspect.id]).to.be.undefined;
+    });
+  });
 });

--- a/scopes/workspace/config-merger/component-config-merger.spec.ts
+++ b/scopes/workspace/config-merger/component-config-merger.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import { ComponentID } from '@teambit/component-id';
+import { EnvsAspect } from '@teambit/envs';
+import { ExtensionDataEntry, ExtensionDataList } from '@teambit/legacy.extension-data';
+import type { Logger } from '@teambit/logger';
+import { ComponentConfigMerger } from './component-config-merger';
+
+const noopLogger = { debug() {}, trace() {} } as unknown as Logger;
+
+// A core-style teambit.envs/envs entry (matched by `name`, so it works without the runtime
+// core-extensions registry being populated — as is the case in an isolated component test).
+const envsEntry = (env: string) => new ExtensionDataEntry(undefined, undefined, EnvsAspect.id, { env }, {});
+// The separate env-aspect entry that carries the resolved version (`id@version`). As stored in a committed
+// version, teambit.envs/envs.config.env holds the id WITHOUT a version; the version lives only here.
+const envAspectEntry = (idWithVersion: string) =>
+  new ExtensionDataEntry(undefined, ComponentID.fromString(idWithVersion), undefined, {}, {});
+
+function mergeEnvConfig(
+  current: ExtensionDataList,
+  base: ExtensionDataList,
+  other: ExtensionDataList,
+  workspaceIds: ComponentID[]
+) {
+  const merger = new ComponentConfigMerger(
+    'my-scope/some-comp',
+    workspaceIds,
+    undefined,
+    current,
+    base,
+    other,
+    'lane',
+    'main',
+    noopLogger,
+    'ours'
+  );
+  return merger.merge().getSuccessfullyMergedConfig();
+}
+
+describe('ComponentConfigMerger', () => {
+  // teambit.envs/envs is a core extension at full runtime (registered by the core aspects). Register it here
+  // so the merger behaves the same inside an isolated component test, and restore the prior state afterwards
+  // so we don't leak into the shared static map (which would make other tests order-dependent).
+  let hadEnvsCoreName: boolean;
+  before(() => {
+    hadEnvsCoreName = ExtensionDataList.coreExtensionsNames.has(EnvsAspect.id);
+    ExtensionDataList.coreExtensionsNames.set(EnvsAspect.id, '');
+  });
+  after(() => {
+    if (!hadEnvsCoreName) ExtensionDataList.coreExtensionsNames.delete(EnvsAspect.id);
+  });
+
+  describe('env migrated on "other" (main) while the current lane kept the old env', () => {
+    // Reproduces the `bit ci pr` config-sync scenario: the PR lane never touched its env (base === current)
+    // and main migrated the component onto a different EXTERNAL env. The change should propagate from main,
+    // and critically must carry the version — syncing teambit.envs/envs.config.env alone (id without version)
+    // would produce an unversioned external env and crash the snap with ExternalEnvWithoutVersion.
+    let mergedConfig: Record<string, any>;
+    before(() => {
+      const oldEnv = 'my-scope.envs/ws-env'; // the env the lane keeps; it's also a workspace component.
+      const newEnv = 'other-scope.envs/ext-env'; // the external env main migrated to.
+      // base === current: the lane didn't change its env.
+      const base = new ExtensionDataList(envsEntry(oldEnv), envAspectEntry(`${oldEnv}@0.0.1`));
+      const current = new ExtensionDataList(envsEntry(oldEnv), envAspectEntry(`${oldEnv}@0.0.1`));
+      const other = new ExtensionDataList(envsEntry(newEnv), envAspectEntry(`${newEnv}@1.0.0`));
+      // `oldEnv` is a workspace component — this used to make envStrategy keep it instead of propagating.
+      const workspaceIds = [ComponentID.fromString(`${oldEnv}@0.0.1`)];
+      mergedConfig = mergeEnvConfig(current, base, other, workspaceIds);
+    });
+    it('should sync the env from main WITH its version (no unversioned env leak)', () => {
+      expect(mergedConfig[EnvsAspect.id]).to.deep.equal({ env: 'other-scope.envs/ext-env@1.0.0' });
+    });
+  });
+
+  describe('current lane deliberately switched to a workspace env', () => {
+    // The lane changed its env (base !== current) to a workspace component. That's a deliberate choice for
+    // this lane, so a differing env on "other" must NOT override it.
+    let mergedConfig: Record<string, any>;
+    before(() => {
+      const baseEnv = 'other-scope.envs/orig-env';
+      const laneEnv = 'my-scope.envs/ws-env'; // the lane switched to this workspace env.
+      const otherEnv = 'other-scope.envs/ext-env';
+      const base = new ExtensionDataList(envsEntry(baseEnv), envAspectEntry(`${baseEnv}@0.9.0`));
+      const current = new ExtensionDataList(envsEntry(laneEnv), envAspectEntry(`${laneEnv}@0.0.1`));
+      const other = new ExtensionDataList(envsEntry(otherEnv), envAspectEntry(`${otherEnv}@1.0.0`));
+      const workspaceIds = [ComponentID.fromString(`${laneEnv}@0.0.1`)];
+      mergedConfig = mergeEnvConfig(current, base, other, workspaceIds);
+    });
+    it('should keep the lane env and not sync teambit.envs/envs from "other"', () => {
+      expect(mergedConfig[EnvsAspect.id]).to.be.undefined;
+    });
+  });
+});

--- a/scopes/workspace/config-merger/component-config-merger.ts
+++ b/scopes/workspace/config-merger/component-config-merger.ts
@@ -216,11 +216,17 @@ export class ComponentConfigMerger {
       !this.baseEnv ||
       this.baseEnv.id !== this.currentEnv.id ||
       Boolean(this.baseEnv.version && this.currentEnv.version && this.baseEnv.version !== this.currentEnv.version);
-    // if the current lane deliberately set its env to a workspace component (or one that exists on the other
-    // lane), keep it — that's the env the user chose for this lane. but if the current lane did NOT touch the
-    // env (base === current) and only "other" changed it (e.g. an env migration on main), don't short-circuit:
-    // fall through to the 3-way merge below so "other"'s env propagates *with its version*.
-    if (currentChangedEnvFromBase && this.isIdInWorkspaceOrOtherLane(this.currentEnv.id, this.currentEnv.version)) {
+    // did "other" switch to a *different* env (a migration), or merely bump the same env's version?
+    const envIdChanged = this.currentEnv.id !== this.otherEnv.id;
+    // keep the current env (don't sync from "other") when it's a workspace component (or exists on the other
+    // lane) AND either the current lane deliberately changed its env, OR only the env's *version* differs.
+    // rationale: a workspace env's version is owned by the workspace, so we never adopt a different version of
+    // the *same* env from the other lane. only a genuine env *migration* (id change) that the current lane did
+    // not make is allowed to propagate — handled by the 3-way merge below (with the new env's version).
+    if (
+      (currentChangedEnvFromBase || !envIdChanged) &&
+      this.isIdInWorkspaceOrOtherLane(this.currentEnv.id, this.currentEnv.version)
+    ) {
       return null;
     }
     return this.basicConfigMerge(mergeStrategyParams);

--- a/scopes/workspace/config-merger/component-config-merger.ts
+++ b/scopes/workspace/config-merger/component-config-merger.ts
@@ -209,8 +209,13 @@ export class ComponentConfigMerger {
       return null;
     }
     // did the current lane deliberately change its env away from the diversion point (base)?
+    // a version difference counts only when both sides have a known version — a missing base version
+    // (versionless/core env, or an absent base env-aspect entry) is "unknown", not "changed", so it must
+    // not block propagation of an env change made on the other lane.
     const currentChangedEnvFromBase =
-      !this.baseEnv || this.baseEnv.id !== this.currentEnv.id || this.baseEnv.version !== this.currentEnv.version;
+      !this.baseEnv ||
+      this.baseEnv.id !== this.currentEnv.id ||
+      Boolean(this.baseEnv.version && this.currentEnv.version && this.baseEnv.version !== this.currentEnv.version);
     // if the current lane deliberately set its env to a workspace component (or one that exists on the other
     // lane), keep it — that's the env the user chose for this lane. but if the current lane did NOT touch the
     // env (base === current) and only "other" changed it (e.g. an env migration on main), don't short-circuit:

--- a/scopes/workspace/config-merger/component-config-merger.ts
+++ b/scopes/workspace/config-merger/component-config-merger.ts
@@ -71,7 +71,12 @@ export class ComponentConfigMerger {
   private currentEnv: EnvData;
   private otherEnv: EnvData;
   private baseEnv?: EnvData;
-  private handledExtIds: string[] = [BuilderAspect.id]; // don't try to merge builder, it's possible that at one end it wasn't built yet, so it's empty
+  // don't try to merge builder, it's possible that at one end it wasn't built yet, so it's empty.
+  // teambit.envs/envs is handled exclusively by envStrategy() — the generic aspect merge only sees the
+  // raw `config.env`, which never carries the env's version (the version lives in the separate env-aspect
+  // entry that only envStrategy knows to attach). Letting the generic merge run would leak an unversioned
+  // external env and break the snap with ExternalEnvWithoutVersion.
+  private handledExtIds: string[] = [BuilderAspect.id, EnvsAspect.id];
   private otherLaneIdsStr: string[];
   constructor(
     private compIdStr: string,
@@ -203,8 +208,14 @@ export class ComponentConfigMerger {
     if (this.currentEnv.id === this.otherEnv.id && this.currentEnv.version === this.otherEnv.version) {
       return null;
     }
-    if (this.isIdInWorkspaceOrOtherLane(this.currentEnv.id, this.otherEnv.version)) {
-      // the env currently used is part of the workspace, that's what the user needs. don't try to resolve anything.
+    // did the current lane deliberately change its env away from the diversion point (base)?
+    const currentChangedEnvFromBase =
+      !this.baseEnv || this.baseEnv.id !== this.currentEnv.id || this.baseEnv.version !== this.currentEnv.version;
+    // if the current lane deliberately set its env to a workspace component (or one that exists on the other
+    // lane), keep it — that's the env the user chose for this lane. but if the current lane did NOT touch the
+    // env (base === current) and only "other" changed it (e.g. an env migration on main), don't short-circuit:
+    // fall through to the 3-way merge below so "other"'s env propagates *with its version*.
+    if (currentChangedEnvFromBase && this.isIdInWorkspaceOrOtherLane(this.currentEnv.id, this.currentEnv.version)) {
       return null;
     }
     return this.basicConfigMerge(mergeStrategyParams);


### PR DESCRIPTION
## Problem

`bit ci pr --keep-lane` syncs main's config onto the PR lane via `ComponentConfigMerger`. When main migrated a component to a different env while the PR lane never touched its env, the config-sync either crashed the snap with `ExternalEnvWithoutVersion` or kept the stale env.

Root cause: `teambit.envs/envs` was processed by both `envStrategy()` and the generic aspect-merge loop. The generic loop only sees `config.env` (the id *without* a version — the version lives in a separate env-aspect entry), so it leaked an unversioned external env whenever `envStrategy()` declined. And `envStrategy()` declined for *any* current env that is a workspace component, even when the lane hadn't changed the env, so a genuine env migration on main was never propagated.

## Fix

- Handle `teambit.envs/envs` exclusively in `envStrategy()` (add `EnvsAspect.id` to `handledExtIds`), so the generic merge can no longer leak an unversioned env.
- Narrow the "keep the workspace env" short-circuit: a genuine env **migration** (env id change) the lane didn't make now propagates from the other lane **with its version**, while the env is kept when the lane deliberately changed it **or** when only the env's *version* differs (same id) — a workspace env's version is owned by the workspace and must not be adopted from the other lane.
- Treat an unknown base env version as "unknown" (not "changed"), and check workspace/other-lane membership using the current env's own version.

## Tests

`component-config-merger.spec.ts` (each verified to fail without its guard):
- env migrated on main while the lane kept the old env → main's env is adopted **with its version**;
- lane deliberately switched to a workspace env → kept;
- unknown base env version → doesn't block propagation;
- other lane bumped only the **version** of the same workspace env → not synced.

`merge-config.e2e.ts`: a lane keeps its workspace env when the other lane only bumped the env version (lightweight `EmptyEnv`).
