### PR TITLE
chore: migrate scripts aspect to core-aspect-env, fix feature-toggle spec isolation

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1519,7 +1519,13 @@
         "scope": "teambit.workspace",
         "version": "0.0.264",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.1.7": {},
+            "teambit.envs/envs": {
+                "env": "teambit.harmony/envs/core-aspect-env"
+            }
+        }
     },
     "sidebar": {
         "name": "sidebar",

--- a/scopes/harmony/modules/feature-toggle/feature-toggle.spec.ts
+++ b/scopes/harmony/modules/feature-toggle/feature-toggle.spec.ts
@@ -1,10 +1,18 @@
 import { expect } from 'chai';
 
-import { addFeature, ENV_VAR_FEATURE_TOGGLE, isFeatureEnabled } from './feature-toggle';
+import { addFeature, ENV_VAR_FEATURE_TOGGLE, isFeatureEnabled, reloadFeatureToggle } from './feature-toggle';
 
 describe('featureToggle', () => {
+  // the FeatureToggle singleton caches the features on first use. when mocha runs multiple
+  // spec files in the same process, an earlier spec may have already populated the cache,
+  // so reset it before each test to make the env-var changes below take effect.
+  beforeEach(() => {
+    delete process.env[ENV_VAR_FEATURE_TOGGLE];
+    reloadFeatureToggle();
+  });
   after(() => {
-    process.env[ENV_VAR_FEATURE_TOGGLE] = '';
+    delete process.env[ENV_VAR_FEATURE_TOGGLE];
+    reloadFeatureToggle();
   });
   describe('isFeatureEnabled', () => {
     it('should work with multiple features', () => {

--- a/scopes/harmony/modules/feature-toggle/feature-toggle.spec.ts
+++ b/scopes/harmony/modules/feature-toggle/feature-toggle.spec.ts
@@ -3,6 +3,10 @@ import { expect } from 'chai';
 import { addFeature, ENV_VAR_FEATURE_TOGGLE, isFeatureEnabled, reloadFeatureToggle } from './feature-toggle';
 
 describe('featureToggle', () => {
+  let originalEnvValue: string | undefined;
+  before(() => {
+    originalEnvValue = process.env[ENV_VAR_FEATURE_TOGGLE];
+  });
   // the FeatureToggle singleton caches the features on first use. when mocha runs multiple
   // spec files in the same process, an earlier spec may have already populated the cache,
   // so reset it before each test to make the env-var changes below take effect.
@@ -10,8 +14,10 @@ describe('featureToggle', () => {
     delete process.env[ENV_VAR_FEATURE_TOGGLE];
     reloadFeatureToggle();
   });
+  // restore the pre-suite env-var value so later specs in the same process are unaffected.
   after(() => {
-    delete process.env[ENV_VAR_FEATURE_TOGGLE];
+    if (originalEnvValue === undefined) delete process.env[ENV_VAR_FEATURE_TOGGLE];
+    else process.env[ENV_VAR_FEATURE_TOGGLE] = originalEnvValue;
     reloadFeatureToggle();
   });
   describe('isFeatureEnabled', () => {


### PR DESCRIPTION
`teambit.workspace/scripts` was the only component still on the `teambit.harmony/aspect` env — every other aspect was migrated to `core-aspect-env`. Since the aspect env's `exports` map has no `types` condition, resolvers that honor `exports` (TS `bundler`/`node16`) can't find the package's type declarations and fail with TS2307. Setting the env to `core-aspect-env@0.1.7` aligns it with the rest of the repo and fixes the resolution.

Also fixes a test-isolation bug in `feature-toggle.spec.ts`: the `FeatureToggle` singleton caches the features on first use, so when mocha runs multiple spec files in one process, a previously-run spec can populate the cache before this spec sets `BIT_FEATURES`, failing its assertions. Reset the cache with `reloadFeatureToggle()` in `beforeEach`.

`pnpm-lock.yaml` was regenerated by `bit install` following the env change.
