### PR TITLE
feat(import): add --write-to-empty-dir flag

### DIFF
--- a/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
+++ b/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
@@ -418,7 +418,7 @@ Flags: --internal
 bring components from remote scopes into your workspace
 
 brings component source files from remote scopes into your workspace and installs their dependencies as packages. supports pattern matching for bulk imports, merge strategies for handling conflicts, and various optimization options. without arguments, fetches all workspace components' latest versions from their remote scopes.
-Flags: --path <path>, --objects, --override, --verbose, --json, --skip-dependency-installation, --skip-write-config-files, --merge [strategy], --dependencies, --dependencies-head, --dependencies-depth <n>, --dependents, --dependents-via <string>, --dependents-all, --silent, --filter-envs <envs>, --save-in-lane, --all-history, --fetch-deps, --write-deps <target>, --track-only, --include-deprecated, --lane-only, --owner
+Flags: --path <path>, --objects, --override, --verbose, --json, --skip-dependency-installation, --skip-write-config-files, --merge [strategy], --dependencies, --dependencies-head, --dependencies-depth <n>, --dependents, --dependents-via <string>, --dependents-all, --silent, --filter-envs <envs>, --save-in-lane, --all-history, --fetch-deps, --write-deps <target>, --track-only, --include-deprecated, --lane-only, --owner, --write-to-empty-dir
 
 ## bit init [path]
 

--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -161,6 +161,46 @@ describe('import functionality on Harmony', function () {
       expect(importOutput).to.include('1 new version(s) available, latest 0.0.3');
     });
   });
+  describe('import into a non-empty directory that is not tracked in .bitmap (with --write-to-empty-dir)', () => {
+    let defaultDir: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      // import once to populate the default directory with the component files.
+      helper.command.importComponentWithoutInstall('comp1');
+      const bitMap = helper.bitMap.read();
+      defaultDir = bitMap.comp1.rootDir;
+      // remove the .bitmap tracking of comp1 but keep the files on disk. now the default target dir exists,
+      // is not empty and is not tracked - the exact scenario the IDE (vscode plugin) hits.
+      delete bitMap.comp1;
+      helper.bitMap.write(bitMap);
+    });
+    describe('without the flag', () => {
+      it('should throw an error about the directory not being empty', () => {
+        expect(() => helper.command.importComponentWithoutInstall('comp1')).to.throw('the directory is not empty');
+      });
+    });
+    describe('with --write-to-empty-dir flag', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.importComponentWithoutInstall('comp1', '--write-to-empty-dir');
+      });
+      it('should import the component successfully', () => {
+        expect(output).to.have.string('successfully imported');
+      });
+      it('should import into an incremented empty dir', () => {
+        expect(helper.bitMap.read().comp1.rootDir).to.equal(`${defaultDir}_1`);
+      });
+      it('should leave the original directory untouched', () => {
+        expect(path.join(helper.scopes.localPath, defaultDir)).to.be.a.directory().and.not.empty;
+      });
+    });
+  });
   describe('multiple components some are directory of others', () => {
     let scopeBeforeImport: string;
     before(() => {

--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -192,6 +192,13 @@ describe('import functionality on Harmony', function () {
         );
       });
     });
+    describe('combined with --path', () => {
+      it('should throw an error that the two flags cannot be used together', () => {
+        expect(() =>
+          helper.command.importComponentWithoutInstall('comp1', '--write-to-empty-dir --path some-dir')
+        ).to.throw('--path and --write-to-empty-dir cannot be used together');
+      });
+    });
     describe('with --write-to-empty-dir flag', () => {
       let output: string;
       before(() => {

--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -185,6 +185,13 @@ describe('import functionality on Harmony', function () {
         expect(() => helper.command.importComponentWithoutInstall('comp1')).to.throw('the directory is not empty');
       });
     });
+    describe('combined with --override', () => {
+      it('should throw an error that the two flags cannot be used together', () => {
+        expect(() => helper.command.importComponentWithoutInstall('comp1', '--write-to-empty-dir --override')).to.throw(
+          '--override and --write-to-empty-dir cannot be used together'
+        );
+      });
+    });
     describe('with --write-to-empty-dir flag', () => {
       let output: string;
       before(() => {

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -273,26 +273,16 @@ export class ComponentWriterMain {
     let componentRootDir: PathLinuxRelative = opts.writeToPath
       ? pathNormalizeToLinux(this.consumer.getPathRelativeToConsumer(path.resolve(opts.writeToPath)))
       : this.consumer.composeRelativeComponentPath(component.id);
-    const getParams = () => {
-      if (!this.consumer) {
-        return {};
-      }
-      // components can't be saved with multiple versions, so we can ignore the version to find the component in bit.map
-      const componentMap = this.consumer.bitMap.getComponentIfExist(component.id, {
-        ignoreVersion: true,
-      });
+    // components can't be saved with multiple versions, so we can ignore the version to find the component in bit.map
+    const existingComponentMap = this.consumer?.bitMap.getComponentIfExist(component.id, { ignoreVersion: true });
+    if (this.consumer) {
       if (opts.writeToEmptyDir) {
         // instead of failing when the target dir is occupied, relocate to an available empty dir.
-        componentRootDir = this.resolveAvailableDir(componentRootDir, componentMap, opts);
+        componentRootDir = this.resolveAvailableDir(componentRootDir, existingComponentMap, opts);
       } else {
-        this.throwErrorWhenDirectoryNotEmpty(componentRootDir, componentMap, opts);
+        this.throwErrorWhenDirectoryNotEmpty(componentRootDir, existingComponentMap, opts);
       }
-      return {
-        existingComponentMap: componentMap,
-      };
-    };
-    // getParams() may reassign componentRootDir (when relocating), so call it before building the props object.
-    const params = getParams();
+    }
     return {
       workspace: this.workspace,
       bitMap: this.consumer.bitMap,
@@ -300,7 +290,7 @@ export class ComponentWriterMain {
       writeToPath: componentRootDir,
       writeConfig: opts.writeConfig,
       skipUpdatingBitMap: opts.skipUpdatingBitMap,
-      ...params,
+      existingComponentMap: existingComponentMap ?? undefined,
     };
   }
   private moveComponentsIfNeeded(opts: ManyComponentsWriterParams) {
@@ -323,17 +313,27 @@ to move all component files to a different directory, run bit remove and then bi
       });
     }
   }
+  /**
+   * true when the directory-conflict check can be skipped: either nothing is written to the filesystem, or the
+   * target directory already belongs to this exact component (so overriding it in place is safe).
+   */
+  private shouldSkipDirConflictCheck(
+    componentMap: ComponentMap | null | undefined,
+    opts: ManyComponentsWriterParams
+  ): boolean {
+    if (opts.skipWritingToFs) return true;
+    // no writeToPath: it goes to the default directory. an existing componentMap means the component is not new.
+    if (!opts.writeToPath && componentMap) return true;
+    // writeToPath specified and that directory is already used for that component.
+    return Boolean(opts.writeToPath && componentMap && componentMap.rootDir === opts.writeToPath);
+  }
+
   private throwErrorWhenDirectoryNotEmpty(
     componentDirRelative: PathOsBasedAbsolute,
     componentMap: ComponentMap | null | undefined,
     opts: ManyComponentsWriterParams
   ) {
-    if (opts.skipWritingToFs) return;
-    // if not writeToPath specified, it goes to the default directory. When componentMap exists, the
-    // component is not new, and it's ok to override the existing directory.
-    if (!opts.writeToPath && componentMap) return;
-    // if writeToPath specified and that directory is already used for that component, it's ok to override
-    if (opts.writeToPath && componentMap && componentMap.rootDir && componentMap.rootDir === opts.writeToPath) return;
+    if (this.shouldSkipDirConflictCheck(componentMap, opts)) return;
 
     const componentDir = this.consumer.toAbsolutePath(componentDirRelative);
     if (!fs.pathExistsSync(componentDir)) return;
@@ -369,12 +369,8 @@ either use --path to specify a different directory or modify "defaultDirectory" 
     componentMap: ComponentMap | null | undefined,
     opts: ManyComponentsWriterParams
   ): PathLinuxRelative {
-    if (opts.skipWritingToFs) return componentDirRelative;
-    // the dir already belongs to this exact component, it's safe to override, no need to relocate.
-    if (!opts.writeToPath && componentMap) return componentDirRelative;
-    if (opts.writeToPath && componentMap && componentMap.rootDir && componentMap.rootDir === opts.writeToPath) {
-      return componentDirRelative;
-    }
+    // when writing is skipped or the dir already belongs to this component, no need to relocate.
+    if (this.shouldSkipDirConflictCheck(componentMap, opts)) return componentDirRelative;
     if (this.isDirAvailableForImport(componentDirRelative, componentMap)) return componentDirRelative;
 
     const existingRootDirs = this.workspace.bitMap.getAllRootDirs();

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -166,6 +166,8 @@ export class ComponentWriterMain {
     const componentWriterInstances = writeComponentsParams.map((writeParams) => new ComponentWriter(writeParams));
     this.fixDirsIfEqual(componentWriterInstances);
     this.fixDirsIfNested(componentWriterInstances);
+    // must run after the fixDirs* passes above, which may still move writeToPath onto an occupied dir.
+    this.relocateOccupiedDirs(componentWriterInstances, opts);
     // add componentMap entries into .bitmap before starting the process because steps like writing package-json
     // rely on .bitmap to determine whether a dependency exists and what's its origin
     await Promise.all(
@@ -270,18 +272,15 @@ export class ComponentWriterMain {
     component: ConsumerComponent,
     opts: ManyComponentsWriterParams
   ): ComponentWriterProps {
-    let componentRootDir: PathLinuxRelative = opts.writeToPath
+    const componentRootDir: PathLinuxRelative = opts.writeToPath
       ? pathNormalizeToLinux(this.consumer.getPathRelativeToConsumer(path.resolve(opts.writeToPath)))
       : this.consumer.composeRelativeComponentPath(component.id);
     // components can't be saved with multiple versions, so we can ignore the version to find the component in bit.map
     const existingComponentMap = this.consumer?.bitMap.getComponentIfExist(component.id, { ignoreVersion: true });
-    if (this.consumer) {
-      if (opts.writeToEmptyDir) {
-        // instead of failing when the target dir is occupied, relocate to an available empty dir.
-        componentRootDir = this.resolveAvailableDir(componentRootDir, existingComponentMap, opts);
-      } else {
-        this.throwErrorWhenDirectoryNotEmpty(componentRootDir, existingComponentMap, opts);
-      }
+    // with --write-to-empty-dir, dir-conflict resolution is deferred to relocateOccupiedDirs() so it runs after the
+    // fixDirs* passes (which may still adjust writeToPath); otherwise fail here when the target dir is occupied.
+    if (this.consumer && !opts.writeToEmptyDir) {
+      this.throwErrorWhenDirectoryNotEmpty(componentRootDir, existingComponentMap, opts);
     }
     return {
       workspace: this.workspace,
@@ -360,34 +359,40 @@ either use --path to specify a different directory or modify "defaultDirectory" 
   }
 
   /**
-   * used by the `--write-to-empty-dir` import flag, mainly for non-interactive clients (such as the IDE) that
-   * can't prompt for `--override`. when the target directory is occupied - either by files that don't belong to
-   * this component or by another component - find the next available empty directory (e.g. "renderers/class" =>
-   * "renderers/class_1") instead of throwing.
-   * when the directory already belongs to this component, it's returned as-is (the existing files are overridden,
-   * same as the default import behavior).
+   * final `writeToPath` resolution for the `--write-to-empty-dir` import flag, mainly for non-interactive clients
+   * (such as the IDE) that can't prompt for `--override`. runs after fixDirsIfEqual()/fixDirsIfNested() - which may
+   * still move dirs using string-only collision checks - so the flag's guarantee holds against the final paths:
+   * every relocated component lands in a directory that is empty (or non-existent) and unclaimed in .bitmap.
+   * when a target is occupied (by foreign files, or a dir/rootDir owned by another component), it's relocated by
+   * suffixing "_N" (e.g. "renderers/class" => "renderers/class_1"). a dir already owned by this component is left
+   * as-is (its files are overridden, same as the default import behavior).
    */
-  private resolveAvailableDir(
-    componentDirRelative: PathLinuxRelative,
-    componentMap: ComponentMap | null | undefined,
-    opts: ManyComponentsWriterParams
-  ): PathLinuxRelative {
-    // when writing is skipped or the dir already belongs to this component, no need to relocate.
-    if (this.shouldSkipDirConflictCheck(componentDirRelative, componentMap, opts)) return componentDirRelative;
-    const unavailableReason = this.getDirUnavailableReason(componentDirRelative, componentMap);
-    if (!unavailableReason) return componentDirRelative;
+  private relocateOccupiedDirs(componentWriterInstances: ComponentWriter[], opts: ManyComponentsWriterParams) {
+    if (!opts.writeToEmptyDir) return;
+    // track dirs already claimed in .bitmap and by other components in this batch, so two relocations never collide.
+    const takenDirs = new Set<string>([
+      ...this.workspace.bitMap.getAllRootDirs(),
+      ...componentWriterInstances.map((componentWriter) => componentWriter.writeToPath),
+    ]);
+    componentWriterInstances.forEach((componentWriter) => {
+      const currentDir = componentWriter.writeToPath;
+      const componentMap = componentWriter.existingComponentMap;
+      if (this.shouldSkipDirConflictCheck(currentDir, componentMap, opts)) return;
+      const unavailableReason = this.getDirUnavailableReason(currentDir, componentMap);
+      if (!unavailableReason) return;
 
-    const existingRootDirs = this.workspace.bitMap.getAllRootDirs();
-    let num = 1;
-    let candidate = `${componentDirRelative}_${num}`;
-    while (existingRootDirs.includes(candidate) || this.getDirUnavailableReason(candidate, componentMap)) {
-      num += 1;
-      candidate = `${componentDirRelative}_${num}`;
-    }
-    this.logger.consoleWarning(
-      `unable to import into "${componentDirRelative}" (${unavailableReason}), importing into "${candidate}" instead`
-    );
-    return candidate;
+      let num = 1;
+      let candidate = `${currentDir}_${num}`;
+      while (takenDirs.has(candidate) || this.getDirUnavailableReason(candidate, componentMap)) {
+        num += 1;
+        candidate = `${currentDir}_${num}`;
+      }
+      this.logger.consoleWarning(
+        `unable to import into "${currentDir}" (${unavailableReason}), importing into "${candidate}" instead`
+      );
+      componentWriter.writeToPath = candidate;
+      takenDirs.add(candidate);
+    });
   }
 
   /**

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -400,10 +400,11 @@ either use --path to specify a different directory or modify "defaultDirectory" 
     componentMap: ComponentMap | null | undefined
   ): string | undefined {
     // a rootDir may be claimed in .bitmap even when its directory was deleted from the filesystem, so check
-    // .bitmap ownership regardless of whether the directory currently exists on disk.
-    if (!componentMap) {
-      const usedByComponent = this.consumer.bitMap.getComponentIdByRootPath(componentDirRelative);
-      if (usedByComponent) return `it is already used by ${usedByComponent.toString()}`;
+    // .bitmap ownership regardless of whether the directory currently exists on disk. it's only ok to reuse the
+    // rootDir when it's claimed by the same component we're importing (comparing without version).
+    const usedByComponent = this.consumer.bitMap.getComponentIdByRootPath(componentDirRelative);
+    if (usedByComponent && !(componentMap && usedByComponent.isEqualWithoutVersion(componentMap.id))) {
+      return `it is already used by ${usedByComponent.toString()}`;
     }
     const componentDir = this.consumer.toAbsolutePath(componentDirRelative);
     if (!fs.pathExistsSync(componentDir)) return undefined;

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -33,6 +33,8 @@ export interface ManyComponentsWriterParams {
   components: ConsumerComponent[];
   writeToPath?: string;
   throwForExistingDir?: boolean;
+  // when the target dir is occupied, import into an available empty dir (e.g. "foo" => "foo_1") instead of failing.
+  writeToEmptyDir?: boolean;
   writeConfig?: boolean;
   skipDependencyInstallation?: boolean;
   verbose?: boolean;
@@ -268,7 +270,7 @@ export class ComponentWriterMain {
     component: ConsumerComponent,
     opts: ManyComponentsWriterParams
   ): ComponentWriterProps {
-    const componentRootDir: PathLinuxRelative = opts.writeToPath
+    let componentRootDir: PathLinuxRelative = opts.writeToPath
       ? pathNormalizeToLinux(this.consumer.getPathRelativeToConsumer(path.resolve(opts.writeToPath)))
       : this.consumer.composeRelativeComponentPath(component.id);
     const getParams = () => {
@@ -279,11 +281,18 @@ export class ComponentWriterMain {
       const componentMap = this.consumer.bitMap.getComponentIfExist(component.id, {
         ignoreVersion: true,
       });
-      this.throwErrorWhenDirectoryNotEmpty(componentRootDir, componentMap, opts);
+      if (opts.writeToEmptyDir) {
+        // instead of failing when the target dir is occupied, relocate to an available empty dir.
+        componentRootDir = this.resolveAvailableDir(componentRootDir, componentMap, opts);
+      } else {
+        this.throwErrorWhenDirectoryNotEmpty(componentRootDir, componentMap, opts);
+      }
       return {
         existingComponentMap: componentMap,
       };
     };
+    // getParams() may reassign componentRootDir (when relocating), so call it before building the props object.
+    const params = getParams();
     return {
       workspace: this.workspace,
       bitMap: this.consumer.bitMap,
@@ -291,7 +300,7 @@ export class ComponentWriterMain {
       writeToPath: componentRootDir,
       writeConfig: opts.writeConfig,
       skipUpdatingBitMap: opts.skipUpdatingBitMap,
-      ...getParams(),
+      ...params,
     };
   }
   private moveComponentsIfNeeded(opts: ManyComponentsWriterParams) {
@@ -345,6 +354,55 @@ either use --path to specify a different directory or modify "defaultDirectory" 
         `unable to import to ${componentDir}, the directory is not empty. use --override flag to delete the directory and then import`
       );
     }
+  }
+
+  /**
+   * used by the `--write-to-empty-dir` import flag, mainly for non-interactive clients (such as the IDE) that
+   * can't prompt for `--override`. when the target directory is occupied - either by files that don't belong to
+   * this component or by another component - find the next available empty directory (e.g. "renderers/class" =>
+   * "renderers/class_1") instead of throwing.
+   * when the directory already belongs to this component, it's returned as-is (the existing files are overridden,
+   * same as the default import behavior).
+   */
+  private resolveAvailableDir(
+    componentDirRelative: PathLinuxRelative,
+    componentMap: ComponentMap | null | undefined,
+    opts: ManyComponentsWriterParams
+  ): PathLinuxRelative {
+    if (opts.skipWritingToFs) return componentDirRelative;
+    // the dir already belongs to this exact component, it's safe to override, no need to relocate.
+    if (!opts.writeToPath && componentMap) return componentDirRelative;
+    if (opts.writeToPath && componentMap && componentMap.rootDir && componentMap.rootDir === opts.writeToPath) {
+      return componentDirRelative;
+    }
+    if (this.isDirAvailableForImport(componentDirRelative, componentMap)) return componentDirRelative;
+
+    const existingRootDirs = this.workspace.bitMap.getAllRootDirs();
+    let num = 1;
+    let candidate = `${componentDirRelative}_${num}`;
+    while (existingRootDirs.includes(candidate) || !this.isDirAvailableForImport(candidate, componentMap)) {
+      num += 1;
+      candidate = `${componentDirRelative}_${num}`;
+    }
+    this.logger.consoleWarning(
+      `the directory "${componentDirRelative}" is not empty, importing into "${candidate}" instead`
+    );
+    return candidate;
+  }
+
+  /**
+   * a directory is available for import when it doesn't exist yet, or it's an empty directory that is not already
+   * used by another component in the .bitmap file.
+   */
+  private isDirAvailableForImport(
+    componentDirRelative: PathLinuxRelative,
+    componentMap: ComponentMap | null | undefined
+  ): boolean {
+    const componentDir = this.consumer.toAbsolutePath(componentDirRelative);
+    if (!fs.pathExistsSync(componentDir)) return true;
+    if (!componentMap && this.consumer.bitMap.getComponentIdByRootPath(componentDirRelative)) return false;
+    if (!isDir(componentDir)) return false;
+    return isDirEmptySync(componentDir);
   }
 
   static slots = [];

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import type { MoverMain } from '@teambit/mover';
 import { MoverAspect } from '@teambit/mover';
 import type { ConsumerComponent } from '@teambit/legacy.consumer-component';
-import type { PathLinuxRelative, PathOsBasedAbsolute } from '@teambit/legacy.utils';
+import type { PathLinuxRelative } from '@teambit/legacy.utils';
 import { isDir, isDirEmptySync, pathNormalizeToLinux } from '@teambit/legacy.utils';
 import type { ComponentMap } from '@teambit/legacy.bit-map';
 import { COMPONENT_CONFIG_FILE_NAME } from '@teambit/legacy.constants';
@@ -318,22 +318,25 @@ to move all component files to a different directory, run bit remove and then bi
    * target directory already belongs to this exact component (so overriding it in place is safe).
    */
   private shouldSkipDirConflictCheck(
+    componentDirRelative: PathLinuxRelative,
     componentMap: ComponentMap | null | undefined,
     opts: ManyComponentsWriterParams
   ): boolean {
     if (opts.skipWritingToFs) return true;
+    if (!componentMap) return false;
     // no writeToPath: it goes to the default directory. an existing componentMap means the component is not new.
-    if (!opts.writeToPath && componentMap) return true;
-    // writeToPath specified and that directory is already used for that component.
-    return Boolean(opts.writeToPath && componentMap && componentMap.rootDir === opts.writeToPath);
+    if (!opts.writeToPath) return true;
+    // writeToPath specified and that directory is already used for that component. compare against the
+    // normalized componentDirRelative (not the raw opts.writeToPath, which may be absolute/OS-specific).
+    return componentMap.rootDir === componentDirRelative;
   }
 
   private throwErrorWhenDirectoryNotEmpty(
-    componentDirRelative: PathOsBasedAbsolute,
+    componentDirRelative: PathLinuxRelative,
     componentMap: ComponentMap | null | undefined,
     opts: ManyComponentsWriterParams
   ) {
-    if (this.shouldSkipDirConflictCheck(componentMap, opts)) return;
+    if (this.shouldSkipDirConflictCheck(componentDirRelative, componentMap, opts)) return;
 
     const componentDir = this.consumer.toAbsolutePath(componentDirRelative);
     if (!fs.pathExistsSync(componentDir)) return;
@@ -370,35 +373,43 @@ either use --path to specify a different directory or modify "defaultDirectory" 
     opts: ManyComponentsWriterParams
   ): PathLinuxRelative {
     // when writing is skipped or the dir already belongs to this component, no need to relocate.
-    if (this.shouldSkipDirConflictCheck(componentMap, opts)) return componentDirRelative;
-    if (this.isDirAvailableForImport(componentDirRelative, componentMap)) return componentDirRelative;
+    if (this.shouldSkipDirConflictCheck(componentDirRelative, componentMap, opts)) return componentDirRelative;
+    const unavailableReason = this.getDirUnavailableReason(componentDirRelative, componentMap);
+    if (!unavailableReason) return componentDirRelative;
 
     const existingRootDirs = this.workspace.bitMap.getAllRootDirs();
     let num = 1;
     let candidate = `${componentDirRelative}_${num}`;
-    while (existingRootDirs.includes(candidate) || !this.isDirAvailableForImport(candidate, componentMap)) {
+    while (existingRootDirs.includes(candidate) || this.getDirUnavailableReason(candidate, componentMap)) {
       num += 1;
       candidate = `${componentDirRelative}_${num}`;
     }
     this.logger.consoleWarning(
-      `the directory "${componentDirRelative}" is not empty, importing into "${candidate}" instead`
+      `unable to import into "${componentDirRelative}" (${unavailableReason}), importing into "${candidate}" instead`
     );
     return candidate;
   }
 
   /**
-   * a directory is available for import when it doesn't exist yet, or it's an empty directory that is not already
+   * returns a human-readable reason why the given directory can't be used for import, or undefined when it's
+   * available. a directory is available when it doesn't exist yet, or it's an empty directory that is not already
    * used by another component in the .bitmap file.
    */
-  private isDirAvailableForImport(
+  private getDirUnavailableReason(
     componentDirRelative: PathLinuxRelative,
     componentMap: ComponentMap | null | undefined
-  ): boolean {
+  ): string | undefined {
+    // a rootDir may be claimed in .bitmap even when its directory was deleted from the filesystem, so check
+    // .bitmap ownership regardless of whether the directory currently exists on disk.
+    if (!componentMap) {
+      const usedByComponent = this.consumer.bitMap.getComponentIdByRootPath(componentDirRelative);
+      if (usedByComponent) return `it is already used by ${usedByComponent.toString()}`;
+    }
     const componentDir = this.consumer.toAbsolutePath(componentDirRelative);
-    if (!fs.pathExistsSync(componentDir)) return true;
-    if (!componentMap && this.consumer.bitMap.getComponentIdByRootPath(componentDirRelative)) return false;
-    if (!isDir(componentDir)) return false;
-    return isDirEmptySync(componentDir);
+    if (!fs.pathExistsSync(componentDir)) return undefined;
+    if (!isDir(componentDir)) return 'it is a file';
+    if (!isDirEmptySync(componentDir)) return 'the directory is not empty';
+    return undefined;
   }
 
   static slots = [];

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -2686,6 +2686,11 @@
         "",
         "owner",
         "treat the argument as an owner name and import all components from all scopes of that owner"
+      ],
+      [
+        "",
+        "write-to-empty-dir",
+        "when the target directory is not empty, import into an available empty directory (e.g. \"foo\" => \"foo_1\") instead of failing"
       ]
     ],
     "description": "bring components from remote scopes into your workspace",

--- a/scopes/harmony/cli-reference/cli-reference.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.mdx
@@ -1204,6 +1204,7 @@ without arguments, fetches all workspace components' latest versions from their 
 | `--include-deprecated`           |                  | when importing with patterns, include deprecated components (default to exclude them)                                                                                               |
 | `--lane-only`                    |                  | when using wildcards on a lane, only import components that exist on the lane (never from main)                                                                                     |
 | `--owner`                        |                  | treat the argument as an owner name and import all components from all scopes of that owner                                                                                         |
+| `--write-to-empty-dir`           |                  | when the target directory is not empty, import into an available empty directory (e.g. "foo" => "foo_1") instead of failing                                                         |
 
 ---
 

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -70,6 +70,7 @@ export type ImportOptions = {
   writeDeps?: 'package.json' | 'workspace.jsonc';
   laneOnly?: boolean; // when on a lane, only import components that exist on the lane (preserves legacy behavior)
   owner?: boolean; // treat the id as an owner name and import all components from all scopes of that owner
+  writeToEmptyDir?: boolean; // when the target dir is not empty, import into an available empty dir instead of failing
 };
 type ComponentMergeStatus = {
   component: Component;
@@ -391,6 +392,7 @@ export default class ImportComponents {
       skipWriteConfigFiles: !this.options.writeConfigFiles,
       verbose: this.options.verbose,
       throwForExistingDir: !this.options.override,
+      writeToEmptyDir: this.options.writeToEmptyDir,
       skipWritingToFs: this.options.trackOnly,
       reasonForBitmapChange: 'import',
       writeDeps: this.options.writeDeps,
@@ -1098,6 +1100,7 @@ otherwise, if tagged/snapped, "bit reset" it, then bit rename it.`);
       skipWriteConfigFiles: !this.options.writeConfigFiles,
       verbose: this.options.verbose,
       throwForExistingDir: !this.options.override,
+      writeToEmptyDir: this.options.writeToEmptyDir,
       skipWritingToFs: this.options.trackOnly,
       shouldUpdateWorkspaceConfig: true,
       reasonForBitmapChange: 'import',

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -297,6 +297,9 @@ without arguments, fetches all workspace components' latest versions from their 
     if (override && merge) {
       throw new BitError('--override and --merge cannot be used together');
     }
+    if (override && writeToEmptyDir) {
+      throw new BitError('--override and --write-to-empty-dir cannot be used together');
+    }
     if (!ids.length && dependencies) {
       throw new BitError('you have to specify ids to use "--dependencies" flag');
     }

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -54,6 +54,7 @@ type ImportFlags = {
   writeDeps?: 'package.json' | 'workspace.jsonc';
   laneOnly?: boolean;
   owner?: boolean;
+  writeToEmptyDir?: boolean;
 };
 
 export class ImportCmd implements Command {
@@ -159,6 +160,11 @@ without arguments, fetches all workspace components' latest versions from their 
       'when using wildcards on a lane, only import components that exist on the lane (never from main)',
     ],
     ['', 'owner', 'treat the argument as an owner name and import all components from all scopes of that owner'],
+    [
+      '',
+      'write-to-empty-dir',
+      'when the target directory is not empty, import into an available empty directory (e.g. "foo" => "foo_1") instead of failing',
+    ],
   ] as CommandOptions;
   loader = true;
   remoteOp = true;
@@ -279,6 +285,7 @@ without arguments, fetches all workspace components' latest versions from their 
       writeDeps,
       laneOnly = false,
       owner = false,
+      writeToEmptyDir = false,
     }: ImportFlags
   ): Promise<ImportResult> {
     if (dependentsDryRun) {
@@ -356,6 +363,7 @@ without arguments, fetches all workspace components' latest versions from their 
       writeDeps,
       laneOnly,
       owner,
+      writeToEmptyDir,
     };
     return this.importer.import(importOptions, this._packageManagerArgs);
   }

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -297,8 +297,11 @@ without arguments, fetches all workspace components' latest versions from their 
     if (override && merge) {
       throw new BitError('--override and --merge cannot be used together');
     }
-    if (override && writeToEmptyDir) {
-      throw new BitError('--override and --write-to-empty-dir cannot be used together');
+    if (writeToEmptyDir) {
+      // --override deletes the occupied dir to write in place, and --path targets one specific directory; both
+      // contradict --write-to-empty-dir, which relocates elsewhere when the target dir is occupied.
+      if (override) throw new BitError('--override and --write-to-empty-dir cannot be used together');
+      if (path) throw new BitError('--path and --write-to-empty-dir cannot be used together');
     }
     if (!ids.length && dependencies) {
       throw new BitError('you have to specify ids to use "--dependencies" flag');


### PR DESCRIPTION
Adds a `--write-to-empty-dir` flag to `bit import`. Instead of failing when the target directory is occupied, it imports into the next available empty directory (e.g. `renderers/class` → `renderers/class_1`). Aimed at non-interactive clients (e.g. the IDE plugin) that can't prompt for `--override`.

Behavior:
- Same component already tracked at that dir → no-op relocation, files overridden as a normal re-import.
- Dir has untracked/foreign files or belongs to another component → relocated to a free dir with a warning, instead of throwing `the directory is not empty`.
- Without the flag → unchanged (still throws the informative error).

A dir counts as available if it doesn't exist, or is empty and not claimed by another `.bitmap` component. Covered by a new e2e test reproducing the IDE scenario.