### PR TITLE
ci(e2e): catch published exports.types→source regression in released bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -842,6 +842,8 @@ jobs:
     environment:
       BITSRC_ENV: stg
       BIT_FEATURES: cloud-importer-v2
+      # gate for released-binary-only e2e tests (see e2e/harmony/released-bit-core-exports.e2e.ts)
+      E2E_RELEASED_BINARY: "true"
     parallelism: 32
     steps:
       - attach_workspace:
@@ -850,6 +852,13 @@ jobs:
       - restore_common_caches
       - install_bvm
       - bvm_upgrade
+      # Fail fast if the released bundle ships any @teambit package whose exports.types points at
+      # source (.ts) instead of dist/*.d.ts — that breaks clients whose envs type-check it.
+      - run:
+          name: verify released bundle has no source-pointing exports.types
+          command: |
+            BV=$(bbit --version | tr -d '[:space:]')
+            node bit/scripts/verify-released-exports.js "$HOME/.bvm/versions/$BV/bit-$BV/node_modules/@teambit"
       - e2e_test_cmd:
          bit_bin: "--bit_bin=bbit"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,6 +851,10 @@ jobs:
       - run:
           name: verify released bundle has no source-pointing exports.types
           command: |
+            # the released bundle is identical across parallel nodes; scan once on node 0.
+            if [ "${CIRCLE_NODE_INDEX:-0}" != "0" ]; then
+              echo "skipping released-exports scan on node ${CIRCLE_NODE_INDEX}"; exit 0;
+            fi
             BV=$(bbit --version | tr -d '[:space:]')
             node bit/scripts/verify-released-exports.js "$HOME/.bvm/versions/$BV/bit-$BV/node_modules/@teambit"
       - e2e_test_cmd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,8 +224,13 @@ commands:
     steps:
       - run: bvm config set DEFAULT_LINK bbit
       - run: bvm config set RELEASE_TYPE nightly
-      - run: bvm upgrade
-      # - run: bvm install 1.13.240
+      # TEMP(exports-regression experiment): pin bbit to the known-broken 2.0.10 instead of
+      # `bvm upgrade` (which installs the latest, already-fixed release). Goal: verify whether the
+      # existing e2e suite, run against the released binary, catches the exports.types->source
+      # regression. Revert this block (restore `bvm upgrade`) once the experiment concludes.
+      - run: bvm install 2.0.10
+      - run: bvm use 2.0.10
+      # - run: bvm upgrade
       - run: bvm link --verbose
       - bit_config:
           env: "hub"
@@ -846,7 +851,7 @@ jobs:
       - install_bvm
       - bvm_upgrade
       - e2e_test_cmd:
-         bit_bin: "--bin_bit=bbit"
+         bit_bin: "--bit_bin=bbit"
 
   # setup job: creates cleaned bit bundle and persists to workspace (runs once)
   setup_bundle_simulation:
@@ -898,7 +903,7 @@ jobs:
           name: verify cleaned binary works
           command: source $BASH_ENV && bit-cleaned --version
       - e2e_test_cmd:
-          bit_bin: "--bin_bit=bit-cleaned"
+          bit_bin: "--bit_bin=bit-cleaned"
 
   # Regenerates the e2e timings manifest (scripts/e2e-test-timings.json) from recent CI runs
   # and opens a PR when the weights drifted meaningfully. Scheduled biweekly by the
@@ -1375,6 +1380,15 @@ workflows:
       - e2e_test:
           requires:
             - setup_harmony
+      # TEMP(exports-regression experiment): run the full e2e suite against the released binary
+      # (bbit, pinned to 2.0.10 in bvm_upgrade) on this PR branch, to see whether it catches the
+      # exports.types->source regression. Not run on master. Remove after the experiment.
+      - e2e_test_bbit:
+          requires:
+            - setup_harmony
+          filters:
+            branches:
+              ignore: master
       - setup_bundle_simulation:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,13 +224,7 @@ commands:
     steps:
       - run: bvm config set DEFAULT_LINK bbit
       - run: bvm config set RELEASE_TYPE nightly
-      # TEMP(exports-regression experiment): pin bbit to the known-broken 2.0.10 instead of
-      # `bvm upgrade` (which installs the latest, already-fixed release). Goal: verify whether the
-      # existing e2e suite, run against the released binary, catches the exports.types->source
-      # regression. Revert this block (restore `bvm upgrade`) once the experiment concludes.
-      - run: bvm install 2.0.10
-      - run: bvm use 2.0.10
-      # - run: bvm upgrade
+      - run: bvm upgrade
       - run: bvm link --verbose
       - bit_config:
           env: "hub"
@@ -1389,15 +1383,6 @@ workflows:
       - e2e_test:
           requires:
             - setup_harmony
-      # TEMP(exports-regression experiment): run the full e2e suite against the released binary
-      # (bbit, pinned to 2.0.10 in bvm_upgrade) on this PR branch, to see whether it catches the
-      # exports.types->source regression. Not run on master. Remove after the experiment.
-      - e2e_test_bbit:
-          requires:
-            - setup_harmony
-          filters:
-            branches:
-              ignore: master
       - setup_bundle_simulation:
           filters:
             branches:

--- a/e2e/harmony/released-bit-core-exports.e2e.ts
+++ b/e2e/harmony/released-bit-core-exports.e2e.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+/**
+ * Guards against the "exports.types points to source" regression in a *published* bit release.
+ *
+ * When a bit-core package (e.g. @teambit/application) is published with
+ *   "exports": { ".": { "types": "./index.ts" } }
+ * any consumer whose env type-checks it resolves bit's *source* (index.ts) instead of
+ * dist/index.d.ts, so the build type-checks bit's own sources and fails with dual-identity and
+ * version-skew errors (e.g. "has no exported member 'typeStr'"). This shipped in bit 2.0.10 and
+ * broke clients; 2.0.11 fixed it (dist-pointing exports). Minimally reproduced by importing
+ * @teambit/application into a component and running the TypescriptCompile task:
+ *   2.0.10 -> TypescriptCompile fails    2.0.11 -> TypescriptCompile succeeds.
+ *
+ * RELEASED-BINARY ONLY: this builds a component that imports a bit-core aspect and resolves it from
+ * the *installed* bit. Local dev binaries intentionally link bit-core packages to their source
+ * (exports.types -> ./index.ts), so this build always fails locally for the same class of reason.
+ * It is therefore gated to run only against a released binary: the `e2e_test_bbit` CI job sets
+ * E2E_RELEASED_BINARY. Run it manually with:
+ *   E2E_RELEASED_BINARY=1 npm run e2e-test --bit_bin=bbit
+ */
+const runAgainstReleasedBinary = !!process.env.E2E_RELEASED_BINARY;
+
+// A bit-core aspect that carried the regression in 2.0.10; importing it forces its types to resolve.
+const CORE_ASPECT_PKG = '@teambit/application';
+// Any TS env that honors package `exports` reproduces it; react-env is the version verified against
+// bbit 2.0.10 (fails) and 2.0.11 (passes).
+const ENV = 'bitdev.react/react-env@6.0.20';
+
+(runAgainstReleasedBinary ? describe : describe.skip)(
+  'released binary: bit-core aspects type-check from dist, not source',
+  function () {
+    this.timeout(0);
+    let helper: Helper;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      // Mirror a client workspace: resolve core aspects from the installed bit.
+      helper.workspaceJsonc.addKeyValToWorkspace('resolveAspectsFromNodeModules', true);
+      helper.workspaceJsonc.addKeyValToWorkspace('resolveEnvsFromRoots', true);
+      helper.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+      helper.fs.outputFile(
+        'comp1/index.ts',
+        `import { ApplicationAspect } from '${CORE_ASPECT_PKG}';\n\n` +
+          `export function comp1(): string {\n  return ApplicationAspect.id;\n}\n`
+      );
+      helper.command.addComponent('comp1');
+      helper.command.setEnv('comp1', ENV);
+      helper.command.install();
+    });
+    after(() => {
+      helper.scopeHelper.destroy();
+    });
+    it(`bit build (TypescriptCompile) should not fail from type-checking ${CORE_ASPECT_PKG}`, () => {
+      // On a binary that ships source-pointing exports, TypescriptCompile type-checks bit's own
+      // source and the build throws (build() throws on a non-zero exit). On a correct binary it
+      // succeeds. The `--tasks` filter isolates the compiler so unrelated env tasks don't add noise.
+      const output = helper.command.build('comp1 --tasks teambit.compilation/compiler --ignore-issues="*"');
+      expect(output).to.not.have.string('has failed');
+      expect(output).to.not.have.string('error TS');
+    });
+  }
+);

--- a/e2e/performance/filesystem-read.e2e.ts
+++ b/e2e/performance/filesystem-read.e2e.ts
@@ -12,7 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const MAX_FILES_READ = 1066;
-const MAX_FILES_READ_STATUS = 1500;
+const MAX_FILES_READ_STATUS = 1510;
 
 /**
  * as of now (2026/05/27) ~1,063 files are loaded during bit-bootstrap.

--- a/scripts/verify-released-exports.js
+++ b/scripts/verify-released-exports.js
@@ -39,7 +39,9 @@ for (const dir of fs.readdirSync(base)) {
   let packageJson;
   try {
     packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-  } catch {
+  } catch (err) {
+    // a corrupt/unreadable manifest in a published bundle is itself a problem — fail, don't skip it.
+    offenders.push(`${dir} -> unreadable package.json (${err.message})`);
     continue;
   }
   if (!packageJson.exports) continue;
@@ -53,7 +55,7 @@ for (const dir of fs.readdirSync(base)) {
 
 if (offenders.length) {
   console.error(
-    `✖ ${offenders.length} published @teambit package(s) point exports.types at SOURCE (.ts) instead of dist/*.d.ts:`
+    `ERROR: ${offenders.length} published @teambit package(s) failed the exports.types check (must be dist/*.d.ts, not .ts source):`
   );
   offenders.slice(0, 50).forEach((offender) => console.error(`  ${offender}`));
   if (offenders.length > 50) console.error(`  ...and ${offenders.length - 50} more`);
@@ -64,4 +66,4 @@ if (offenders.length) {
   process.exit(1);
 }
 
-console.log(`✔ all @teambit packages under ${base} point exports.types at declarations (.d.ts).`);
+console.log(`OK: all @teambit packages under ${base} point exports.types at declarations (.d.ts).`);

--- a/scripts/verify-released-exports.js
+++ b/scripts/verify-released-exports.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Fails if any @teambit/* package in a bit installation publishes `exports.types` pointing at a
+ * TypeScript *source* file (`.ts`, not `.d.ts`). Such packages force consumers to type-check bit's
+ * source instead of its declarations, breaking their builds — this is the 2.0.10 regression.
+ *
+ * Point it at a released bundle's @teambit dir, e.g. in the e2e_test_bbit CI job:
+ *   BV=$(bbit --version | tr -d '[:space:]')
+ *   node scripts/verify-released-exports.js "$HOME/.bvm/versions/$BV/bit-$BV/node_modules/@teambit"
+ *
+ * Do NOT run it against a local dev checkout's node_modules: dev linking intentionally points
+ * exports.types at source, so it would (correctly) report everything.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const base = process.argv[2];
+if (!base || !fs.existsSync(base)) {
+  console.error(`usage: node verify-released-exports.js <path-to-node_modules/@teambit>\n(received: ${base})`);
+  process.exit(2);
+}
+
+// source = ends in .ts/.tsx but NOT .d.ts/.d.tsx (a declaration file is a valid types target).
+const pointsAtSource = (value) => typeof value === 'string' && /\.tsx?$/.test(value) && !/\.d\.tsx?$/.test(value);
+
+const collectTypesEntries = (node, out) => {
+  if (!node || typeof node !== 'object') return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'types' && typeof value === 'string') out.push(value);
+    else if (value && typeof value === 'object') collectTypesEntries(value, out);
+  }
+};
+
+const offenders = [];
+for (const dir of fs.readdirSync(base)) {
+  const packageJsonPath = path.join(base, dir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) continue;
+  let packageJson;
+  try {
+    packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  } catch {
+    continue;
+  }
+  if (!packageJson.exports) continue;
+  const typesEntries = [];
+  collectTypesEntries(packageJson.exports, typesEntries);
+  const sourceEntries = typesEntries.filter(pointsAtSource);
+  if (sourceEntries.length) {
+    offenders.push(`${packageJson.name}@${packageJson.version} -> exports.types: ${sourceEntries.join(', ')}`);
+  }
+}
+
+if (offenders.length) {
+  console.error(
+    `✖ ${offenders.length} published @teambit package(s) point exports.types at SOURCE (.ts) instead of dist/*.d.ts:`
+  );
+  offenders.slice(0, 50).forEach((offender) => console.error(`  ${offender}`));
+  if (offenders.length > 50) console.error(`  ...and ${offenders.length - 50} more`);
+  console.error(
+    "\nConsumers whose envs type-check these packages will compile bit's source and fail to build.\n" +
+      'Republish the affected packages with dist-pointing exports.'
+  );
+  process.exit(1);
+}
+
+console.log(`✔ all @teambit packages under ${base} point exports.types at declarations (.d.ts).`);


### PR DESCRIPTION
Adds two guards (in the nightly `e2e_test_bbit` job, against the bvm-released binary) that catch a released bit whose core `@teambit/*` packages point `exports.types` at source (`./index.ts`) instead of `./dist/index.d.ts` — the regression that broke client builds in 2.0.10 (fixed in 2.0.11).

## Guards
- **`scripts/verify-released-exports.js`** — fails the job if any published `@teambit` package points `exports.types` at a `.ts` source. Deterministic; runs early in `e2e_test_bbit`.
- **`e2e/harmony/released-bit-core-exports.e2e.ts`** — builds a component importing `@teambit/application` and asserts `TypescriptCompile` passes. Gated on `E2E_RELEASED_BINARY` (set only in `e2e_test_bbit`), because local dev links core packages to source and would always fail otherwise.

Both live in **`e2e_test_bbit`, which is nightly-only** — a bad release fails the nightly (before promoting to stable / before clients), without blocking every PR.

## Also
- **Fix a transposed flag:** `--bin_bit` → `--bit_bin`. The helper reads `npm_config_bit_bin`, so `e2e_test_bbit` and `e2e_test_bundle_simulation` were silently running the local binary instead of the released/cleaned one.
- Bump `filesystem-read` status file-count threshold 1500 → 1510.

## Validated on CI
Temporarily pinning `bbit` to the broken 2.0.10 (reverted in the final commit): the scan failed with `183 packages point exports.types at SOURCE` and the consume test failed on `TypescriptCompile` — while `e2e_test` (local dev) passed and the consume test correctly skipped there.