### PR TITLE
chore: update node babel/mocha envs

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -24,30 +24,21 @@
         "scope": "teambit.api-reference",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/api-reference/api-reference"
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1081",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/api-server"
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/application"
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
@@ -64,10 +55,7 @@
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/aspect"
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -214,20 +202,14 @@
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/aspect-loader"
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/compilation/babel"
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
@@ -244,10 +226,7 @@
         "scope": "teambit.harmony",
         "version": "2.0.13",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/bit"
     },
     "bit-map": {
         "name": "bit-map",
@@ -264,10 +243,7 @@
         "scope": "teambit.pipelines",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/pipelines/builder"
     },
     "builder-data": {
         "name": "builder-data",
@@ -284,80 +260,56 @@
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/compilation/bundler"
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1442",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/cache"
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/changelog"
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/checkout"
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.440",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/git/ci"
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.568",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/clear-cache"
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1349",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/cli"
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.207",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/mcp/cli-mcp-server"
     },
     "cli-table": {
         "name": "cli-table",
@@ -394,80 +346,56 @@
         "scope": "teambit.cloud",
         "version": "0.0.1347",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/cloud/cloud"
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/code"
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/explorer/command-bar"
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.777",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/community/community"
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/compilation/compiler"
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component"
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component-compare"
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.455",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component-descriptor"
     },
     "component-diff": {
         "name": "component-diff",
@@ -504,10 +432,7 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component-log"
     },
     "component-package-version": {
         "name": "component-package-version",
@@ -524,30 +449,21 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component-sizer"
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component-tree"
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/component-writer"
     },
     "composition-card": {
         "name": "composition-card",
@@ -561,40 +477,28 @@
         "scope": "teambit.compositions",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/compositions/compositions"
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1524",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/config"
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.918",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/config-merger"
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.230",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "components/config-store"
     },
     "constants": {
         "name": "constants",
@@ -658,10 +562,7 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/dependencies/dependencies"
     },
     "dependency-graph": {
         "name": "dependency-graph",
@@ -678,40 +579,28 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/dependencies/dependency-resolver"
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/deprecation"
     },
     "dev-files": {
         "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/dev-files"
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/diagnostic"
     },
     "doc-parser": {
         "name": "doc-parser",
@@ -728,20 +617,14 @@
         "scope": "teambit.docs",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/docs/docs"
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.736",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/doctor"
     },
     "e2e-helper": {
         "name": "e2e-helper",
@@ -758,10 +641,7 @@
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/eject"
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
@@ -798,30 +678,21 @@
         "scope": "teambit.envs",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/envs/env"
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/envs/envs"
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/eslint"
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
@@ -848,20 +719,14 @@
         "scope": "teambit.scope",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/scope/export"
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1448",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/express"
     },
     "extension-data": {
         "name": "extension-data",
@@ -878,20 +743,14 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/forking"
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/formatter"
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
@@ -968,10 +827,7 @@
         "scope": "teambit.generator",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/generator/generator"
     },
     "get-bit-version": {
         "name": "get-bit-version",
@@ -988,50 +844,35 @@
         "scope": "teambit.git",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/git/git"
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1353",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/global-config"
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/graph"
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/graphql"
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
@@ -1106,90 +947,63 @@
         "scope": "teambit.harmony",
         "version": "0.0.764",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/host-initializer"
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/scope/importer"
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/explorer/insights"
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/install"
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.50",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/internalize"
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/ipc-events"
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/isolator"
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/issues"
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/jest"
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
@@ -1206,10 +1020,7 @@
         "scope": "teambit.lanes",
         "version": "1.0.1070",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/lanes/lanes"
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
@@ -1226,20 +1037,14 @@
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/linter"
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/lister"
     },
     "loader": {
         "name": "loader",
@@ -1273,30 +1078,21 @@
         "scope": "teambit.lanes",
         "version": "1.0.1070",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/lanes/merge-lanes"
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1054",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/merging"
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.867",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/mocha"
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -1694,30 +1490,21 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/mover"
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/compilation/multi-compiler"
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/multi-tester"
     },
     "network": {
         "name": "network",
@@ -1744,10 +1531,7 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/new-component-helper"
     },
     "node": {
         "name": "node",
@@ -1761,20 +1545,14 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/notifications/aspect"
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.558",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/scope/objects"
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
@@ -1788,10 +1566,7 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.1352",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/panels"
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1845,10 +1620,7 @@
         "scope": "teambit.pkg",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/pkg/pkg"
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
@@ -1875,20 +1647,14 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1085",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/dependencies/pnpm"
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/prettier"
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
@@ -1905,10 +1671,7 @@
         "scope": "teambit.preview",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/preview/preview"
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
@@ -1925,10 +1688,7 @@
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/pubsub"
     },
     "react": {
         "name": "react",
@@ -1942,10 +1702,7 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/react-router/react-router"
     },
     "readme": {
         "name": "readme",
@@ -1959,10 +1716,7 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/refactoring"
     },
     "remote-actions": {
         "name": "remote-actions",
@@ -1989,20 +1743,14 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/remove"
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/renaming"
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -2023,20 +1771,14 @@
         "scope": "teambit.cloud",
         "version": "0.0.133",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/cloud/ripple"
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/semantics/schema"
     },
     "scope-api": {
         "name": "scope-api",
@@ -2053,20 +1795,14 @@
         "scope": "teambit.workspace",
         "version": "0.0.270",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/scripts"
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/sidebar"
     },
     "snap-distance": {
         "name": "snap-distance",
@@ -2083,10 +1819,7 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/snapping"
     },
     "sources": {
         "name": "sources",
@@ -2103,20 +1836,14 @@
         "scope": "teambit.component",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/stash"
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1074",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/status"
     },
     "string/capitalize": {
         "name": "string/capitalize",
@@ -2190,10 +1917,7 @@
         "scope": "teambit.harmony",
         "version": "0.0.1442",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/logger"
     },
     "teambit.legacy/logger": {
         "name": "logger",
@@ -2220,20 +1944,14 @@
         "scope": "teambit.scope",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/scope/scope"
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/tester"
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
@@ -2280,10 +1998,7 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/component/tracker"
     },
     "ts-server": {
         "name": "ts-server",
@@ -2310,20 +2025,14 @@
         "scope": "teambit.typescript",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/typescript/typescript"
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/ui"
     },
     "ui/aspect-box": {
         "name": "ui/aspect-box",
@@ -2742,10 +2451,7 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/ui-foundation/user-agent"
     },
     "utils": {
         "name": "utils",
@@ -2762,100 +2468,70 @@
         "scope": "teambit.defender",
         "version": "0.0.287",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/defender/validator"
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1617",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/variants"
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.843",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/scope/version-history"
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.417",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/vue/vue"
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/watcher"
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/webpack/webpack"
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1653",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/harmony/worker"
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/workspace"
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/workspace/workspace-config-files"
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn",
-        "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
-        }
+        "rootDir": "scopes/dependencies/yarn"
     },
     "$schema-version": "17.0.0"
 }

--- a/.bitmap
+++ b/.bitmap
@@ -14,42 +14,60 @@
         "scope": "teambit.legacy",
         "version": "0.0.97",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/analytics"
+        "rootDir": "components/legacy/analytics",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "api-reference": {
         "name": "api-reference",
         "scope": "teambit.api-reference",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1081",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
         "scope": "teambit.toolbox",
         "version": "0.0.6",
         "mainFile": "find-duplications.ts",
-        "rootDir": "scopes/toolbox/array/duplications-finder"
+        "rootDir": "scopes/toolbox/array/duplications-finder",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "aspect": {
         "name": "aspect",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -196,238 +214,340 @@
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
         "scope": "teambit.react",
         "version": "1.0.53",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/bit-react-transformer"
+        "rootDir": "scopes/react/bit-react-transformer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "bit": {
         "name": "bit",
         "scope": "teambit.harmony",
         "version": "2.0.13",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "bit-map": {
         "name": "bit-map",
         "scope": "teambit.legacy",
         "version": "0.0.192",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/bit-map"
+        "rootDir": "components/legacy/bit-map",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "builder": {
         "name": "builder",
         "scope": "teambit.pipelines",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
         "scope": "teambit.pipelines",
         "version": "0.0.409",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/builder-data"
+        "rootDir": "scopes/pipelines/modules/builder-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "bundler": {
         "name": "bundler",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1442",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.440",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci"
+        "rootDir": "scopes/git/ci",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.568",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1349",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.207",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server"
+        "rootDir": "scopes/mcp/cli-mcp-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
         "scope": "teambit.toolbox",
         "version": "0.0.53",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/tables/cli-table"
+        "rootDir": "scopes/toolbox/tables/cli-table",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "cli/error": {
         "name": "cli/error",
         "scope": "teambit.legacy",
         "version": "0.0.48",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/cli/error"
+        "rootDir": "components/legacy/cli/error",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "cli/webpack-events-listener": {
         "name": "cli/webpack-events-listener",
         "scope": "teambit.preview",
         "version": "0.0.181",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/cli/webpack-events-listener"
+        "rootDir": "scopes/preview/cli/webpack-events-listener",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "cloud": {
         "name": "cloud",
         "scope": "teambit.cloud",
         "version": "0.0.1347",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.777",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.455",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor"
+        "rootDir": "scopes/component/component-descriptor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-diff": {
         "name": "component-diff",
         "scope": "teambit.legacy",
         "version": "0.0.191",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-diff"
+        "rootDir": "components/legacy/component-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "component-issues": {
         "name": "component-issues",
         "scope": "teambit.component",
         "version": "0.0.176",
         "mainFile": "index.ts",
-        "rootDir": "components/component-issues"
+        "rootDir": "components/component-issues",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "component-list": {
         "name": "component-list",
         "scope": "teambit.legacy",
         "version": "0.0.189",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-list"
+        "rootDir": "components/legacy/component-list",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "component-log": {
         "name": "component-log",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
         "scope": "teambit.component",
         "version": "0.0.453",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-package-version"
+        "rootDir": "scopes/component/component-package-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "component-sizer": {
         "name": "component-sizer",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -441,56 +561,80 @@
         "scope": "teambit.compositions",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1524",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.918",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.230",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store"
+        "rootDir": "components/config-store",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "constants": {
         "name": "constants",
         "scope": "teambit.legacy",
         "version": "0.0.33",
         "mainFile": "constants.ts",
-        "rootDir": "components/legacy/constants"
+        "rootDir": "components/legacy/constants",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "consumer": {
         "name": "consumer",
         "scope": "teambit.legacy",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer"
+        "rootDir": "components/legacy/consumer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "consumer-component": {
         "name": "consumer-component",
         "scope": "teambit.legacy",
         "version": "0.0.136",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-component"
+        "rootDir": "components/legacy/consumer-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "consumer-config": {
         "name": "consumer-config",
         "scope": "teambit.legacy",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-config"
+        "rootDir": "components/legacy/consumer-config",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "content/cli-reference": {
         "name": "content/cli-reference",
@@ -504,287 +648,410 @@
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "components/crypto/sha1"
+        "rootDir": "components/crypto/sha1",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "dependencies": {
         "name": "dependencies",
         "scope": "teambit.dependencies",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "dependency-graph": {
         "name": "dependency-graph",
         "scope": "teambit.legacy",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/dependency-graph"
+        "rootDir": "components/legacy/dependency-graph",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "dependency-resolver": {
         "name": "dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "dev-files": {
         "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "doc-parser": {
         "name": "doc-parser",
         "scope": "teambit.semantics",
         "version": "0.0.143",
         "mainFile": "index.ts",
-        "rootDir": "components/semantics/doc-parser"
+        "rootDir": "components/semantics/doc-parser",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "docs": {
         "name": "docs",
         "scope": "teambit.docs",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.736",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor"
+        "rootDir": "scopes/harmony/doctor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "e2e-helper": {
         "name": "e2e-helper",
         "scope": "teambit.legacy",
         "version": "0.0.182",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/e2e-helper"
+        "rootDir": "components/legacy/e2e-helper",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "eject": {
         "name": "eject",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
         "scope": "teambit.lanes",
         "version": "0.0.192",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/entities/lane-diff"
+        "rootDir": "scopes/lanes/entities/lane-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "entities/semantic-schema": {
         "name": "entities/semantic-schema",
         "scope": "teambit.semantics",
         "version": "0.0.106",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema"
+        "rootDir": "components/entities/semantic-schema",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "entities/semantic-schema-diff": {
         "name": "entities/semantic-schema-diff",
         "scope": "teambit.semantics",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema-diff"
+        "rootDir": "components/entities/semantic-schema-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "env": {
         "name": "env",
         "scope": "teambit.envs",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint"
+        "rootDir": "scopes/defender/eslint",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
         "scope": "teambit.react",
         "version": "2.0.14",
         "mainFile": "index.js",
-        "rootDir": "scopes/react/eslint-config-bit-react"
+        "rootDir": "scopes/react/eslint-config-bit-react",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "eslint/config-mutator": {
         "name": "eslint/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.126",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint-config-mutator"
+        "rootDir": "scopes/defender/eslint-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "export": {
         "name": "export",
         "scope": "teambit.scope",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1448",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "extension-data": {
         "name": "extension-data",
         "scope": "teambit.legacy",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/extension-data"
+        "rootDir": "components/legacy/extension-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "forking": {
         "name": "forking",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
         "scope": "teambit.toolbox",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/extension-getter"
+        "rootDir": "scopes/toolbox/fs/extension-getter",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "fs/hard-link-directory": {
         "name": "fs/hard-link-directory",
         "scope": "teambit.toolbox",
         "version": "0.0.30",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/hard-link-directory"
+        "rootDir": "scopes/toolbox/fs/hard-link-directory",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "fs/is-dir-empty": {
         "name": "fs/is-dir-empty",
         "scope": "teambit.toolbox",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/is-dir-empty"
+        "rootDir": "scopes/toolbox/fs/is-dir-empty",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "fs/last-modified": {
         "name": "fs/last-modified",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/last-modified"
+        "rootDir": "scopes/toolbox/fs/last-modified",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "fs/link-or-symlink": {
         "name": "fs/link-or-symlink",
         "scope": "teambit.toolbox",
         "version": "0.0.54",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/link-or-symlink"
+        "rootDir": "scopes/toolbox/fs/link-or-symlink",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "fs/linked-dependencies": {
         "name": "fs/linked-dependencies",
         "scope": "teambit.dependencies",
         "version": "0.0.62",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/fs/linked-dependencies"
+        "rootDir": "scopes/dependencies/fs/linked-dependencies",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "fs/remove-empty-dir": {
         "name": "fs/remove-empty-dir",
         "scope": "teambit.toolbox",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/remove-empty-dir"
+        "rootDir": "scopes/toolbox/fs/remove-empty-dir",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "generator": {
         "name": "generator",
         "scope": "teambit.generator",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "get-bit-version": {
         "name": "get-bit-version",
         "scope": "teambit.bit",
         "version": "0.0.19",
         "mainFile": "index.ts",
-        "rootDir": "components/bit/get-bit-version"
+        "rootDir": "components/bit/get-bit-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "git": {
         "name": "git",
         "scope": "teambit.git",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1353",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
         "scope": "teambit.cloud",
         "version": "0.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-cloud-scopes"
+        "rootDir": "scopes/cloud/hooks/use-cloud-scopes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "hooks/use-current-user": {
         "name": "hooks/use-current-user",
         "scope": "teambit.cloud",
         "version": "0.0.29",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-current-user"
+        "rootDir": "scopes/cloud/hooks/use-current-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "hooks/use-lane-components": {
         "name": "hooks/use-lane-components",
@@ -805,7 +1072,10 @@
         "scope": "teambit.cloud",
         "version": "0.0.22",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-logout"
+        "rootDir": "scopes/cloud/hooks/use-logout",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "hooks/use-navigation-message-listener": {
         "name": "hooks/use-navigation-message-listener",
@@ -826,119 +1096,170 @@
         "scope": "teambit.lanes",
         "version": "0.0.259",
         "mainFile": "index.ts",
-        "rootDir": "components/hooks/use-viewed-lane-from-url_1"
+        "rootDir": "components/hooks/use-viewed-lane-from-url_1",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "host-initializer": {
         "name": "host-initializer",
         "scope": "teambit.harmony",
         "version": "0.0.764",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer"
+        "rootDir": "scopes/harmony/host-initializer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.50",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize"
+        "rootDir": "scopes/component/internalize",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
         "scope": "teambit.toolbox",
         "version": "0.0.5",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/json/jsonc-utils"
+        "rootDir": "scopes/toolbox/json/jsonc-utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "lanes": {
         "name": "lanes",
         "scope": "teambit.lanes",
         "version": "1.0.1070",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
         "scope": "teambit.component",
         "version": "0.0.421",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy-component-log"
+        "rootDir": "components/legacy-component-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "linter": {
         "name": "linter",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "loader": {
         "name": "loader",
         "scope": "teambit.legacy",
         "version": "0.0.22",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/loader"
+        "rootDir": "components/legacy/loader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "mcp-config-writer": {
         "name": "mcp-config-writer",
         "scope": "teambit.mcp",
         "version": "0.0.12",
         "mainFile": "index.ts",
-        "rootDir": "components/mcp/mcp-config-writer"
+        "rootDir": "components/mcp/mcp-config-writer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -952,21 +1273,30 @@
         "scope": "teambit.lanes",
         "version": "1.0.1070",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1054",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.867",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -980,56 +1310,80 @@
         "scope": "teambit.compositions",
         "version": "0.0.524",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/model/composition-type"
+        "rootDir": "scopes/compositions/model/composition-type",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "models/cloud-scope": {
         "name": "models/cloud-scope",
         "scope": "teambit.cloud",
         "version": "0.0.23",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-scope"
+        "rootDir": "scopes/cloud/models/cloud-scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "models/cloud-user": {
         "name": "models/cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.23",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-user"
+        "rootDir": "scopes/cloud/models/cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "models/scope-model": {
         "name": "models/scope-model",
         "scope": "teambit.scope",
         "version": "0.0.554",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/models/scope-model"
+        "rootDir": "scopes/scope/models/scope-model",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/babel-compiler": {
         "name": "modules/babel-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.145",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/modules/babel-compiler"
+        "rootDir": "scopes/compilation/modules/babel-compiler",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/component-package-name": {
         "name": "modules/component-package-name",
         "scope": "teambit.pkg",
         "version": "0.0.142",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/component-package-name"
+        "rootDir": "components/modules/component-package-name",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/component-url": {
         "name": "modules/component-url",
         "scope": "teambit.component",
         "version": "0.0.194",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-url"
+        "rootDir": "scopes/component/component-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/concurrency": {
         "name": "modules/concurrency",
         "scope": "teambit.harmony",
         "version": "0.0.34",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/concurrency"
+        "rootDir": "scopes/harmony/modules/concurrency",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/config-mutator": {
         "name": "modules/config-mutator",
@@ -1043,70 +1397,100 @@
         "scope": "teambit.html",
         "version": "0.0.128",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/create-element-from-string"
+        "rootDir": "scopes/html/modules/create-element-from-string",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/create-lane": {
         "name": "modules/create-lane",
         "scope": "teambit.lanes",
         "version": "0.0.170",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/modules/create-lane"
+        "rootDir": "scopes/lanes/modules/create-lane",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/diff": {
         "name": "modules/diff",
         "scope": "teambit.lanes",
         "version": "0.0.639",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/diff"
+        "rootDir": "scopes/lanes/diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/feature-toggle": {
         "name": "modules/feature-toggle",
         "scope": "teambit.harmony",
         "version": "0.0.45",
         "mainFile": "feature-toggle.ts",
-        "rootDir": "scopes/harmony/modules/feature-toggle"
+        "rootDir": "scopes/harmony/modules/feature-toggle",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/fetch-html-from-url": {
         "name": "modules/fetch-html-from-url",
         "scope": "teambit.html",
         "version": "0.0.128",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/fetch-html-from-url"
+        "rootDir": "scopes/html/modules/fetch-html-from-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/find-scope-path": {
         "name": "modules/find-scope-path",
         "scope": "teambit.scope",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/find-scope-path"
+        "rootDir": "components/modules/find-scope-path",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/fs-cache": {
         "name": "modules/fs-cache",
         "scope": "teambit.workspace",
         "version": "0.0.63",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/fs-cache"
+        "rootDir": "scopes/workspace/modules/fs-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/generate-asset-manifest": {
         "name": "modules/generate-asset-manifest",
         "scope": "teambit.rspack",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/generate-asset-manifest"
+        "rootDir": "components/modules/generate-asset-manifest",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "modules/generate-expose-loaders": {
         "name": "modules/generate-expose-loaders",
         "scope": "teambit.webpack",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-expose-loaders"
+        "rootDir": "scopes/webpack/modules/generate-expose-loaders",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/generate-externals": {
         "name": "modules/generate-externals",
         "scope": "teambit.webpack",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-externals"
+        "rootDir": "scopes/webpack/modules/generate-externals",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/generate-style-loaders": {
         "name": "modules/generate-style-loaders",
@@ -1120,175 +1504,250 @@
         "scope": "teambit.harmony",
         "version": "0.0.136",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/get-basic-log"
+        "rootDir": "scopes/harmony/modules/get-basic-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/get-cloud-user": {
         "name": "modules/get-cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.136",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/modules/get-cloud-user"
+        "rootDir": "scopes/cloud/modules/get-cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/git-executable": {
         "name": "modules/git-executable",
         "scope": "teambit.git",
         "version": "0.0.34",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/git-executable"
+        "rootDir": "scopes/git/modules/git-executable",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/harmony-root-generator": {
         "name": "modules/harmony-root-generator",
         "scope": "teambit.harmony",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/harmony-root-generator"
+        "rootDir": "components/modules/harmony-root-generator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/ignore-file-reader": {
         "name": "modules/ignore-file-reader",
         "scope": "teambit.git",
         "version": "0.0.34",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/ignore-file-reader"
+        "rootDir": "scopes/git/modules/ignore-file-reader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/in-memory-cache": {
         "name": "modules/in-memory-cache",
         "scope": "teambit.harmony",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/in-memory-cache"
+        "rootDir": "scopes/harmony/modules/in-memory-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/load-trace": {
         "name": "modules/load-trace",
         "scope": "teambit.harmony",
         "version": "0.0.5",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/load-trace"
+        "rootDir": "scopes/harmony/modules/load-trace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/match-pattern": {
         "name": "modules/match-pattern",
         "scope": "teambit.workspace",
         "version": "0.0.524",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/match-pattern"
+        "rootDir": "scopes/workspace/modules/match-pattern",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/merge-component-results": {
         "name": "modules/merge-component-results",
         "scope": "teambit.pipelines",
         "version": "0.0.516",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/merge-component-results"
+        "rootDir": "scopes/pipelines/modules/merge-component-results",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/merge-helper": {
         "name": "modules/merge-helper",
         "scope": "teambit.component",
         "version": "0.0.78",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/modules/merge-helper"
+        "rootDir": "scopes/component/modules/merge-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/module-resolver": {
         "name": "modules/module-resolver",
         "scope": "teambit.toolbox",
         "version": "0.0.21",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/modules/module-resolver"
+        "rootDir": "scopes/toolbox/modules/module-resolver",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "modules/node-modules-linker": {
         "name": "modules/node-modules-linker",
         "scope": "teambit.workspace",
         "version": "0.0.366",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/node-modules-linker"
+        "rootDir": "scopes/workspace/modules/node-modules-linker",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/requireable-component": {
         "name": "modules/requireable-component",
         "scope": "teambit.harmony",
         "version": "0.0.517",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/requireable-component"
+        "rootDir": "scopes/harmony/modules/requireable-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/resolved-component": {
         "name": "modules/resolved-component",
         "scope": "teambit.harmony",
         "version": "0.0.517",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/resolved-component"
+        "rootDir": "scopes/harmony/modules/resolved-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/semver-helper": {
         "name": "modules/semver-helper",
         "scope": "teambit.pkg",
         "version": "0.0.26",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/modules/semver-helper"
+        "rootDir": "scopes/pkg/modules/semver-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/send-server-sent-events": {
         "name": "modules/send-server-sent-events",
         "scope": "teambit.harmony",
         "version": "0.0.21",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/send-server-sent-events"
+        "rootDir": "scopes/harmony/modules/send-server-sent-events",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/style-regexps": {
         "name": "modules/style-regexps",
         "scope": "teambit.webpack",
         "version": "1.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/style-regexps"
+        "rootDir": "scopes/webpack/style-regexps",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/ts-config-mutator": {
         "name": "modules/ts-config-mutator",
         "scope": "teambit.typescript",
         "version": "0.0.90",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/modules/ts-config-mutator"
+        "rootDir": "scopes/typescript/modules/ts-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "modules/workspace-locator": {
         "name": "modules/workspace-locator",
         "scope": "teambit.workspace",
         "version": "0.0.34",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/workspace-locator"
+        "rootDir": "scopes/workspace/modules/workspace-locator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "mover": {
         "name": "mover",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "network": {
         "name": "network",
         "scope": "teambit.scope",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/network"
+        "rootDir": "scopes/scope/network",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "network/get-port": {
         "name": "network/get-port",
         "scope": "teambit.toolbox",
         "version": "1.0.22",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/network/get-port"
+        "rootDir": "scopes/toolbox/network/get-port",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "new-component-helper": {
         "name": "new-component-helper",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "node": {
         "name": "node",
@@ -1302,14 +1761,20 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.558",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects"
+        "rootDir": "scopes/scope/objects",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
@@ -1323,7 +1788,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.1352",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1337,91 +1805,130 @@
         "scope": "teambit.toolbox",
         "version": "0.0.510",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/is-path-inside"
+        "rootDir": "scopes/toolbox/path/is-path-inside",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "path/match-patterns": {
         "name": "path/match-patterns",
         "scope": "teambit.toolbox",
         "version": "0.0.29",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/match-patterns"
+        "rootDir": "scopes/toolbox/path/match-patterns",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "path/path": {
         "name": "path/path",
         "scope": "teambit.toolbox",
         "version": "0.0.18",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/path"
+        "rootDir": "scopes/toolbox/path/path",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "path/to-windows-compatible-path": {
         "name": "path/to-windows-compatible-path",
         "scope": "teambit.toolbox",
         "version": "0.0.510",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/to-windows-compatible-path"
+        "rootDir": "scopes/toolbox/path/to-windows-compatible-path",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "pkg": {
         "name": "pkg",
         "scope": "teambit.pkg",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
         "scope": "teambit.webpack",
         "version": "0.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin"
+        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "plugins/manifest-plugin": {
         "name": "plugins/manifest-plugin",
         "scope": "teambit.rspack",
         "version": "0.0.5",
         "mainFile": "index.ts",
-        "rootDir": "components/plugins/manifest-plugin"
+        "rootDir": "components/plugins/manifest-plugin",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "pnpm": {
         "name": "pnpm",
         "scope": "teambit.dependencies",
         "version": "1.0.1085",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.120",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier-config-mutator"
+        "rootDir": "scopes/defender/prettier-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "preview": {
         "name": "preview",
         "scope": "teambit.preview",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/promise/map-pool"
+        "rootDir": "scopes/toolbox/promise/map-pool",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "pubsub": {
         "name": "pubsub",
         "scope": "teambit.harmony",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "react": {
         "name": "react",
@@ -1435,7 +1942,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "readme": {
         "name": "readme",
@@ -1449,35 +1959,50 @@
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "remote-actions": {
         "name": "remote-actions",
         "scope": "teambit.scope",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/remote-actions"
+        "rootDir": "scopes/scope/remote-actions",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "remotes": {
         "name": "remotes",
         "scope": "teambit.scope",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "components/scope/remotes"
+        "rootDir": "components/scope/remotes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "remove": {
         "name": "remove",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -1498,112 +2023,160 @@
         "scope": "teambit.cloud",
         "version": "0.0.133",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple"
+        "rootDir": "scopes/cloud/ripple",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "scope-api": {
         "name": "scope-api",
         "scope": "teambit.legacy",
         "version": "0.0.190",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope-api"
+        "rootDir": "components/legacy/scope-api",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "scripts": {
         "name": "scripts",
         "scope": "teambit.workspace",
         "version": "0.0.270",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "snap-distance": {
         "name": "snap-distance",
         "scope": "teambit.component",
         "version": "0.0.136",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snap-distance"
+        "rootDir": "scopes/component/snap-distance",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "snapping": {
         "name": "snapping",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "sources": {
         "name": "sources",
         "scope": "teambit.component",
         "version": "0.0.187",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/sources"
+        "rootDir": "scopes/component/sources",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "stash": {
         "name": "stash",
         "scope": "teambit.component",
         "version": "1.0.1052",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1074",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
         "scope": "teambit.toolbox",
         "version": "0.0.510",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/capitalize"
+        "rootDir": "scopes/toolbox/string/capitalize",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "string/ellipsis": {
         "name": "string/ellipsis",
         "scope": "teambit.toolbox",
         "version": "0.0.201",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/ellipsis"
+        "rootDir": "scopes/toolbox/string/ellipsis",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "string/eol": {
         "name": "string/eol",
         "scope": "teambit.toolbox",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/eol"
+        "rootDir": "scopes/toolbox/string/eol",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "string/get-initials": {
         "name": "string/get-initials",
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/get-initials"
+        "rootDir": "scopes/toolbox/string/get-initials",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "string/random": {
         "name": "string/random",
         "scope": "teambit.toolbox",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/random"
+        "rootDir": "scopes/toolbox/string/random",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "string/strip-trailing-char": {
         "name": "string/strip-trailing-char",
         "scope": "teambit.toolbox",
         "version": "0.0.510",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/strip-trailing-char"
+        "rootDir": "scopes/toolbox/string/strip-trailing-char",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "tagged-exports": {
         "name": "tagged-exports",
@@ -1617,98 +2190,140 @@
         "scope": "teambit.harmony",
         "version": "0.0.1442",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
         "scope": "teambit.legacy",
         "version": "0.0.48",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/logger"
+        "rootDir": "components/legacy/logger",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "teambit.legacy/scope": {
         "name": "scope",
         "scope": "teambit.legacy",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope"
+        "rootDir": "components/legacy/scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "teambit.scope/scope": {
         "name": "scope",
         "scope": "teambit.scope",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
         "scope": "teambit.harmony",
         "version": "0.0.401",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/testing/load-aspect"
+        "rootDir": "scopes/harmony/testing/load-aspect",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "testing/mock-components": {
         "name": "testing/mock-components",
         "scope": "teambit.component",
         "version": "0.0.406",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/testing/mock-components"
+        "rootDir": "scopes/component/testing/mock-components",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "testing/mock-workspace": {
         "name": "testing/mock-workspace",
         "scope": "teambit.workspace",
         "version": "0.0.209",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/testing/mock-workspace"
+        "rootDir": "scopes/workspace/testing/mock-workspace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "time/timer": {
         "name": "time/timer",
         "scope": "teambit.toolbox",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/time/timer"
+        "rootDir": "scopes/toolbox/time/timer",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "tracker": {
         "name": "tracker",
         "scope": "teambit.component",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
         "scope": "teambit.typescript",
         "version": "0.0.83",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/ts-server"
+        "rootDir": "scopes/typescript/ts-server",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "types/serializable": {
         "name": "types/serializable",
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/types/serializable"
+        "rootDir": "scopes/toolbox/types/serializable",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "typescript": {
         "name": "typescript",
         "scope": "teambit.typescript",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui"
+        "rootDir": "scopes/ui-foundation/ui",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ui/aspect-box": {
         "name": "ui/aspect-box",
@@ -1736,7 +2351,10 @@
         "scope": "teambit.code",
         "version": "0.0.348",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/code-compare"
+        "rootDir": "components/ui/code-compare",
+        "config": {
+            "teambit.react/v17/react-env@1.2.7": {}
+        }
     },
     "ui/code-editor": {
         "name": "ui/code-editor",
@@ -1771,7 +2389,10 @@
         "scope": "teambit.component",
         "version": "0.0.266",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/component-compare"
+        "rootDir": "components/ui/component-compare/component-compare",
+        "config": {
+            "teambit.react/v17/react-env@1.2.7": {}
+        }
     },
     "ui/component-compare/context": {
         "name": "ui/component-compare/context",
@@ -1785,7 +2406,10 @@
         "scope": "teambit.component",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/models/component-compare-props"
+        "rootDir": "components/ui/component-compare/models/component-compare-props",
+        "config": {
+            "teambit.react/v17/react-env@1.2.7": {}
+        }
     },
     "ui/component-compare/utils/lazy-loading": {
         "name": "ui/component-compare/utils/lazy-loading",
@@ -2023,7 +2647,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.526",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/react-router/slot-router"
+        "rootDir": "components/ui/react-router/slot-router",
+        "config": {
+            "teambit.react/v17/react-env@1.2.7": {}
+        }
     },
     "ui/rendering/html": {
         "name": "ui/rendering/html",
@@ -2037,7 +2664,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.939",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/side-bar"
+        "rootDir": "components/ui/side-bar",
+        "config": {
+            "teambit.react/v17/react-env@1.2.7": {}
+        }
     },
     "ui/test-compare": {
         "name": "ui/test-compare",
@@ -2107,98 +2737,140 @@
         "scope": "teambit.toolbox",
         "version": "0.0.514",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/url/add-avatar-query-params"
+        "rootDir": "scopes/toolbox/url/add-avatar-query-params",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "url/query-string": {
         "name": "url/query-string",
         "scope": "teambit.toolbox",
         "version": "0.0.510",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/url/query-string"
+        "rootDir": "scopes/toolbox/url/query-string",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@1.0.1": {}
+        }
     },
     "user-agent": {
         "name": "user-agent",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "utils": {
         "name": "utils",
         "scope": "teambit.legacy",
         "version": "0.0.41",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/utils"
+        "rootDir": "components/legacy/utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.2": {}
+        }
     },
     "validator": {
         "name": "validator",
         "scope": "teambit.defender",
         "version": "0.0.287",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator"
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1617",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.843",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history"
+        "rootDir": "scopes/scope/version-history",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.417",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue"
+        "rootDir": "scopes/vue/vue",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1653",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1051",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/.bitmap
+++ b/.bitmap
@@ -2351,10 +2351,7 @@
         "scope": "teambit.code",
         "version": "0.0.348",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/code-compare",
-        "config": {
-            "teambit.react/v17/react-env@1.2.7": {}
-        }
+        "rootDir": "components/ui/code-compare"
     },
     "ui/code-editor": {
         "name": "ui/code-editor",
@@ -2389,10 +2386,7 @@
         "scope": "teambit.component",
         "version": "0.0.266",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/component-compare",
-        "config": {
-            "teambit.react/v17/react-env@1.2.7": {}
-        }
+        "rootDir": "components/ui/component-compare/component-compare"
     },
     "ui/component-compare/context": {
         "name": "ui/component-compare/context",
@@ -2406,10 +2400,7 @@
         "scope": "teambit.component",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/models/component-compare-props",
-        "config": {
-            "teambit.react/v17/react-env@1.2.7": {}
-        }
+        "rootDir": "components/ui/component-compare/models/component-compare-props"
     },
     "ui/component-compare/utils/lazy-loading": {
         "name": "ui/component-compare/utils/lazy-loading",
@@ -2647,10 +2638,7 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.526",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/react-router/slot-router",
-        "config": {
-            "teambit.react/v17/react-env@1.2.7": {}
-        }
+        "rootDir": "components/ui/react-router/slot-router"
     },
     "ui/rendering/html": {
         "name": "ui/rendering/html",
@@ -2664,10 +2652,7 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.939",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/side-bar",
-        "config": {
-            "teambit.react/v17/react-env@1.2.7": {}
-        }
+        "rootDir": "components/ui/side-bar"
     },
     "ui/test-compare": {
         "name": "ui/test-compare",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,7 @@ commands:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v1.0.0-v1
+          key: core-aspect-env-v1.0.1-v1
       - run: npm view @teambit/bit version > ./version.txt
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
@@ -476,7 +476,7 @@ commands:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v1.0.0-v1
+          key: core-aspect-env-v1.0.1-v1
       - run: npm view @teambit/bit version > ./version.txt
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
@@ -584,7 +584,7 @@ jobs:
           name: bbit install
           command: cd bit && bbit install
       - save_cache:
-          key: core-aspect-env-v1.0.0-v1
+          key: core-aspect-env-v1.0.1-v1
           paths:
             - /home/circleci/Library/Caches/Bit/capsules/caec9a107
       # - run: cd bit && bbit compile
@@ -634,7 +634,7 @@ jobs:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v1.0.0-v1
+          key: core-aspect-env-v1.0.1-v1
       - run:
           name: 'check circular dependencies'
           command: 'cd bit && ./scripts/circular-deps-check/ci-check.sh'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,7 @@ commands:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v1.0.1-v1
+          key: core-aspect-env-v1.0.0-v1
       - run: npm view @teambit/bit version > ./version.txt
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
@@ -476,7 +476,7 @@ commands:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v1.0.1-v1
+          key: core-aspect-env-v1.0.0-v1
       - run: npm view @teambit/bit version > ./version.txt
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
@@ -584,7 +584,7 @@ jobs:
           name: bbit install
           command: cd bit && bbit install
       - save_cache:
-          key: core-aspect-env-v1.0.1-v1
+          key: core-aspect-env-v1.0.0-v1
           paths:
             - /home/circleci/Library/Caches/Bit/capsules/caec9a107
       # - run: cd bit && bbit compile
@@ -634,7 +634,7 @@ jobs:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v1.0.1-v1
+          key: core-aspect-env-v1.0.0-v1
       - run:
           name: 'check circular dependencies'
           command: 'cd bit && ./scripts/circular-deps-check/ci-check.sh'

--- a/components/legacy/consumer-config/workspace-config.ts
+++ b/components/legacy/consumer-config/workspace-config.ts
@@ -29,6 +29,11 @@ export type WorkspaceConfigProps = {
   defaultScope?: string;
 };
 
+// stored on globalThis because in build capsules this module may be loaded twice (once from the
+// capsule source and once from an installed dist). a static class field would then be set on one
+// copy and read from the other, making the workspace config silently fail to load.
+const workspaceConfigLoadingRegistryKey = '__bit_workspaceConfigLoadingRegistry';
+
 export default class WorkspaceConfig extends AbstractConfig {
   componentsDefaultDirectory: string;
   packageManager: PackageManagerClients;
@@ -39,7 +44,12 @@ export default class WorkspaceConfig extends AbstractConfig {
   packageJsonObject: Record<string, any> | null | undefined; // workspace package.json if exists (parsed)
   defaultScope: string | undefined; // default remote scope to export to
 
-  static workspaceConfigLoadingRegistry: WorkspaceConfigLoadFunction;
+  static get workspaceConfigLoadingRegistry(): WorkspaceConfigLoadFunction | undefined {
+    return (globalThis as any)[workspaceConfigLoadingRegistryKey];
+  }
+  static set workspaceConfigLoadingRegistry(func: WorkspaceConfigLoadFunction | undefined) {
+    (globalThis as any)[workspaceConfigLoadingRegistryKey] = func;
+  }
   static registerOnWorkspaceConfigLoading(func: WorkspaceConfigLoadFunction) {
     this.workspaceConfigLoadingRegistry = func;
   }

--- a/components/ui/side-bar/side-bar.composition.tsx
+++ b/components/ui/side-bar/side-bar.composition.tsx
@@ -19,7 +19,7 @@ function mockComponent(id: string, scope: string, namespace?: string): Component
     id: {
       scope,
       fullName,
-      toString: ({ ignoreVersion }: { ignoreVersion?: boolean } = {}) => fullId,
+      toString: () => fullId,
       toStringWithoutVersion: () => fullId,
       toObject: () => ({ scope, name: fullName }),
     },

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1500,7 +1500,11 @@ export class IsolatorMain {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       packageJson.addOrUpdateProperty('version', semver.inc(legacyComp.version!, 'prerelease') || '0.0.1-0');
     }
-    await PackageJsonTransformer.applyTransformers(component, packageJson);
+    // "as any" is needed when compiling in a capsule: this file gets PackageJsonFile from the
+    // capsule-source of component.sources, while node-modules-linker's d.ts references the
+    // installed dist copy. they're identical, but protected members make TS treat them as
+    // incompatible nominal types.
+    await PackageJsonTransformer.applyTransformers(component, packageJson as any);
     const valuesToMerge = legacyComp.overrides.componentOverridesPackageJsonData;
     packageJson.mergePackageJsonObject(valuesToMerge);
     if (populateArtifactsFromComps && !opts?.populateArtifactsIgnorePkgJson) {


### PR DESCRIPTION
Updates the node envs to their latest versions via `bit env update`, scoped to just these two:

- **node-babel-mocha** → 1.0.2 (drops the ESLint stack for oxlint, pre-bundled preview, `@mdx-js/react` v3)
- **node-typescript-mocha** → 1.0.1