### PR TITLE
fix(harmony): load core aspects from bit's own install when workspace dist is missing

### DIFF
--- a/scopes/harmony/bit/hook-require.ts
+++ b/scopes/harmony/bit/hook-require.ts
@@ -22,6 +22,22 @@ export function hookRequire() {
         if (!pkgJson.main || pkgJson.main === 'index.js') throw firstErr;
         return this.constructor._load(path.join(id, pkgJson.main), this);
       } catch {
+        // Last resort for Bit's own core-aspect packages (`@teambit/*`). In a workspace where
+        // these are source components (most notably the Bit repo itself), an env loaded from
+        // root node_modules can eagerly `require('@teambit/builder')` during `bit install` —
+        // before the workspace component is compiled — so the resolved copy's `dist` main
+        // doesn't exist yet and the require above hard-crashes. Bit's own installation always
+        // ships a compiled copy of its core aspects, so re-resolve from this module's context
+        // (inside `@teambit/bit`) and load that instead of failing. Only runs on the crash
+        // path, so the happy path (dist present, e.g. every normal user workspace) is untouched.
+        if (id.startsWith('@teambit/')) {
+          try {
+            const fromBitContext = require.resolve(id, { paths: [__dirname] });
+            return this.constructor._load(fromBitContext, this);
+          } catch {
+            throw firstErr;
+          }
+        }
         throw firstErr;
       }
     }


### PR DESCRIPTION
## Problem

When a workspace loads envs from root node_modules (`resolveEnvsFromRoots: true`), an env's constructor can eagerly `require('@teambit/builder')` (and `@teambit/ui`) at module-load time. In a workspace where the core aspects are **source components** — most notably the Bit repo itself — that require resolves to the workspace copy, whose `dist/main` doesn't exist yet during `bit install` (before `bit compile`). Result: `Cannot find module '.../@teambit/builder/dist/index.js'` and the install crashes.

This isn't specific to `core-aspect-env`: `node`, `node-babel-mocha`, `node-typescript-mocha`, and `base-react-env` all eagerly touch `@teambit/builder` the same way.

## Fix

Add a last-resort fallback in `hook-require.ts`: when a `@teambit/*` core-aspect package fails to load, re-resolve it from Bit's own installed context (which always ships compiled `dist`) and load that. It only runs on the existing crash path, so the happy path — every normal user workspace where these are registry packages with `dist` present — is untouched.

## Why

Unblocks setting `resolveEnvsFromRoots: true` in the Bit repo, which lets envs load from node_modules instead of stacking per-version scope-aspects capsules in the global cache. The flag flip is a follow-up, after this ships in a nightly (the crash occurs inside the released `bbit` during `setup_harmony`, so it must land here first).