### PR TITLE
test(cli): reproduce ci rebuild-scope failures

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1736,7 +1736,13 @@
         "scope": "teambit.code",
         "version": "0.0.348",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/code-compare"
+        "rootDir": "components/ui/code-compare",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/code-editor": {
         "name": "ui/code-editor",
@@ -1771,7 +1777,13 @@
         "scope": "teambit.component",
         "version": "0.0.266",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/component-compare"
+        "rootDir": "components/ui/component-compare/component-compare",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/component-compare/context": {
         "name": "ui/component-compare/context",
@@ -1785,7 +1797,13 @@
         "scope": "teambit.component",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/models/component-compare-props"
+        "rootDir": "components/ui/component-compare/models/component-compare-props",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/component-compare/utils/lazy-loading": {
         "name": "ui/component-compare/utils/lazy-loading",
@@ -2023,7 +2041,13 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.526",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/react-router/slot-router"
+        "rootDir": "components/ui/react-router/slot-router",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/rendering/html": {
         "name": "ui/rendering/html",
@@ -2037,7 +2061,13 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.939",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/side-bar"
+        "rootDir": "components/ui/side-bar",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/test-compare": {
         "name": "ui/test-compare",

--- a/scopes/harmony/cli/command.ts
+++ b/scopes/harmony/cli/command.ts
@@ -1,5 +1,8 @@
 import type { Group } from './command-groups';
 
+// no-op change to force a rebuild of teambit.harmony/cli and its dependents in `bit ci pr`,
+// isolating whether the capsule test failures stem from the rebuild scope (not any behavior change).
+
 type CommandOption = [string, string, string];
 export type CommandOptions = Array<CommandOption>;
 


### PR DESCRIPTION
Isolation experiment: a single no-op comment change in `teambit.harmony/cli` to force a full rebuild of its dependents in `bit ci pr`.

Goal: confirm whether the capsule test failures seen on the pager PR (#10472) stem purely from the rebuild scope (touching the cli framework rebuilds snapping/checkout/lanes, whose integration specs are fragile in capsules) rather than any behavior change.

Not intended to merge.