### PR TITLE
fix(envs): migrate remaining components from react/v17 env to react 19

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1736,7 +1736,13 @@
         "scope": "teambit.code",
         "version": "0.0.348",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/code-compare"
+        "rootDir": "components/ui/code-compare",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/code-editor": {
         "name": "ui/code-editor",
@@ -1771,7 +1777,13 @@
         "scope": "teambit.component",
         "version": "0.0.266",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/component-compare"
+        "rootDir": "components/ui/component-compare/component-compare",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/component-compare/context": {
         "name": "ui/component-compare/context",
@@ -1785,7 +1797,13 @@
         "scope": "teambit.component",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/component-compare/models/component-compare-props"
+        "rootDir": "components/ui/component-compare/models/component-compare-props",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/component-compare/utils/lazy-loading": {
         "name": "ui/component-compare/utils/lazy-loading",
@@ -2023,7 +2041,13 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.526",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/react-router/slot-router"
+        "rootDir": "components/ui/react-router/slot-router",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/rendering/html": {
         "name": "ui/rendering/html",
@@ -2037,7 +2061,13 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.939",
         "mainFile": "index.ts",
-        "rootDir": "components/ui/side-bar"
+        "rootDir": "components/ui/side-bar",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/test-compare": {
         "name": "ui/test-compare",


### PR DESCRIPTION
The repo's TS6 env upgrade left 5 components on the old `teambit.react/v17/react-env`, while all other React components had moved to `teambit.react/react` (React 19). The stale env intermittently failed the `GeneratePreview` task in capsule builds with `SyntaxError: Unexpected token 'export'`.

Migrates the 5 stragglers to `teambit.react/react`:
- `ui/code-compare`
- `ui/component-compare/component-compare`
- `ui/component-compare/models/component-compare-props`
- `ui/react-router/slot-router`
- `ui/side-bar`

Done via `bit env set '$env:teambit.react/v17/react-env' teambit.react/react` + `bit install`. The React 17 env is now unused and dropped from the lockfile, which also collapses a large amount of react 17/18 peer-variant duplication.

Verified on a capsule build: the React 19 `GeneratePreview` task passes for all 5 components and the v17 env no longer appears.