### PR TITLE
test(e2e-helper): verify + retry remote-scope registration in capsule builds

### DIFF
--- a/components/legacy/e2e-helper/e2e-scope-helper.ts
+++ b/components/legacy/e2e-helper/e2e-scope-helper.ts
@@ -142,15 +142,19 @@ export default class ScopeHelper {
   }
 
   /**
-   * read the `remotes` map from the workspace scope.json (`<cwd>/.bit/scope.json`). the map is
+   * read the `remotes` map from the scope.json of the scope at `cwd`. the map is
    * `{ [scopeName]: host }` (see ScopeJson.addRemote), and for e2e file remotes the scope name is
-   * the remote directory's basename.
+   * the remote directory's basename. scope.json lives under `.bit/` for a workspace but at the root
+   * for a bare scope (`bit init --bare`), and `bit remote add` can target either — so check both.
    */
   private readWorkspaceRemotes(cwd: string): Record<string, string> {
-    const scopeJsonPath = path.join(cwd, '.bit', 'scope.json');
-    if (!fs.existsSync(scopeJsonPath)) return {};
-    const scopeJson = fs.readJsonSync(scopeJsonPath, { throws: false });
-    return (scopeJson && scopeJson.remotes) || {};
+    const candidatePaths = [path.join(cwd, '.bit', 'scope.json'), path.join(cwd, 'scope.json')];
+    for (const scopeJsonPath of candidatePaths) {
+      if (!fs.existsSync(scopeJsonPath)) continue;
+      const scopeJson = fs.readJsonSync(scopeJsonPath, { throws: false });
+      if (scopeJson && scopeJson.remotes) return scopeJson.remotes;
+    }
+    return {};
   }
 
   private isRemoteRegistered(remoteScopePath: string, cwd: string): boolean {

--- a/components/legacy/e2e-helper/e2e-scope-helper.ts
+++ b/components/legacy/e2e-helper/e2e-scope-helper.ts
@@ -113,7 +113,55 @@ export default class ScopeHelper {
     isGlobal = false
   ) {
     const globalArg = isGlobal ? '-g' : '';
-    return this.command.runCmd(`bit remote add file://${remoteScopePath} ${globalArg}`, cwd);
+    const cmd = `bit remote add file://${remoteScopePath} ${globalArg}`;
+    const result = this.command.runCmd(cmd, cwd);
+    // Verify the remote actually landed in the workspace scope.json and retry a few times if not.
+    // Under a capsule build (`bit ci pr --build`) dozens of these integration specs run back-to-back
+    // in a single long-lived process while the host build machinery touches the same shared global
+    // config/scope. That occasionally leaves the just-added `<hash>-remote` unresolvable to a later
+    // in-process import, which then falls through to the bit.cloud hub and throws
+    // `InvalidScopeNameFromRemote`. A bounded re-add recovers a transient write race; if it still
+    // can't be verified we log a loud, diagnosable message (rather than throw) so we never regress
+    // the hundreds of other callers, and so a residual CI failure clearly points at registration
+    // vs. an import-side resolution problem.
+    if (!isGlobal) {
+      const maxRetries = 3;
+      for (let attempt = 0; attempt < maxRetries && !this.isRemoteRegistered(remoteScopePath, cwd); attempt += 1) {
+        this.command.runCmd(cmd, cwd);
+      }
+      if (!this.isRemoteRegistered(remoteScopePath, cwd)) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[e2e-helper] WARNING: remote "file://${remoteScopePath}" is not registered in the workspace ` +
+            `scope.json at "${cwd}" after ${maxRetries + 1} attempts. remotes on disk: ` +
+            JSON.stringify(this.readWorkspaceRemotes(cwd))
+        );
+      }
+    }
+    return result;
+  }
+
+  /**
+   * read the `remotes` map from the workspace scope.json (`<cwd>/.bit/scope.json`). the map is
+   * `{ [scopeName]: host }` (see ScopeJson.addRemote), and for e2e file remotes the scope name is
+   * the remote directory's basename.
+   */
+  private readWorkspaceRemotes(cwd: string): Record<string, string> {
+    const scopeJsonPath = path.join(cwd, '.bit', 'scope.json');
+    if (!fs.existsSync(scopeJsonPath)) return {};
+    const scopeJson = fs.readJsonSync(scopeJsonPath, { throws: false });
+    return (scopeJson && scopeJson.remotes) || {};
+  }
+
+  private isRemoteRegistered(remoteScopePath: string, cwd: string): boolean {
+    const scopeName = path.basename(remoteScopePath);
+    const remotes = this.readWorkspaceRemotes(cwd);
+    // match by scope name (the registered key) or by the host value referencing the remote path —
+    // basename is stable against any path normalization the remote-add may apply to the host.
+    return (
+      scopeName in remotes ||
+      Object.values(remotes).some((host) => typeof host === 'string' && host.includes(scopeName))
+    );
   }
 
   addRemoteHttpScope(port = '3000') {

--- a/scopes/workspace/testing/mock-workspace/mock-workspace.ts
+++ b/scopes/workspace/testing/mock-workspace/mock-workspace.ts
@@ -19,6 +19,17 @@ export function mockWorkspace(opts: { bareScopeName?: string } = {}): WorkspaceD
   if (opts.bareScopeName) {
     legacyHelper.scopeHelper.reInitWorkspace();
     legacyHelper.scopes.setRemoteScope(undefined, undefined, opts.bareScopeName);
+    // this "second workspace" flow reconstructs the remote path from the scope name and re-registers
+    // it. it only works if the bare scope created by the first workspace still exists at that path.
+    // surface a clear diagnostic if it doesn't (a leftover-cleanup / ordering issue), instead of the
+    // cryptic scope-resolution error that surfaces later at import time.
+    if (!fs.existsSync(legacyHelper.scopes.remotePath)) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[mockWorkspace] WARNING: bare scope "${opts.bareScopeName}" does not exist at ` +
+          `"${legacyHelper.scopes.remotePath}"; the reconstructed remote will not resolve.`
+      );
+    }
     legacyHelper.scopeHelper.addRemoteScope();
   } else {
     legacyHelper.scopeHelper.setWorkspaceWithRemoteScope();


### PR DESCRIPTION
## Problem

Integration specs that create file-based remote scopes (snapping/checkout/lanes via `mockWorkspace`) intermittently fail **only under `bit ci pr --build`** (capsule builds), not under `bit test`, with:

- `InvalidScopeNameFromRemote: cannot find scope '<hash>-remote'`
- `MissingBitMapComponent: component "<hash>-remote/comp1" was not found`

Root cause: these in-process integration tests share global state with no per-test isolation (the global config/scope dir is frozen at module-load from `~/Library/Caches/Bit`). Under a build, dozens of them run back-to-back in one long-lived process alongside the host build machinery, so a just-registered `<hash>-remote` occasionally isn't resolvable to a later import, which then falls through to the bit.cloud hub.

## This change

Hardens the e2e-helper remote registration as a low-risk first step:

- `ScopeHelper.addRemoteScope()` now verifies the remote actually landed in the workspace `scope.json` and re-adds it (bounded retry) if not — recovering a transient write race. If it still can't be verified it logs a loud, diagnosable message (does **not** throw), so the hundreds of other callers can't regress and any residual CI failure clearly points at registration vs. an import-side resolution problem.
- `mockWorkspace({ bareScopeName })` warns clearly if the reconstructed bare-scope path doesn't exist, instead of surfacing a cryptic scope-resolution error later.

Test-infra only; no product behavior change. This is deliberately conservative — we'll watch several `bit_pr` runs to see whether it removes the flake or localizes it to the import side for a follow-up.