### PR TITLE
fix(isolator): don't isolate published-tag dependency-only cycles

### DIFF
--- a/e2e/harmony/isolate-cyclic-deps.e2e.ts
+++ b/e2e/harmony/isolate-cyclic-deps.e2e.ts
@@ -34,6 +34,36 @@ describe('isolating cyclic dependencies', function () {
     });
   });
 
+  // Regression for the reverse case: when the seeder is NOT part of a cycle, a cycle that exists
+  // purely among its dependencies (published tags) must stay out of the isolation and be installed
+  // as packages from the registry. Pulling such a dependency-only cycle in needlessly isolates
+  // components we don't build here and force-loads each one's env — which fails `bit build`/`bit sign`
+  // when a dependency carries an old/deprecated env that can't be loaded. Only cyclic deps the
+  // registry can't serve (unpublished snaps, or cycles that include a seeder) should be isolated.
+  describe('a dependency-only cycle, seeder not part of the cycle, isolated seeders-only', () => {
+    let capsuleIds: string[];
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      // comp1 <-> comp2 form a cycle among the dependencies. comp3 (the seeder) depends on comp1 but
+      // is not itself part of the cycle.
+      helper.fs.outputFile('comp1/index.js', `require('@${helper.scopes.remote}/comp2');`);
+      helper.fs.outputFile('comp2/index.js', `require('@${helper.scopes.remote}/comp1');`);
+      helper.fs.outputFile('comp3/index.js', `require('@${helper.scopes.remote}/comp1');`);
+      helper.command.addComponent('comp1');
+      helper.command.addComponent('comp2');
+      helper.command.addComponent('comp3');
+      helper.command.install();
+      helper.command.tagAllWithoutBuild('--ignore-issues="CircularDependencies"');
+      const output = helper.command.runCmd('bit capsule create comp3 --seeders-only -j');
+      capsuleIds = JSON.parse(output).map((capsule: { id: string }) => capsule.id.split('@')[0]);
+    });
+    it('should isolate only the seeder, not the dependency-only cycle members', () => {
+      expect(capsuleIds).to.include(`${helper.scopes.remote}/comp3`);
+      expect(capsuleIds).to.not.include(`${helper.scopes.remote}/comp1`);
+      expect(capsuleIds).to.not.include(`${helper.scopes.remote}/comp2`);
+    });
+  });
+
   // Regression for the Ripple failure that persisted after the seeders-only fix above: it happens
   // in the ASPECT-loading isolation path, not the sign path. A custom env built on a lane together
   // with a component it cycles with (the env's mounter imports the component; the component uses

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -530,9 +530,10 @@ export class IsolatorMain {
       const id = graph.node(idStr)?.attr;
       return id?.version != null && isSnap(id.version);
     };
-    // seeders compared without version — the seeder ids passed in may be versionless while graph nodes
-    // are versioned (same reason findCycles is called with includeDeps=true above).
-    const seederIdsNoVer = new Set(alreadyIsolated.map((comp) => comp.id.toStringWithoutVersion()));
+    // seeders compared without version — the seeder ids may be versionless while graph nodes are
+    // versioned (same reason findCycles is called with includeDeps=true above). Keyed off the
+    // `seeders` argument directly (not `alreadyIsolated`) so it doesn't rely on them being equal.
+    const seederIdsNoVer = new Set(seeders.map((id) => id.toStringWithoutVersion()));
     const cycleInvolvesSeeder = (cycle: string[]): boolean =>
       cycle.some((idStr) => {
         const attr = graph.node(idStr)?.attr;

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -518,8 +518,9 @@ export class IsolatorMain {
     const host = opts.host || this.componentAspect.getHost();
     const getGraphOpts = pick(opts, ['host']);
     const graph = await this.graph.getGraphIds(seeders, getGraphOpts);
-    // the graph only spans the seeders and their dependencies, so any cycle in it is a cycle a
-    // seeder participates in. Pass includeDeps=true so detection doesn't rely on matching the
+    // the graph spans the seeders and their dependency closure, so cycles here are either cycles a
+    // seeder participates in, or cycles purely among dependencies (only the former need isolating -
+    // see the members filter below). Pass includeDeps=true so detection doesn't rely on matching the
     // (possibly versionless) seeder ids against the graph's versioned node ids — otherwise a
     // seeder-involving cycle can be missed and its members get installed from the registry again.
     const cycles = graph.findCycles(undefined, true);
@@ -529,13 +530,29 @@ export class IsolatorMain {
       const id = graph.node(idStr)?.attr;
       return id?.version != null && isSnap(id.version);
     };
+    // seeders compared without version — the seeder ids passed in may be versionless while graph nodes
+    // are versioned (same reason findCycles is called with includeDeps=true above).
+    const seederIdsNoVer = new Set(alreadyIsolated.map((comp) => comp.id.toStringWithoutVersion()));
+    const cycleInvolvesSeeder = (cycle: string[]): boolean =>
+      cycle.some((idStr) => {
+        const attr = graph.node(idStr)?.attr;
+        return attr ? seederIdsNoVer.has(attr.toStringWithoutVersion()) : false;
+      });
     const idsToAddStr = new Set<string>();
     const cyclicMemberIds = new Set<string>();
     for (const cycle of cycles) {
+      const involvesSeeder = cycleInvolvesSeeder(cycle);
       // the members this cycle would contribute as new capsules. In onlySnaps mode a published-tag
       // member stays a registry install, so it neither gets pulled in nor groups the cycle.
       const newMembers = cycle.filter((idStr) => !alreadyIsolatedIds.has(idStr));
-      const membersToAdd = onlySnaps ? newMembers.filter(isSnapId) : newMembers;
+      // A member is only worth isolating if the registry can't serve it: it's an unpublished snap, or
+      // it's in a cycle *with a seeder* (whose own package is unpublished, so a registry install of the
+      // member would try to fetch the seeder and fail). A published-tag, dependency-only cycle installs
+      // fine from the registry — pulling it in would needlessly isolate a dependency we don't build here
+      // and force-load its (possibly deprecated/unavailable) env, so leave it out.
+      const membersToAdd = onlySnaps
+        ? newMembers.filter(isSnapId)
+        : newMembers.filter((idStr) => involvesSeeder || isSnapId(idStr));
       if (membersToAdd.length === 0) continue;
       membersToAdd.forEach((idStr) => idsToAddStr.add(idStr));
       // group the whole cycle (the just-added members plus the already-isolated seeders in it) so


### PR DESCRIPTION
## Symptom

`bit build` can abort with `EnvNotFound` for a **dependency's** env — a component that is never built in this run, only pulled in as build context. When such a dependency carries an old/deprecated env that can't be loaded, resolving it fails the whole build, even though the dependency should simply be installed as a package.

## Root cause

Since **#10449** (`isolate cyclic dependencies of seeders to avoid registry fetch`), refined by **#10453** (`isolate & link snap-versioned cyclic deps during aspect isolation`), `getCyclicDependenciesOfSeeders` pulls cyclic deps of seeders into the seeders-only isolation. #10453 added an `onlySnaps` guard but applied it **only to aspect isolation** — the build path runs with `onlySnaps=false` and therefore pulls in **every** member of **every** cycle found in the seeder's dependency closure, including cycles that exist purely among dependencies.

A published-tag, dependency-only cycle resolves fine from the registry and never needed a capsule. Isolating it needlessly pulls in large transitive graphs and force-loads each member's env — which aborts the build when a member has an env that can't be loaded.

**Why it worked before those PRs:** seeders-only isolation contained only the seeders — dependencies installed as packages, so their envs were never resolved.

## Fix

Isolate a cyclic dependency only when the registry can't serve it: it's an unpublished **snap**, or it belongs to a cycle that **includes a seeder** (whose own package is unpublished, so a registry install of the member would try to fetch the seeder and fail). A published-tag, dependency-only cycle installs as a regular package again.

Behavior for the scenarios #10449/#10453 target is unchanged: cycles involving a seeder still pull in all their members, snap-versioned members are still isolated, and the aspect-isolation (`onlySnaps`) path is untouched.

## Test

Added an e2e case (`e2e/harmony/isolate-cyclic-deps.e2e.ts`): when the seeder is outside a dependency-only cycle, `bit capsule create <seeder> --seeders-only` isolates only the seeder, not the cycle members — the inverse of the existing test that verifies a seeder-cycle *is* isolated.
