### PR TITLE
fix(harmony): load core aspects from bit's own install when workspace dist is missing

### DIFF
--- a/scopes/harmony/bit/hook-require.ts
+++ b/scopes/harmony/bit/hook-require.ts
@@ -22,6 +22,22 @@ export function hookRequire() {
         if (!pkgJson.main || pkgJson.main === 'index.js') throw firstErr;
         return this.constructor._load(path.join(id, pkgJson.main), this);
       } catch {
+        // Last resort for Bit's own core-aspect packages (`@teambit/*`). In a workspace where
+        // these are source components (most notably the Bit repo itself), an env loaded from
+        // root node_modules can eagerly `require('@teambit/builder')` during `bit install` —
+        // before the workspace component is compiled — so the resolved copy's `dist` main
+        // doesn't exist yet and the require above hard-crashes. Bit's own installation always
+        // ships a compiled copy of its core aspects, so re-resolve from this module's context
+        // (inside `@teambit/bit`) and load that instead of failing. Only runs on the crash
+        // path, so the happy path (dist present, e.g. every normal user workspace) is untouched.
+        if (id.startsWith('@teambit/')) {
+          try {
+            const fromBitContext = require.resolve(id, { paths: [__dirname] });
+            return this.constructor._load(fromBitContext, this);
+          } catch {
+            throw firstErr;
+          }
+        }
         throw firstErr;
       }
     }


### PR DESCRIPTION
## Problem

With `resolveEnvsFromRoots: true`, an env's constructor eagerly `require`s Bit core aspects (`@teambit/builder`, `@teambit/ui`, `@teambit/pkg`, …) at module load. In a workspace that **authors** those core aspects — the Bit repo itself — they're source components whose `dist` only exists after `bit compile`. But `bit install` reloads envs (`install.main.runtime.ts`, `reloadNonLoadedEnvs`) **before** its own compile step, so the env crashes:

```
Cannot find module '.../node_modules/@teambit/builder/dist/index.js'
```

It's a bootstrap cycle: loading the env needs a compiled builder; compiling builder needs the env.

Not specific to `core-aspect-env` — `node`, `node-babel-mocha`, `node-typescript-mocha` and `base-react-env` all eagerly touch `@teambit/builder` the same way.

## Fix

Add a last-resort fallback in `hook-require.ts`: when a `@teambit/*` package fails to load, re-resolve it from Bit's own installation (which always ships compiled aspects) and load that.

It must be at the require level: Node resolves the env's symlink to its **realpath** in `.pnpm/`, then walks up to the workspace **root** `node_modules/@teambit/builder`. Any fix that links compiled aspects into `.bit_roots/<env>/node_modules/` is never consulted (verified — see below). `hookRequire` overrides `require` globally, so it intercepts wherever the env physically lives.

## A bootstrap crutch, not a substitution

The fallback only fires while the workspace copy has **no `dist`** — the window before compile. Once `bit install`'s compile produces it, normal resolution succeeds and the hook never engages again, so the Bit repo keeps testing its **own** core aspects.

## Test evidence

Reproduced the fresh-checkout state locally (removed builder's `dist`, both flags `true`) and ran `bbit install` (bvm 2.0.13):

| run | result |
|---|---|
| stock bbit (control) | 💥 `Cannot find module .../builder/dist/index.js` — reproduces CI byte-for-byte |
| bbit + resolution-layer fix | 💥 identical crash (that approach is a no-op) |
| **bbit + this hook** | ✅ **installed + compiled 313 components in 205s**, builder `dist` restored by the compile, no capsules created |

## Blast radius

Only reached on the `MODULE_NOT_FOUND` crash path, only for `@teambit/*`, and only when Bit's own install has a resolvable copy (otherwise the original error is rethrown). Normal user workspaces resolve these from the registry with `dist` present, so the fallback never runs.

## Why

Unblocks `resolveEnvsFromRoots: true` in the Bit repo — envs load from node_modules instead of stacking per-version scope-aspects capsules (~10GB/repo) in the global cache. The flag flip is a follow-up, after this ships in a nightly (the crash happens inside the released `bbit` during `setup_harmony`).