### PR TITLE
fix(install): resolve envs' core-aspect phantom deps during bootstrap

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -601,7 +601,7 @@ export class DependencyLinker {
    * against the running bit while the workspace still builds and loads its own core aspects. The
    * links are removed again once the source components have been compiled.
    *
-   * A no-op in a workspace that doesn't author core aspects, i.e. everywhere but the bit repo.
+   * Only reached from a workspace with `linkCoreAspects` off, i.e. one that authors them.
    */
   async linkUncompiledCoreAspectsForEnvs(rootDir: string, componentIds: ComponentID[]): Promise<void> {
     const idsInWorkspace = componentIds.map((id) => id.toString({ ignoreVersion: true }));

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -629,7 +629,7 @@ export class DependencyLinker {
         await this.removeCoreAspectBootstrapLink(linkPath, rootDir);
         continue;
       }
-      const fromDir = this._getCoreAspectSourceDir(aspectId, packageName);
+      const fromDir = this._getCoreAspectSourceDir(aspectId, packageName, rootDir);
       if (fromDir) links[packageName] = `link:${fromDir}`;
     }
     const packagesToLink = Object.keys(links);
@@ -658,26 +658,38 @@ export class DependencyLinker {
   /**
    * the directory to bridge a core aspect from: the running bit installation's copy. bvm is where a
    * released bit runs from; when bit runs from elsewhere (e.g. installed through a package manager),
-   * fall back to the module-resolution strategy aspect-loader uses to locate core aspects. either
-   * way the copy is only usable as a bridge source if its own compiled main exists.
+   * fall back to the module-resolution strategy aspect-loader uses to locate core aspects.
+   *
+   * a copy is only usable as a bridge source if its own compiled main exists AND it lives outside
+   * the workspace. the second condition is what lets removeCoreAspectBootstrapLink identify this
+   * method's links: a workspace-internal source (e.g. a published bit installed as a workspace
+   * dependency) would produce a link the cleanup can never tell apart from pnpm's own hoisted
+   * entries, shadowing the workspace's compiled sources forever.
    */
-  private _getCoreAspectSourceDir(aspectId: string, packageName: string): string | undefined {
+  private _getCoreAspectSourceDir(aspectId: string, packageName: string, workspaceDir: string): string | undefined {
+    const isUsableSource = (dir: string) => this.hasCompiledMain(dir) && !this._realpathIsInside(dir, workspaceDir);
     const fromBvmDir = this._getPkgPathFromCurrentBitDir(packageName);
-    if (fromBvmDir && this.hasCompiledMain(fromBvmDir)) return fromBvmDir;
+    if (fromBvmDir && isUsableSource(fromBvmDir)) return fromBvmDir;
     try {
       const fromRunningBit = getAspectDir(aspectId);
-      if (this.hasCompiledMain(fromRunningBit)) return fromRunningBit;
+      if (isUsableSource(fromRunningBit)) return fromRunningBit;
     } catch {
       // not resolvable from the running installation either
     }
     return undefined;
   }
 
+  /** both paths must exist. compares real paths, as either side may be reached through a symlink. */
+  private _realpathIsInside(target: string, dir: string): boolean {
+    return fs.realpathSync(target).startsWith(fs.realpathSync(dir) + path.sep);
+  }
+
   /**
-   * only removes links created by syncCoreAspectLinksForEnvs. at this location+name nothing else
-   * creates links that resolve outside the workspace - pnpm's own hoisted entries always point back
-   * into the virtual store. matching the exact bit installation instead would be too strict: a link
-   * leaked by an interrupted install may point at a bit version that was since upgraded or removed
+   * only removes links created by syncCoreAspectLinksForEnvs, identified by resolving OUTSIDE the
+   * workspace - an invariant _getCoreAspectSourceDir enforces on every link source, and one nothing
+   * else at this location+name violates: pnpm's own hoisted entries always point back into the
+   * virtual store. matching the exact bit installation instead would be too strict: a link leaked
+   * by an interrupted install may point at a bit version that was since upgraded or removed
    * (dangling), and it must still be cleaned up or it would shadow the workspace's copy forever.
    */
   private async removeCoreAspectBootstrapLink(linkPath: string, workspaceDir: string): Promise<void> {
@@ -687,7 +699,7 @@ export class DependencyLinker {
       return; // nothing at this path
     }
     try {
-      if (fs.realpathSync(linkPath).startsWith(fs.realpathSync(workspaceDir) + path.sep)) return;
+      if (this._realpathIsInside(linkPath, workspaceDir)) return;
     } catch {
       // dangling link - fall through and remove it
     }

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -9,6 +9,7 @@ import type { ComponentMap, Component, ComponentID, ComponentMain } from '@teamb
 import type { Logger } from '@teambit/logger';
 import type { PathAbsolute } from '@teambit/toolbox.path.path';
 import { componentIdToPackageName } from '@teambit/pkg.modules.component-package-name';
+import { createLinks } from '@teambit/dependencies.fs.linked-dependencies';
 import { BitError } from '@teambit/bit-error';
 import type { EnvsMain } from '@teambit/envs';
 import type { AspectLoaderMain } from '@teambit/aspect-loader';
@@ -580,6 +581,81 @@ export class DependencyLinker {
 
     const results = filtered.map((id) => this.linkCoreAspect(id, opts));
     return compact(results);
+  }
+
+  /**
+   * The core aspects are phantom dependencies of the published envs - an env requires
+   * `@teambit/builder` (and `@teambit/ui`, `@teambit/pkg`...) without declaring it, and relies on the
+   * running bit installation to provide it. `linkCoreAspectsAndLegacy` is what normally satisfies
+   * that, by linking bit's own copies into the workspace's root node_modules.
+   *
+   * A workspace that authors the core aspects has them as source components instead, so they're
+   * excluded from that linking - such a workspace must build and load its own. That leaves the envs'
+   * phantom require resolving to a source component, which has no `main` until it's been compiled,
+   * so an env resolved from the root (see `resolveEnvsFromRoots`) fails to load during install -
+   * before the compile step that would have made it resolvable.
+   *
+   * Bridge that gap by linking bit's own (always compiled) copies into pnpm's hoisted store. That
+   * directory is on the module resolution path of packages inside the virtual store - the published
+   * envs - and not on the resolution path of the workspace's own components, so the envs bootstrap
+   * against the running bit while the workspace still builds and loads its own core aspects. The
+   * links are removed again once the source components have been compiled.
+   *
+   * A no-op in a workspace that doesn't author core aspects, i.e. everywhere but the bit repo.
+   */
+  async linkUncompiledCoreAspectsForEnvs(rootDir: string, componentIds: ComponentID[]): Promise<void> {
+    const idsInWorkspace = componentIds.map((id) => id.toString({ ignoreVersion: true }));
+    const authoredCoreAspects = this.aspectLoader.getCoreAspectIds().filter((aspectId) => {
+      if (aspectId === this.aspectLoader.mainAspect?.id) return false;
+      // the same naive comparison done by linkNonExistingCoreAspects, whose filter this inverts
+      const name = getCoreAspectName(aspectId);
+      return idsInWorkspace.some((id) => id === name || id === aspectId);
+    });
+    if (!authoredCoreAspects.length) return;
+
+    const hoistedStoreDir = path.join(rootDir, 'node_modules', '.pnpm');
+    const links: Record<string, string> = {};
+    await Promise.all(
+      authoredCoreAspects.map(async (aspectId) => {
+        const packageName = getCoreAspectPackageName(aspectId);
+        const fromDir = this._getPkgPathFromCurrentBitDir(packageName);
+        if (this.hasCompiledMain(path.join(rootDir, 'node_modules', packageName))) {
+          await this.removeUncompiledCoreAspectLink(path.join(hoistedStoreDir, 'node_modules', packageName), fromDir);
+          return;
+        }
+        if (fromDir) links[packageName] = `link:${fromDir}`;
+      })
+    );
+    if (!Object.keys(links).length) return;
+    this.logger.debug(
+      `linkUncompiledCoreAspectsForEnvs: linking ${Object.keys(links).join(', ')} from ${this._currentBitDir}`
+    );
+    await createLinks(hoistedStoreDir, links, { skipIfSymlinkValid: true });
+  }
+
+  private hasCompiledMain(pkgDir: string): boolean {
+    try {
+      const { main } = fs.readJsonSync(path.join(pkgDir, 'package.json'));
+      return fs.pathExistsSync(path.join(pkgDir, main ?? 'index.js'));
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * only removes links created by linkUncompiledCoreAspectsForEnvs, identified by resolving to the
+   * very package it would have linked. anything else in the hoisted store is pnpm's, and is left
+   * alone. compares real paths because the bit installation is itself reached through a symlink.
+   */
+  private async removeUncompiledCoreAspectLink(target: string, fromDir?: string): Promise<void> {
+    if (!fromDir) return;
+    try {
+      if (!fs.lstatSync(target).isSymbolicLink()) return;
+      if (fs.realpathSync(target) !== fs.realpathSync(fromDir)) return;
+    } catch {
+      return;
+    }
+    await fs.remove(target);
   }
 
   private isBitRepoWorkspace(dir: string) {

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -598,12 +598,15 @@ export class DependencyLinker {
    * Bridge that gap by linking bit's own (always compiled) copies into pnpm's hoisted store. That
    * directory is on the module resolution path of packages inside the virtual store - the published
    * envs - and not on the resolution path of the workspace's own components, so the envs bootstrap
-   * against the running bit while the workspace still builds and loads its own core aspects. The
-   * links are removed again once the source components have been compiled.
+   * against the running bit while the workspace still builds and loads its own core aspects.
+   *
+   * This is a reconciler - each core aspect converges to "link present iff its source is still
+   * uncompiled", so the same call both creates the links during bootstrap and removes them once the
+   * source components have been compiled.
    *
    * Only reached from a workspace with `linkCoreAspects` off, i.e. one that authors them.
    */
-  async linkUncompiledCoreAspectsForEnvs(rootDir: string, componentIds: ComponentID[]): Promise<void> {
+  async syncCoreAspectLinksForEnvs(rootDir: string, componentIds: ComponentID[]): Promise<void> {
     const idsInWorkspace = componentIds.map((id) => id.toString({ ignoreVersion: true }));
     const authoredCoreAspects = this.aspectLoader.getCoreAspectIds().filter((aspectId) => {
       if (aspectId === this.aspectLoader.mainAspect?.id) return false;
@@ -614,48 +617,63 @@ export class DependencyLinker {
     if (!authoredCoreAspects.length) return;
 
     const hoistedStoreDir = path.join(rootDir, 'node_modules', '.pnpm');
+    // the hoisted store only exists in a pnpm-managed workspace. anywhere else this directory is on
+    // no resolution path, so there is nothing to bridge - and it must not be fabricated here.
+    if (!fs.pathExistsSync(hoistedStoreDir)) return;
+
     const links: Record<string, string> = {};
-    await Promise.all(
-      authoredCoreAspects.map(async (aspectId) => {
-        const packageName = getCoreAspectPackageName(aspectId);
-        const fromDir = this._getPkgPathFromCurrentBitDir(packageName);
-        if (this.hasCompiledMain(path.join(rootDir, 'node_modules', packageName))) {
-          await this.removeUncompiledCoreAspectLink(path.join(hoistedStoreDir, 'node_modules', packageName), fromDir);
-          return;
-        }
-        if (fromDir) links[packageName] = `link:${fromDir}`;
-      })
-    );
-    if (!Object.keys(links).length) return;
-    this.logger.debug(
-      `linkUncompiledCoreAspectsForEnvs: linking ${Object.keys(links).join(', ')} from ${this._currentBitDir}`
-    );
-    await createLinks(hoistedStoreDir, links, { skipIfSymlinkValid: true });
+    for (const aspectId of authoredCoreAspects) {
+      const packageName = getCoreAspectPackageName(aspectId);
+      const linkPath = path.join(hoistedStoreDir, 'node_modules', packageName);
+      if (this.hasCompiledMain(path.join(rootDir, 'node_modules', packageName))) {
+        await this.removeCoreAspectBootstrapLink(linkPath, rootDir);
+        continue;
+      }
+      const fromDir = this._getPkgPathFromCurrentBitDir(packageName);
+      if (fromDir && fs.pathExistsSync(fromDir)) links[packageName] = `link:${fromDir}`;
+    }
+    const packagesToLink = Object.keys(links);
+    if (!packagesToLink.length) return;
+    this.logger.debug(`syncCoreAspectLinksForEnvs: linking ${packagesToLink.join(', ')} from ${this._currentBitDir}`);
+    try {
+      await createLinks(hoistedStoreDir, links, { skipIfSymlinkValid: true });
+    } catch (err: any) {
+      // the bridge is best-effort. without it the envs may fail to load during install, which the
+      // install flow already tolerates - a broken bridge must not turn that into a fatal error.
+      this.logger.warn(
+        `syncCoreAspectLinksForEnvs: failed linking core aspects into the hoisted store. ${err.message}`
+      );
+    }
   }
 
   private hasCompiledMain(pkgDir: string): boolean {
     try {
       const { main } = fs.readJsonSync(path.join(pkgDir, 'package.json'));
-      return fs.pathExistsSync(path.join(pkgDir, main ?? 'index.js'));
+      return fs.pathExistsSync(path.join(pkgDir, main || 'index.js'));
     } catch {
       return false;
     }
   }
 
   /**
-   * only removes links created by linkUncompiledCoreAspectsForEnvs, identified by resolving to the
-   * very package it would have linked. anything else in the hoisted store is pnpm's, and is left
-   * alone. compares real paths because the bit installation is itself reached through a symlink.
+   * only removes links created by syncCoreAspectLinksForEnvs. at this location+name nothing else
+   * creates links that resolve outside the workspace - pnpm's own hoisted entries always point back
+   * into the virtual store. matching the exact bit installation instead would be too strict: a link
+   * leaked by an interrupted install may point at a bit version that was since upgraded or removed
+   * (dangling), and it must still be cleaned up or it would shadow the workspace's copy forever.
    */
-  private async removeUncompiledCoreAspectLink(target: string, fromDir?: string): Promise<void> {
-    if (!fromDir) return;
+  private async removeCoreAspectBootstrapLink(linkPath: string, workspaceDir: string): Promise<void> {
     try {
-      if (!fs.lstatSync(target).isSymbolicLink()) return;
-      if (fs.realpathSync(target) !== fs.realpathSync(fromDir)) return;
+      if (!fs.lstatSync(linkPath).isSymbolicLink()) return;
     } catch {
-      return;
+      return; // nothing at this path
     }
-    await fs.remove(target);
+    try {
+      if (fs.realpathSync(linkPath).startsWith(fs.realpathSync(workspaceDir) + path.sep)) return;
+    } catch {
+      // dangling link - fall through and remove it
+    }
+    await fs.remove(linkPath);
   }
 
   private isBitRepoWorkspace(dir: string) {

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -629,12 +629,12 @@ export class DependencyLinker {
         await this.removeCoreAspectBootstrapLink(linkPath, rootDir);
         continue;
       }
-      const fromDir = this._getPkgPathFromCurrentBitDir(packageName);
-      if (fromDir && fs.pathExistsSync(fromDir)) links[packageName] = `link:${fromDir}`;
+      const fromDir = this._getCoreAspectSourceDir(aspectId, packageName);
+      if (fromDir) links[packageName] = `link:${fromDir}`;
     }
     const packagesToLink = Object.keys(links);
     if (!packagesToLink.length) return;
-    this.logger.debug(`syncCoreAspectLinksForEnvs: linking ${packagesToLink.join(', ')} from ${this._currentBitDir}`);
+    this.logger.debug(`syncCoreAspectLinksForEnvs: linking ${packagesToLink.join(', ')}`);
     try {
       await createLinks(hoistedStoreDir, links, { skipIfSymlinkValid: true });
     } catch (err: any) {
@@ -653,6 +653,24 @@ export class DependencyLinker {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * the directory to bridge a core aspect from: the running bit installation's copy. bvm is where a
+   * released bit runs from; when bit runs from elsewhere (e.g. installed through a package manager),
+   * fall back to the module-resolution strategy aspect-loader uses to locate core aspects. either
+   * way the copy is only usable as a bridge source if its own compiled main exists.
+   */
+  private _getCoreAspectSourceDir(aspectId: string, packageName: string): string | undefined {
+    const fromBvmDir = this._getPkgPathFromCurrentBitDir(packageName);
+    if (fromBvmDir && this.hasCompiledMain(fromBvmDir)) return fromBvmDir;
+    try {
+      const fromRunningBit = getAspectDir(aspectId);
+      if (this.hasCompiledMain(fromRunningBit)) return fromRunningBit;
+    } catch {
+      // not resolvable from the running installation either
+    }
+    return undefined;
   }
 
   /**

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -457,7 +457,7 @@ export class InstallMain {
       this.workspace.inInstallAfterPmContext = true;
       let cacheCleared = false;
       await this.linkCodemods(compDirMap);
-      await this.linkUncompiledCoreAspectsForEnvs(compDirMap);
+      await this.syncCoreAspectLinksForEnvs(compDirMap);
       const oldNonLoadedEnvs = this.setOldNonLoadedEnvs();
       await this.reloadMovedEnvs();
       await this.reloadNonLoadedEnvs();
@@ -505,7 +505,7 @@ export class InstallMain {
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
     // the core aspects are compiled by now, so drop the links added above and let the envs resolve
     // them from the workspace again.
-    await this.linkUncompiledCoreAspectsForEnvs(compDirMap);
+    await this.syncCoreAspectLinksForEnvs(compDirMap);
     if (!options?.lockfileOnly && !options?.skipPrune) {
       // We clean node_modules only after the last install.
       // Otherwise, we might load an env from a location that we later remove.
@@ -1314,17 +1314,17 @@ export class InstallMain {
   }
 
   /**
-   * see DependencyLinker.linkUncompiledCoreAspectsForEnvs.
+   * see DependencyLinker.syncCoreAspectLinksForEnvs.
    *
    * `linkCoreAspects` is only turned off by a workspace that authors the core aspects, since it must
    * use the ones it builds rather than the running bit's. That opt-out is also exactly what leaves
    * the envs' phantom require unsatisfied until those sources are compiled, so there is nothing to
    * bridge in any other workspace - where this returns on the config read alone.
    */
-  private async linkUncompiledCoreAspectsForEnvs(compDirMap: ComponentMap<string>) {
+  private async syncCoreAspectLinksForEnvs(compDirMap: ComponentMap<string>) {
     if (this.dependencyResolver.linkCoreAspects()) return;
     const linker = this.dependencyResolver.getLinker({ rootDir: this.workspace.path });
-    await linker.linkUncompiledCoreAspectsForEnvs(
+    await linker.syncCoreAspectLinksForEnvs(
       this.workspace.path,
       compDirMap.toArray().map(([component]) => component.id)
     );

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -1314,10 +1314,15 @@ export class InstallMain {
   }
 
   /**
-   * see DependencyLinker.linkUncompiledCoreAspectsForEnvs. relevant only to a workspace that authors
-   * bit's core aspects, a no-op in any other.
+   * see DependencyLinker.linkUncompiledCoreAspectsForEnvs.
+   *
+   * `linkCoreAspects` is only turned off by a workspace that authors the core aspects, since it must
+   * use the ones it builds rather than the running bit's. That opt-out is also exactly what leaves
+   * the envs' phantom require unsatisfied until those sources are compiled, so there is nothing to
+   * bridge in any other workspace - where this returns on the config read alone.
    */
   private async linkUncompiledCoreAspectsForEnvs(compDirMap: ComponentMap<string>) {
+    if (this.dependencyResolver.linkCoreAspects()) return;
     const linker = this.dependencyResolver.getLinker({ rootDir: this.workspace.path });
     await linker.linkUncompiledCoreAspectsForEnvs(
       this.workspace.path,

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -457,6 +457,7 @@ export class InstallMain {
       this.workspace.inInstallAfterPmContext = true;
       let cacheCleared = false;
       await this.linkCodemods(compDirMap);
+      await this.linkUncompiledCoreAspectsForEnvs(compDirMap);
       const oldNonLoadedEnvs = this.setOldNonLoadedEnvs();
       await this.reloadMovedEnvs();
       await this.reloadNonLoadedEnvs();
@@ -502,6 +503,9 @@ export class InstallMain {
       current = await this._getComponentsManifests(installer, mergedRootPolicy, calcManifestsOpts);
       installCycle += 1;
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
+    // the core aspects are compiled by now, so drop the links added above and let the envs resolve
+    // them from the workspace again.
+    await this.linkUncompiledCoreAspectsForEnvs(compDirMap);
     if (!options?.lockfileOnly && !options?.skipPrune) {
       // We clean node_modules only after the last install.
       // Otherwise, we might load an env from a location that we later remove.
@@ -1307,6 +1311,18 @@ export class InstallMain {
       await this._linkAllComponentsToBitRoots(compDirMap);
     }
     return { linkResults: res, linkedRootDeps };
+  }
+
+  /**
+   * see DependencyLinker.linkUncompiledCoreAspectsForEnvs. relevant only to a workspace that authors
+   * bit's core aspects, a no-op in any other.
+   */
+  private async linkUncompiledCoreAspectsForEnvs(compDirMap: ComponentMap<string>) {
+    const linker = this.dependencyResolver.getLinker({ rootDir: this.workspace.path });
+    await linker.linkUncompiledCoreAspectsForEnvs(
+      this.workspace.path,
+      compDirMap.toArray().map(([component]) => component.id)
+    );
   }
 
   async linkCodemods(compDirMap: ComponentMap<string>, options?: { rewire?: boolean }) {


### PR DESCRIPTION
Prerequisite for turning on `resolveEnvsFromRoots` in this repo (#10478), which is what stops the scope-aspects capsules from being created.

### The problem

Published envs `require('@teambit/builder')` (also `pkg`, `preview`, `typescript`, `ui`, `workspace-config-files`) **without declaring them** — phantom deps, satisfied by whatever the bit installation puts in the root `node_modules`. `linkCoreAspectsAndLegacy` is what normally does that.

A workspace that *authors* the core aspects has them as source components, so they're deliberately excluded from that linking — it must use its own. But then the phantom require resolves to a source component with no `main` until it's compiled, and the env fails to load during `bit install` — before the compile that would have fixed it.

Node resolves the env through its realpath in the virtual store, so its search path is:

```
1. .pnpm/<env>/node_modules/@teambit/builder    not declared -> miss
2. .pnpm/node_modules/@teambit/builder          pnpm's hoisted store -> miss
3. <ws>/node_modules/@teambit/builder           HIT -> uncompiled -> crash
```

### The fix

Fill slot 2 during install with the running bit's own (always compiled) copies, and remove them once the sources are compiled.

That directory is on the resolution path of packages **inside** the virtual store — the published envs — and **not** on the resolution path of the workspace's own components, which resolve from `<ws>/node_modules` directly. So the envs bootstrap against the installed bit while the workspace keeps building and loading its own core aspects. Nothing is substituted: after install, the envs resolve every core aspect back to the workspace.

No repo detection or name list. Any workspace with `linkCoreAspects` on — the default; only a workspace that authors the core aspects turns it off — returns on that single config read. Past the gate, the set to bridge is derived: core aspects this workspace owns as source *and* hasn't compiled.

### Verified

Reproduced the bootstrap crash locally (both flags on, the 6 core aspects' `dist` removed, `bit install` from a released bit patched with this change):

| | result |
|---|---|
| unpatched | `Cannot find module '<ws>/node_modules/@teambit/builder/dist/index.js'`, exit 1 |
| patched | installed + compiled 313 components, exit 0 |

Of 109 core aspects the workspace authors, it linked exactly the 6 uncompiled ones, then removed all 6 after the compile. End state: every core aspect resolves from the workspace, no leftover links, no capsules created.
