### PR TITLE
fix(lanes): switch to main should fetch the latest from the original scope

### DIFF
--- a/e2e/harmony/lanes/switch-lanes.e2e.ts
+++ b/e2e/harmony/lanes/switch-lanes.e2e.ts
@@ -346,6 +346,37 @@ describe('bit lane command', function () {
       expect(bitmap.comp1.version).to.equal('0.0.1');
     });
   });
+  // the lane lives on a different scope than the component. as a result, the lane snaps are exported
+  // to the lane's scope only, and the component's original scope never gets them. when switching to
+  // main, the ids must be fetched by "latest" from the original scope. otherwise, the original scope
+  // is asked for a snap-hash it doesn't have, it drops it from the response silently, the local head
+  // on main is left stale, and the switch checks out an old version of main.
+  describe('switch to main when main has updates on the remote and the lane is on another scope', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      const laneScope = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('dev', `--scope ${laneScope}`);
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      const beforeUpdatingMain = helper.scopeHelper.cloneWorkspace();
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.scopeHelper.getClonedWorkspace(beforeUpdatingMain);
+    });
+    it('should fetch and switch to the head of main', () => {
+      helper.command.switchLocalLane('main', '-x');
+      const bitmap = helper.bitMap.read();
+      expect(bitmap.comp1.version).to.equal('0.0.2');
+    });
+  });
   describe('switch to a lane when it has updates on the remote', () => {
     let beforeSwitch: string;
     let firstSnap: string;

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -73,7 +73,12 @@ export class LaneSwitcher {
     const localLane = await this.consumer.scope.loadLane(laneId);
     const getMainIds = async () => {
       if (!skipFetch) {
-        const allIds = this.workspace.listIds();
+        // fetch by "latest" and without a lane, so the remote resolves each id against the head on
+        // main of its original scope. passing the ids as-is would send the versions from .bitmap,
+        // which on a lane are snap hashes that live on the lane's scope, not on the component's
+        // original scope. the original scope can't resolve them, drops them from the response
+        // silently, and the local head on main is left stale.
+        const allIds = this.workspace.listIds().toVersionLatest();
         try {
           await this.workspace.scope.legacyScope.scopeImporter.importWithoutDeps(allIds, {
             cache: false,


### PR DESCRIPTION
`bit switch main` was sending each id with the version from `.bitmap`, which on a lane is a snap hash. Those snaps live on the lane's scope, not on the component's original scope, so when the fetch is grouped by original scope (no lane passed), the original scope can't resolve the hash. It drops the component from the response silently — no error, no warning — and the local head on main is left stale. `getIdsOfDefaultLane()` then hands checkout an old version, so the component is either skipped as "already at version X" or checked out to an outdated version of main.

Fix: fetch by `latest` (and still without a lane), so the remote resolves each id against the head on main of its original scope. This matches what every other `importWithoutDeps` caller that wants the latest already does. It also revives `ignoreMissingHead`, which was a no-op here since its guard requires the id to have no version.

Only reproduces when the lane's scope differs from the component's scope — with a same-scope lane the original scope has the snap and the head refreshes fine. Added an e2e test for the cross-scope case; it fails without the fix (checks out 0.0.1 instead of 0.0.2).