### PR TITLE
fix(preview): resolve componentMap fullName collisions across scopes

### DIFF
--- a/scopes/preview/preview/generate-link.spec.ts
+++ b/scopes/preview/preview/generate-link.spec.ts
@@ -1,3 +1,6 @@
+import os from 'os';
+import { join } from 'path';
+import fs from 'fs-extra';
 import { expect } from 'chai';
 import { generateLink } from './generate-link';
 
@@ -19,9 +22,23 @@ function mockComponentMap(ids: { scope: string; fullName: string }[]) {
 }
 
 describe('generateLink', () => {
+  // generateLink writes a preview-modules-<hash>.mjs side file; without an
+  // explicit tempPackageDir it lands in previewDistDir, which can fall back to
+  // this component's own directory — keep test output in a throwaway temp dir.
+  let tmpDir: string;
+  before(() => {
+    tmpDir = fs.mkdtempSync(join(os.tmpdir(), 'bit-generate-link-'));
+  });
+  after(() => {
+    fs.removeSync(tmpDir);
+  });
+
+  const genLink = (ids: { scope: string; fullName: string }[]) =>
+    generateLink('overview', mockComponentMap(ids), undefined, false, tmpDir);
+
   describe('componentMap entries', () => {
     it('emits a plain entry for a fullName that appears once', () => {
-      const contents = generateLink('overview', mockComponentMap([{ scope: 'org.scope', fullName: 'ui/button' }]));
+      const contents = genLink([{ scope: 'org.scope', fullName: 'ui/button' }]);
       expect(contents).to.include('"ui/button": [file_0_0]');
     });
 
@@ -31,14 +48,11 @@ describe('generateLink', () => {
     // non-active components resolve to a null-rendering Placeholder, every other
     // same-named component's preview rendered blank without any error.
     it('emits a single runtime-conditional entry when the same fullName exists in several scopes', () => {
-      const contents = generateLink(
-        'overview',
-        mockComponentMap([
-          { scope: 'org.scope-a', fullName: 'readme' },
-          { scope: 'org.scope-b', fullName: 'readme' },
-          { scope: 'org.scope-c', fullName: 'readme' },
-        ])
-      );
+      const contents = genLink([
+        { scope: 'org.scope-a', fullName: 'readme' },
+        { scope: 'org.scope-b', fullName: 'readme' },
+        { scope: 'org.scope-c', fullName: 'readme' },
+      ]);
       const entries = contents.match(/"readme":/g);
       expect(entries).to.have.lengthOf(1);
       expect(contents).to.include(
@@ -49,14 +63,11 @@ describe('generateLink', () => {
     });
 
     it('keeps plain entries for non-colliding names alongside a colliding group', () => {
-      const contents = generateLink(
-        'overview',
-        mockComponentMap([
-          { scope: 'org.scope-a', fullName: 'ui/card' },
-          { scope: 'org.scope-a', fullName: 'readme' },
-          { scope: 'org.scope-b', fullName: 'readme' },
-        ])
-      );
+      const contents = genLink([
+        { scope: 'org.scope-a', fullName: 'ui/card' },
+        { scope: 'org.scope-a', fullName: 'readme' },
+        { scope: 'org.scope-b', fullName: 'readme' },
+      ]);
       expect(contents).to.include('"ui/card": [file_0_0]');
       expect(contents).to.include(
         '"readme": __bitShouldSurfaceFor("org.scope-a/readme") ? [file_1_0] : ' +

--- a/scopes/preview/preview/generate-link.spec.ts
+++ b/scopes/preview/preview/generate-link.spec.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { generateLink } from './generate-link';
+
+function mockComponentMap(ids: { scope: string; fullName: string }[]) {
+  return {
+    toArray: () =>
+      ids.map(({ scope, fullName }) => [
+        {
+          id: {
+            toStringWithoutVersion: () => `${scope}/${fullName}`,
+            version: '0.0.1',
+            scope,
+            fullName,
+          },
+        },
+        [`/fake/${scope}/${fullName.replace(/\//g, '-')}.docs.mdx`],
+      ]),
+  } as any;
+}
+
+describe('generateLink', () => {
+  describe('componentMap entries', () => {
+    it('emits a plain entry for a fullName that appears once', () => {
+      const contents = generateLink('overview', mockComponentMap([{ scope: 'org.scope', fullName: 'ui/button' }]));
+      expect(contents).to.include('"ui/button": [file_0_0]');
+    });
+
+    // the componentMap is keyed by fullName, which carries no scope. components
+    // from different scopes sharing a fullName (served by one deduped dev server)
+    // used to emit duplicate object keys — the last entry silently won, and since
+    // non-active components resolve to a null-rendering Placeholder, every other
+    // same-named component's preview rendered blank without any error.
+    it('emits a single runtime-conditional entry when the same fullName exists in several scopes', () => {
+      const contents = generateLink(
+        'overview',
+        mockComponentMap([
+          { scope: 'org.scope-a', fullName: 'readme' },
+          { scope: 'org.scope-b', fullName: 'readme' },
+          { scope: 'org.scope-c', fullName: 'readme' },
+        ])
+      );
+      const entries = contents.match(/"readme":/g);
+      expect(entries).to.have.lengthOf(1);
+      expect(contents).to.include(
+        '"readme": __bitShouldSurfaceFor("org.scope-a/readme") ? [file_0_0] : ' +
+          '__bitShouldSurfaceFor("org.scope-b/readme") ? [file_1_0] : ' +
+          '__bitShouldSurfaceFor("org.scope-c/readme") ? [file_2_0] : [file_2_0]'
+      );
+    });
+
+    it('keeps plain entries for non-colliding names alongside a colliding group', () => {
+      const contents = generateLink(
+        'overview',
+        mockComponentMap([
+          { scope: 'org.scope-a', fullName: 'ui/card' },
+          { scope: 'org.scope-a', fullName: 'readme' },
+          { scope: 'org.scope-b', fullName: 'readme' },
+        ])
+      );
+      expect(contents).to.include('"ui/card": [file_0_0]');
+      expect(contents).to.include(
+        '"readme": __bitShouldSurfaceFor("org.scope-a/readme") ? [file_1_0] : ' +
+          '__bitShouldSurfaceFor("org.scope-b/readme") ? [file_2_0] : [file_2_0]'
+      );
+    });
+  });
+});

--- a/scopes/preview/preview/generate-link.ts
+++ b/scopes/preview/preview/generate-link.ts
@@ -197,9 +197,7 @@ linkModules('${prefix}', {
   },
   isSplitComponentBundle: ${isSplitComponentBundle},
   componentMap: {
-${componentLinks
-  .map((cl) => `    "${cl.componentIdentifier}": [${cl.modules.map((m) => m.varName).join(', ')}]`)
-  .join(',\n')}
+${generateComponentMapEntries(componentLinks)}
   }
 });
 }
@@ -210,6 +208,37 @@ ${runtimeBootstrap}
 
 function moduleVarName(componentIdx: number, fileIdx: number) {
   return `file_${componentIdx}_${fileIdx}`;
+}
+
+/**
+ * The componentMap is keyed by the component fullName, which carries no scope.
+ * Components from different scopes sharing a fullName (e.g. several scopes each
+ * exposing a "readme" component, all served by one deduped dev server) would
+ * emit duplicate object keys — the last entry silently wins, and since
+ * non-active components resolve to a null-rendering Placeholder (see
+ * getComponentImports), every other same-named component's preview renders
+ * blank with no error. For colliding names, select the active component's
+ * modules at runtime via __bitShouldSurfaceFor, falling back to the last entry
+ * (which preserves the previous behavior when no component id is active, e.g.
+ * in isolated builds).
+ */
+function generateComponentMapEntries(componentLinks: ComponentLink[] = []): string {
+  const byIdentifier = new Map<string, ComponentLink[]>();
+  componentLinks.forEach((cl) => {
+    const links = byIdentifier.get(cl.componentIdentifier) || [];
+    links.push(cl);
+    byIdentifier.set(cl.componentIdentifier, links);
+  });
+  const moduleArr = (cl: ComponentLink) => `[${cl.modules.map((m) => m.varName).join(', ')}]`;
+  return Array.from(byIdentifier.entries())
+    .map(([identifier, links]) => {
+      if (links.length === 1) return `    "${identifier}": ${moduleArr(links[0])}`;
+      const conditionals = links
+        .map((cl) => `__bitShouldSurfaceFor("${cl.componentIdString}") ? ${moduleArr(cl)} : `)
+        .join('');
+      return `    "${identifier}": ${conditionals}${moduleArr(links[links.length - 1])}`;
+    })
+    .join(',\n');
 }
 
 function getEnvVarName(envId: string) {


### PR DESCRIPTION
## Problem

The generated preview link file keys its `componentMap` by `component.id.fullName`, which carries **no scope**. When components from different scopes share a fullName and are served by one (deduped) dev server — e.g. several scopes each exposing a `readme` component — the generated file emits duplicate object keys:

```js
componentMap: {
  "readme": [file_33_0],
  "readme": [file_34_0],
  "readme": [file_35_0],
  "readme": [file_36_0],   // last one silently wins
}
```

Since each `file_N_0` import is gated by the `__bitShouldSurfaceFor("<scope>/<name>")` lazy guard and non-active components resolve to a null-rendering `Placeholder`, every same-named component except the last renders a **blank overview and blank compositions with zero console errors**. The last one appears to work by accident.

Repro: a workspace containing `bitdev.harmony/readme`, `bitdev.node/readme`, `bitdev.react/readme`, `bitdev.symphony/readme` — only the symphony readme (last in the map) rendered; the other three showed an empty docs block and empty compositions.

## Fix

Generator-only, no consumer/runtime changes. For colliding fullNames, emit a single entry that selects the active component's modules at runtime, falling back to the last entry (preserving today's behavior when no component id is active, e.g. isolated builds):

```js
"readme": __bitShouldSurfaceFor("bitdev.harmony/readme") ? [file_33_0]
        : __bitShouldSurfaceFor("bitdev.node/readme")    ? [file_34_0]
        : __bitShouldSurfaceFor("bitdev.react/readme")   ? [file_35_0]
        : __bitShouldSurfaceFor("bitdev.symphony/readme")? [file_36_0] : [file_36_0]
```

Non-colliding entries are emitted exactly as before.

## Verification

- New unit tests in `generate-link.spec.ts` covering the single-entry, colliding, and mixed cases (`bit test teambit.preview/preview`: 14/14 passing).
- Verified end-to-end in the multi-scope repro workspace (`bit start` with this build): all four readme components render their own scope's overview and compositions; previously three of them rendered blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
