### PR TITLE
fix: correct typos and grammar in user-facing text

### DIFF
--- a/components/legacy/bit-map/bit-map.ts
+++ b/components/legacy/bit-map/bit-map.ts
@@ -112,7 +112,7 @@ export class BitMap {
         throw new BitError(
           `unable to add "${id.toString()}", its rootDir ${rootDir} is inside ${
             existingComponentMap.rootDir
-          } which used by another component "${existingComponentMap.id.toString()}"`
+          } which is used by another component "${existingComponentMap.id.toString()}"`
         );
       }
       if (isParentDir(rootDir, existingComponentMap.rootDir)) {

--- a/components/legacy/scope/lanes/unmerged-components.ts
+++ b/components/legacy/scope/lanes/unmerged-components.ts
@@ -104,7 +104,7 @@ export class UnmergedComponents {
     );
     if (existingComponent) {
       throw new Error(
-        `unable to add an unmerged component, a component with the same name already exist. name ${existingComponent.id.name}, scope: ${existingComponent.id.scope}`
+        `unable to add an unmerged component, a component with the same name already exists. name ${existingComponent.id.name}, scope: ${existingComponent.id.scope}`
       );
     }
     this.unmerged.push(unmergedComponent);

--- a/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
+++ b/contrib/claude-skill-bit-cli/CLI_REFERENCE.md
@@ -350,7 +350,7 @@ Assigns one or more components a development environment (env)
 
 un-sets an env from components that were previously set by "bit env set" or by a component template
 
-keep in mind that this doesn't remove envs that are set via variants. in only removes envs that appear in the .bitmap file, which were previously configured via "bit env set". the purpose of this command is to reset previously assigned envs to either allow variants configure the env or use the base node env. you can use a `<pattern>` for multiple component ids, such as `bit env unset "org.scope/utils/**"`. use comma to separate patterns and '!' to exclude. e.g. 'ui/\*\*, !ui/button' use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. always wrap the pattern with single quotes to avoid collision with shell commands. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.
+keep in mind that this doesn't remove envs that are set via variants. it only removes envs that appear in the .bitmap file, which were previously configured via "bit env set". the purpose of this command is to reset previously assigned envs to either allow variants to configure the env or use the base node env. you can use a `<pattern>` for multiple component ids, such as `bit env unset "org.scope/utils/**"`. use comma to separate patterns and '!' to exclude. e.g. 'ui/\*\*, !ui/button' use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. always wrap the pattern with single quotes to avoid collision with shell commands. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.
 
 ## bit envs replace <current-env> <new-env>
 
@@ -547,14 +547,14 @@ Flags: --skip-dependency-installation
 
 revert to a previous history of the current lane. see also "bit lane checkout"
 
-revert is similar to "lane checkout", but it keeps the versions and only change the files. choose one or the other based on your needs. if you want to continue working on this lane and needs the changes from the history to be the head, then use "lane revert". if you want to fork the lane from a certain point in history, use "lane checkout" and create a new lane from it.
+revert is similar to "lane checkout", but it keeps the versions and only changes the files. choose one or the other based on your needs. if you want to continue working on this lane and need the changes from the history to be the head, then use "lane revert". if you want to fork the lane from a certain point in history, use "lane checkout" and create a new lane from it.
 Flags: --skip-dependency-installation, --restore-deleted-components, --json
 
 ## bit lane merge-move <new-lane-name>
 
 EXPERIMENT. move the current merge state into a new lane. the current lane will be reset
 
-this command is useful when you got a messy merge state that from one hand you don't want to loose the changes, but on the other hand, you want to keep your lane without those changes. this command does the following: 1. create a new lane with the current merge state. including all the filesystem changes. (in practice, it leaves the fs intact) 2. reset the current lane to the state before the merge. so then once done with the new lane, you can switch to the current lane and it'll be clean.
+this command is useful when you got a messy merge state that on one hand you don't want to lose the changes, but on the other hand, you want to keep your lane without those changes. this command does the following: 1. create a new lane with the current merge state. including all the filesystem changes. (in practice, it leaves the fs intact) 2. reset the current lane to the state before the merge. so then once done with the new lane, you can switch to the current lane and it'll be clean.
 Flags: --scope <scope-name>
 
 ## bit link [component-names...]
@@ -615,7 +615,7 @@ Flags: --one-line
 authenticate with Bit Cloud for component publishing and collaboration
 
 opens browser to authenticate with Bit Cloud (bit.cloud) and obtain access token for publishing components. automatically updates .npmrc file with registry configuration and authentication token for seamless package publishing. supports custom cloud domains, CI/machine authentication, and manual token refresh options.
-Flags: --skip-config-update, --refresh-token, --cloud-domain <domain>, --default-cloud-domain, --port <port>, --no-browser, --machine-name <name>, --suppress-browser-launch
+Flags: --skip-config-update, --refresh-token, --cloud-domain <domain>, --default-cloud-domain, --port <port>, --no-browser, --machine-name <name>
 
 ## bit logout
 
@@ -822,7 +822,7 @@ configure scope assignments for components including setting default scopes and 
 
 Sets the scope for specified component/s. If no component is specified, sets the default scope of the workspace
 
-default scopes for components are set in the bitmap file. the default scope for a workspace is set in the workspace.jsonc. a component is set with a scope (as oppose to default scope) only once it is versioned.' you can use a `<pattern>` for multiple component ids, such as `bit scope set scope-name "org.scope/utils/**"`. use comma to separate patterns and '!' to exclude. e.g. 'ui/\*\*, !ui/button' use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. always wrap the pattern with single quotes to avoid collision with shell commands. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.
+default scopes for components are set in the bitmap file. the default scope for a workspace is set in the workspace.jsonc. a component is set with a scope (as opposed to default scope) only once it is versioned. you can use a `<pattern>` for multiple component ids, such as `bit scope set scope-name "org.scope/utils/**"`. use comma to separate patterns and '!' to exclude. e.g. 'ui/\*\*, !ui/button' use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. always wrap the pattern with single quotes to avoid collision with shell commands. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.
 
 ## bit scope trust [action] [pattern]
 

--- a/e2e/flows/id-with-wildcard.e2e.ts
+++ b/e2e/flows/id-with-wildcard.e2e.ts
@@ -59,7 +59,7 @@ describe('component id with wildcard', function () {
       describe('when wildcard does not match any component', () => {
         it('should throw an error saying the wildcard does not match any id', () => {
           const removeFunc = () => helper.command.removeComponent('none/*');
-          expect(removeFunc).to.throw('unable to find any matching');
+          expect(removeFunc).to.throw('unable to find any component matching');
         });
       });
       describe('when wildcard match some of the components', () => {
@@ -194,7 +194,7 @@ describe('component id with wildcard', function () {
       describe('when wildcard does not match any component', () => {
         it('should throw an error saying that no components found', () => {
           const output = helper.general.runWithTryCatch('bit reset "none/*"');
-          expect(output).to.have.string('unable to find any matching');
+          expect(output).to.have.string('unable to find any component matching');
         });
       });
       describe('when wildcard match some of the components', () => {

--- a/e2e/flows/id-with-wildcard.e2e.ts
+++ b/e2e/flows/id-with-wildcard.e2e.ts
@@ -31,7 +31,7 @@ describe('component id with wildcard', function () {
       describe('when wildcard does not match any component', () => {
         it('should not tag any component', () => {
           const output = helper.general.runWithTryCatch('bit tag "none/*"');
-          expect(output).to.have.string('unable to find any matching for "none/*" pattern');
+          expect(output).to.have.string('unable to find any component matching the "none/*" pattern');
         });
       });
       describe('when wildcard match some of the components', () => {

--- a/scopes/cloud/cloud/login.cmd.ts
+++ b/scopes/cloud/cloud/login.cmd.ts
@@ -26,7 +26,7 @@ supports custom cloud domains, CI/machine authentication, and manual token refre
       'machine-name <name>',
       'specify machine-name to pair with the token (useful for CI to avoid accidentally revoking the token)',
     ],
-    ['', 'suppress-browser-launch', 'DEPRECATE. use --no-browser instead'],
+    ['', 'suppress-browser-launch', 'DEPRECATED. use --no-browser instead'],
   ] as CommandOptions;
   loader = true;
   remoteOp = true;

--- a/scopes/compilation/compiler/templates/compiler/files/compiler-file.ts
+++ b/scopes/compilation/compiler/templates/compiler/files/compiler-file.ts
@@ -18,7 +18,7 @@ export class ${namePascalCase} implements Compiler {
     constructor(readonly id: string, readonly distDir, private compiler: CompilerMain) {}
 
     /**
-     * Detemines whether unsupported files (such as assets)
+     * Determines whether unsupported files (such as assets)
      * should be copied by Compiler aspect into the 'dist' directory
      */
     shouldCopyNonSupportedFiles = true;
@@ -52,7 +52,7 @@ export class ${namePascalCase} implements Compiler {
     }
 
     /* This is optional but recommended.
-    Not using it will require consumers of your compiler to use two APIs and have two depndencies
+    Not using it will require consumers of your compiler to use two APIs and have two dependencies
     to their Envs - your compiler
     */
     createTask() {

--- a/scopes/component/graph/graph-cmd.ts
+++ b/scopes/component/graph/graph-cmd.ts
@@ -31,7 +31,7 @@ by default shows only workspace components; use --include-dependencies for full 
     [
       '',
       'layout <name>',
-      'GraphVis layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
+      'Graphviz layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
     ],
     ['', 'png', 'save the graph as a png file instead of svg. requires "graphviz" to be installed'],
     ['', 'cycles', 'generate a graph of cycles only'],

--- a/scopes/component/issues/issues-cmd.ts
+++ b/scopes/component/issues/issues-cmd.ts
@@ -31,7 +31,7 @@ ${chalk.yellow('━'.repeat(80))}
 ${chalk.yellow.bold('IGNORING ISSUES (Emergency Use Only)')}
 ${chalk.yellow('━'.repeat(80))}
 
-${chalk.bold('While highly not recommended')}, it is possible to ignore issues in two ways:
+${chalk.bold('While strongly discouraged')}, it is possible to ignore issues in two ways:
 
 ${chalk.bold('1. Temporarily ignore for a single command:')}
    Use the --ignore-issues flag with tag/snap/build commands:

--- a/scopes/component/mover/mover.main.runtime.ts
+++ b/scopes/component/mover/mover.main.runtime.ts
@@ -28,7 +28,7 @@ export class MoverMain {
     if (!fromExists && !toExists) throw new BitError(`both paths from (${from}) and to (${to}) do not exist`);
     if (fromExists && !isDir(from)) {
       throw new BitError(`bit move supports moving directories only, not files.
-files withing a component dir are automatically tracked, no action is needed.
+files within a component dir are automatically tracked, no action is needed.
 to change the main-file, use "bit add <component-dir> --main <new-main-file>"`);
     }
     if (toExists && !isDir(to)) {

--- a/scopes/component/remove/delete-cmd.ts
+++ b/scopes/component/remove/delete-cmd.ts
@@ -46,7 +46,7 @@ to remove components from your local workspace only, use "bit remove" instead.`;
     [
       'f',
       'force',
-      'relevant for --hard. allow the deletion even if used as a dependency. WARNING: components that depend on this component will corrupt',
+      'relevant for --hard. allow the deletion even if used as a dependency. WARNING: components that depend on this component will be corrupted',
     ],
     ['', 'snaps <string>', 'comma-separated list of snap hashes to mark as deleted (e.g. --snaps "hash1,hash2,hash3")'],
   ] as CommandOptions;

--- a/scopes/component/renaming/rename.cmd.ts
+++ b/scopes/component/renaming/rename.cmd.ts
@@ -39,7 +39,7 @@ for local components: simply renames the existing component in place.`;
     ['', 'preserve', 'avoid renaming files and variables/classes according to the new component name'],
     ['', 'ast', 'use ast to transform files instead of regex'],
     ['', 'delete', 'DEPRECATED. this is now the default'],
-    ['', 'deprecate', 'instead of deleting the original component, deprecating it'],
+    ['', 'deprecate', 'instead of deleting the original component, deprecate it'],
     [
       'p',
       'path <relative-path>',

--- a/scopes/component/renaming/scope-rename.cmd.ts
+++ b/scopes/component/renaming/scope-rename.cmd.ts
@@ -20,7 +20,7 @@ as a result of this change`;
       'refactor',
       'update the import statements in all dependent components to the new package name (i.e. with the new scope name)',
     ],
-    ['', 'deprecate', 'for exported components, instead of deleting the original components, deprecating them'],
+    ['', 'deprecate', 'for exported components, instead of deleting the original components, deprecate them'],
     ['x', 'skip-dependency-installation', 'do not install dependencies after the rename'],
   ] as CommandOptions;
   group = 'component-config';

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -132,7 +132,7 @@ use for official releases. for development versions, use 'bit snap' instead.`;
   arguments = [
     {
       name: 'component-patterns...',
-      description: `${COMPONENT_PATTERN_HELP}. By default, all new and modified are tagged.`,
+      description: `${COMPONENT_PATTERN_HELP}. By default, all new and modified components are tagged.`,
     },
   ];
   helpUrl = 'reference/components/snaps#create-a-tag-(release-version)';

--- a/scopes/component/tracker/exceptions/missing-main-file-multiple-components.ts
+++ b/scopes/component/tracker/exceptions/missing-main-file-multiple-components.ts
@@ -9,7 +9,7 @@ export default class MissingMainFileMultipleComponents extends BitError {
     super(
       `error: the components ${chalk.bold(
         componentIds.join(', ')
-      )} does not contain a main file.\nplease either use --id to group all added files as one component or use our DSL to define the main file dynamically.\nsee troubleshooting at ${BASE_DOCS_DOMAIN} components/component-main-file`
+      )} do not contain a main file.\nplease either use --id to group all added files as one component or use our DSL to define the main file dynamically.\nsee troubleshooting at ${BASE_DOCS_DOMAIN}components/component-main-file`
     );
     this.componentIds = componentIds;
   }

--- a/scopes/component/tracker/exceptions/parent-dir-tracked.ts
+++ b/scopes/component/tracker/exceptions/parent-dir-tracked.ts
@@ -3,7 +3,7 @@ import { BitError } from '@teambit/bit-error';
 export class ParentDirTracked extends BitError {
   constructor(parentDir: string, componentId: string, currentDir: string) {
     // TODO @david: separate error outputs for `bit create` and `bit add`
-    super(`components can't be nested under other components. unable to create a component in directory "${currentDir}" which is nested to component "${componentId}".
-using 'bit create', choose a different path for with the '--path' or if using 'bit add' put the component in a different directory"`);
+    super(`components can't be nested under other components. unable to create a component in directory "${currentDir}" which is nested under component "${componentId}".
+using 'bit create', choose a different path with the '--path' flag or if using 'bit add' put the component in a different directory`);
   }
 }

--- a/scopes/compositions/aspect-docs/compositions/compositions.mdx
+++ b/scopes/compositions/aspect-docs/compositions/compositions.mdx
@@ -11,7 +11,7 @@ Moreover, a component's composition is a way to demonstrate the component for ot
 **Create component examples with zero configuration:** Write your compositions the same way you write your components.
 Place your examples in the component's `*.compositions.*` file to have them rendered in the Workspace UI with no additional configurations.
 
-**See your components render in all relevant contexts:** - Render components in the visual context of related and dependant components to learn how changes impact other components during development.
+**See your components render in all relevant contexts:** - Render components in the visual context of related and dependent components to learn how changes impact other components during development.
 
 **Hot-reloading in workspace UI:** - See various instances of a component render live to reflect most recent changes. Get immediate feedbacks to changes in your component's code.
 

--- a/scopes/dependencies/aspect-docs/dependency-resolver/dependency-resolver.mdx
+++ b/scopes/dependencies/aspect-docs/dependency-resolver/dependency-resolver.mdx
@@ -402,7 +402,7 @@ An example of the `"overrides"` field:
 }
 ```
 
-You may specify the package the overriden dependency belongs to by separating the package selector from the dependency selector with a `">"`, for example `qar@1>zoo` will only override the `zoo` dependency of `qar@1`, not for any other dependencies.
+You may specify the package the overridden dependency belongs to by separating the package selector from the dependency selector with a `">"`, for example `qar@1>zoo` will only override the `zoo` dependency of `qar@1`, not for any other dependencies.
 
 ## Side-Effects cache
 

--- a/scopes/dependencies/dependencies/dependencies-cmd.ts
+++ b/scopes/dependencies/dependencies/dependencies-cmd.ts
@@ -185,7 +185,7 @@ see also 'bit deps unset'`;
   async report([pattern, packages]: [string, string[]], removeDepsFlags: RemoveDependenciesFlags) {
     const results = await this.deps.removeDependency(pattern, packages, removeDepsFlags);
     if (!results.length) {
-      return formatHint('the specified component-pattern do not use the entered packages. nothing to remove');
+      return formatHint('the specified component-pattern does not use the entered packages. nothing to remove');
     }
 
     const sections = results.map(({ id, removedPackages }) => {
@@ -223,7 +223,7 @@ see also "bit deps remove"`;
   async report([pattern, packages]: [string, string[]], removeDepsFlags: RemoveDependenciesFlags) {
     const results = await this.deps.removeDependency(pattern, packages, removeDepsFlags, true);
     if (!results.length) {
-      return formatHint('the specified component-pattern do not use the entered packages. nothing to unset');
+      return formatHint('the specified component-pattern does not use the entered packages. nothing to unset');
     }
 
     const sections = results.map(({ id, removedPackages }) => {

--- a/scopes/dependencies/dependency-resolver/exceptions/main-aspect-not-installable.ts
+++ b/scopes/dependencies/dependency-resolver/exceptions/main-aspect-not-installable.ts
@@ -2,6 +2,6 @@ import { BitError } from '@teambit/bit-error';
 
 export class MainAspectNotInstallable extends BitError {
   constructor() {
-    super(`can't install main aspect because it's version or name is not defined`);
+    super(`can't install main aspect because its version or name is not defined`);
   }
 }

--- a/scopes/dependencies/dependency-resolver/exceptions/main-aspect-not-linkable.ts
+++ b/scopes/dependencies/dependency-resolver/exceptions/main-aspect-not-linkable.ts
@@ -2,6 +2,6 @@ import { BitError } from '@teambit/bit-error';
 
 export class MainAspectNotLinkable extends BitError {
   constructor() {
-    super(`can't link main aspect because it's name is not defined`);
+    super(`can't link main aspect because its name is not defined`);
   }
 }

--- a/scopes/dependencies/dependency-resolver/policy/workspace-policy/exceptions/entry-already-exist.ts
+++ b/scopes/dependencies/dependency-resolver/policy/workspace-policy/exceptions/entry-already-exist.ts
@@ -4,7 +4,7 @@ import type { WorkspacePolicyEntry } from '../workspace-policy';
 export class EntryAlreadyExist extends BitError {
   constructor(entry: WorkspacePolicyEntry) {
     super(
-      `policy entry with ${entry.dependencyId} already exist, use install -u | --update-existing to update the entry`
+      `policy entry with ${entry.dependencyId} already exists, use install -u | --update-existing to update the entry`
     );
   }
 }

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.spec.ts
@@ -1024,7 +1024,7 @@ describe('convertGraphToLockfile on invalid graph', () => {
       error = _error as Error;
     }
     expect(error?.message).eq(
-      `Failed to generate a valid lockfile. The "packages['foo@1.0.0'] entry doesn't have a "resolution" field.`
+      `Failed to generate a valid lockfile. The "packages['foo@1.0.0']" entry doesn't have a "resolution" field.`
     );
   });
 });

--- a/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
+++ b/scopes/dependencies/pnpm/lockfile-deps-graph-converter.ts
@@ -411,7 +411,7 @@ export async function convertGraphToLockfile(
   for (const [depPath, pkg] of Object.entries(lockfile.packages)) {
     if (pkg.resolution == null || Object.keys(pkg.resolution).length === 0) {
       throw new BitError(
-        `Failed to generate a valid lockfile. The "packages['${depPath}'] entry doesn't have a "resolution" field.`
+        `Failed to generate a valid lockfile. The "packages['${depPath}']" entry doesn't have a "resolution" field.`
       );
     }
   }

--- a/scopes/docs/docs/exceptions/file-extension-not-supported.ts
+++ b/scopes/docs/docs/exceptions/file-extension-not-supported.ts
@@ -1,6 +1,6 @@
 export class FileExtensionNotSupported extends Error {
   constructor(filePath: string, extension: string) {
     super(`failed reading doc file: ${filePath} as file extension ${extension} is not supported
-by any of registered component doc readers. To register a doc reader please use the 'registerDocReader' API of the teambit.docs/docs.`);
+by any of the registered component doc readers. To register a doc reader please use the 'registerDocReader' API of the teambit.docs/docs.`);
   }
 }

--- a/scopes/envs/envs/envs.cmd.ts
+++ b/scopes/envs/envs/envs.cmd.ts
@@ -39,7 +39,7 @@ export class GetEnvCmd implements Command {
       description: "the 'component name' or 'component id' of the component whose env you'd like to inspect",
     },
   ];
-  examples: [{ cmd: 'get ui/button'; description: 'show config information from the env configured for ui/button' }];
+  examples = [{ cmd: 'get ui/button', description: 'show config information from the env configured for ui/button' }];
   options = [
     [
       '',

--- a/scopes/envs/envs/exceptions/env-not-configured-for-component.ts
+++ b/scopes/envs/envs/exceptions/env-not-configured-for-component.ts
@@ -3,7 +3,7 @@ import { BitError } from '@teambit/bit-error';
 export class EnvNotConfiguredForComponent extends BitError {
   constructor(id: string, componentId?: string) {
     const suffix = componentId ? ` for the component ${componentId}` : '';
-    super(`environment with ID: "${id}" is not configured as extension${suffix}.
+    super(`environment with ID: "${id}" is not configured as an extension${suffix}.
 you probably need to set this environment to your component(s). for example, "bit env set <component-pattern> ${id}"
 `);
   }

--- a/scopes/generator/generator/create.cmd.ts
+++ b/scopes/generator/generator/create.cmd.ts
@@ -46,7 +46,7 @@ export class CreateCmd implements Command {
     {
       cmd: 'bit create mdx docs/create-components --aspect teambit.mdx/mdx-env --scope my-org.my-scope',
       description:
-        "creates an mdx component named 'docs/create-components' and sets it scope to 'my-org.my-scope'. \nby default, the scope is the `defaultScope` value, configured in your `workspace.jsonc`.",
+        "creates an mdx component named 'docs/create-components' and sets its scope to 'my-org.my-scope'. \nby default, the scope is the `defaultScope` value, configured in your `workspace.jsonc`.",
     },
     {
       cmd: 'bit create react my-org.my-scope/hooks/use-session',

--- a/scopes/generator/generator/new.cmd.ts
+++ b/scopes/generator/generator/new.cmd.ts
@@ -52,7 +52,7 @@ installs dependencies and configures the workspace for immediate development.`;
     [
       '',
       'load-from <path-to-template>',
-      'local path to the workspace containing the template. Helpful during a development of a workspace-template',
+      'local path to the workspace containing the template. Helpful during the development of a workspace-template',
     ],
     [
       'c',

--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -82,7 +82,7 @@ export class SetAspectCmd implements Command {
     },
   ];
   options = [
-    ['m', 'merge', 'merge with an existing config if exits. (by default, it replaces overlapping existing configs)'],
+    ['m', 'merge', 'merge with an existing config if exists. (by default, it replaces overlapping existing configs)'],
   ] as CommandOptions;
   group = 'component-config';
 

--- a/scopes/harmony/aspect/aspect.docs.mdx
+++ b/scopes/harmony/aspect/aspect.docs.mdx
@@ -35,4 +35,4 @@ It's possible to run any arbitrary javascript code with fx, so for example, if y
 bit aspect get ui/text --debug --json | fx 'Object.keys(this).map(origin => ({ origin, value: this[origin].extensions["teambit.pkg/pkg"] }))'
 ```
 
-Another data shown with the `--debug` flag is the rules in the workspace.jsonc#variants applied to this component. It shows the list of these rules sorted with the data about the specifity.
+Another data shown with the `--debug` flag is the rules in the workspace.jsonc#variants applied to this component. It shows the list of these rules sorted with the data about the specificity.

--- a/scopes/harmony/cli-reference/cli-reference.docs.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.docs.mdx
@@ -1,4 +1,4 @@
 ---
-description: 'Bit command synopses. Bit version: 2.0.21'
+description: 'Bit command synopses. Bit version: 2.0.22'
 labels: ['cli', 'mdx', 'docs']
 ---

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -219,6 +219,12 @@
             "name": "component-name",
             "description": "the 'component name' or 'component id' of the component whose env you'd like to inspect"
           }
+        ],
+        "examples": [
+          {
+            "cmd": "get ui/button",
+            "description": "show config information from the env configured for ui/button"
+          }
         ]
       },
       {

--- a/scopes/harmony/cli-reference/cli-reference.json
+++ b/scopes/harmony/cli-reference/cli-reference.json
@@ -255,7 +255,7 @@
         "name": "unset <component-pattern>",
         "options": [],
         "description": "un-sets an env from components that were previously set by \"bit env set\" or by a component template",
-        "extendedDescription": "keep in mind that this doesn't remove envs that are set via variants.\nin only removes envs that appear in the .bitmap file, which were previously configured via \"bit env set\".\nthe purpose of this command is to reset previously assigned envs to either allow variants configure the env or use the base node env.\nyou can use a `<pattern>` for multiple component ids, such as `bit env unset \"org.scope/utils/**\"`.\nuse comma to separate patterns and '!' to exclude. e.g. 'ui/**, !ui/button'\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nalways wrap the pattern with single quotes to avoid collision with shell commands.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.\n",
+        "extendedDescription": "keep in mind that this doesn't remove envs that are set via variants.\nit only removes envs that appear in the .bitmap file, which were previously configured via \"bit env set\".\nthe purpose of this command is to reset previously assigned envs to either allow variants to configure the env or use the base node env.\nyou can use a `<pattern>` for multiple component ids, such as `bit env unset \"org.scope/utils/**\"`.\nuse comma to separate patterns and '!' to exclude. e.g. 'ui/**, !ui/button'\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nalways wrap the pattern with single quotes to avoid collision with shell commands.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.\n",
         "group": "component-config",
         "arguments": [
           {
@@ -532,7 +532,7 @@
       [
         "v",
         "verbose",
-        "show verbose output for inspection and prints stack trace"
+        "show verbose output for inspection and print stack trace"
       ],
       [
         "n",
@@ -597,7 +597,7 @@
       [
         "",
         "layout <name>",
-        "GraphVis layout. default to \"dot\". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]"
+        "Graphviz layout. default to \"dot\". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]"
       ],
       [
         "",
@@ -644,7 +644,7 @@
         "name": "set <scope-name> [component-pattern]",
         "options": [],
         "description": "Sets the scope for specified component/s. If no component is specified, sets the default scope of the workspace",
-        "extendedDescription": "default scopes for components are set in the bitmap file. the default scope for a workspace is set in the workspace.jsonc.\na component is set with a scope (as oppose to default scope) only once it is versioned.'\n\nyou can use a `<pattern>` for multiple component ids, such as `bit scope set scope-name \"org.scope/utils/**\"`.\nuse comma to separate patterns and '!' to exclude. e.g. 'ui/**, !ui/button'\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nalways wrap the pattern with single quotes to avoid collision with shell commands.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.\n",
+        "extendedDescription": "default scopes for components are set in the bitmap file. the default scope for a workspace is set in the workspace.jsonc.\na component is set with a scope (as opposed to default scope) only once it is versioned.\n\nyou can use a `<pattern>` for multiple component ids, such as `bit scope set scope-name \"org.scope/utils/**\"`.\nuse comma to separate patterns and '!' to exclude. e.g. 'ui/**, !ui/button'\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nalways wrap the pattern with single quotes to avoid collision with shell commands.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.\n",
         "group": "component-config",
         "arguments": [
           {
@@ -690,7 +690,7 @@
           [
             "",
             "deprecate",
-            "for exported components, instead of deleting the original components, deprecating them"
+            "for exported components, instead of deleting the original components, deprecate them"
           ],
           [
             "x",
@@ -863,12 +863,12 @@
       [
         "p",
         "propagate",
-        "mark propagate true in the config file, so that component.json configs will be merge with workspace configs"
+        "mark propagate true in the config file, so that component.json configs will be merged with workspace configs"
       ],
       [
         "o",
         "override",
-        "override file if exist"
+        "override the file if it exists"
       ]
     ],
     "description": "create component.json configuration files for components",
@@ -1241,7 +1241,7 @@
       [
         "",
         "suppress-browser-launch",
-        "DEPRECATE. use --no-browser instead"
+        "DEPRECATED. use --no-browser instead"
       ]
     ],
     "description": "authenticate with Bit Cloud for component publishing and collaboration",
@@ -1883,7 +1883,7 @@
       },
       {
         "cmd": "bit create mdx docs/create-components --aspect teambit.mdx/mdx-env --scope my-org.my-scope",
-        "description": "creates an mdx component named 'docs/create-components' and sets it scope to 'my-org.my-scope'. \nby default, the scope is the `defaultScope` value, configured in your `workspace.jsonc`."
+        "description": "creates an mdx component named 'docs/create-components' and sets its scope to 'my-org.my-scope'. \nby default, the scope is the `defaultScope` value, configured in your `workspace.jsonc`."
       },
       {
         "cmd": "bit create react my-org.my-scope/hooks/use-session",
@@ -1962,7 +1962,7 @@
       [
         "",
         "load-from <path-to-template>",
-        "local path to the workspace containing the template. Helpful during a development of a workspace-template"
+        "local path to the workspace containing the template. Helpful during the development of a workspace-template"
       ],
       [
         "c",
@@ -2388,7 +2388,7 @@
       [
         "",
         "skip-unavailable",
-        "when adding missing dependencies, skip those that are not found in the regisry"
+        "when adding missing dependencies, skip those that are not found in the registry"
       ],
       [
         "",
@@ -2635,7 +2635,7 @@
       [
         "",
         "dependents-dry-run",
-        "DEPRECATED. (this is the default now). same as --dependents, except it prints the found dependents and wait for confirmation before importing them"
+        "DEPRECATED. (this is the default now). same as --dependents, except it prints the found dependents and waits for confirmation before importing them"
       ],
       [
         "",
@@ -2660,7 +2660,7 @@
       [
         "",
         "fetch-deps",
-        "fetch dependencies (bit components) objects to the local scope, but dont add to the workspace. Useful to resolve errors about missing dependency data"
+        "fetch dependencies (bit components) objects to the local scope, but don't add to the workspace. Useful to resolve errors about missing dependency data"
       ],
       [
         "",
@@ -2816,7 +2816,7 @@
       [
         "f",
         "force",
-        "relevant for --hard. allow the deletion even if used as a dependency. WARNING: components that depend on this component will corrupt"
+        "relevant for --hard. allow the deletion even if used as a dependency. WARNING: components that depend on this component will be corrupted"
       ],
       [
         "",
@@ -3589,7 +3589,7 @@
     "arguments": [
       {
         "name": "component-patterns...",
-        "description": "component name, component id, component pattern, or relative directory path. use component pattern to select multiple components.\nwrap the pattern with quotes. use comma to separate patterns and \"!\" to exclude. e.g. \"ui/**, !ui/button\".\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.. By default, all new and modified are tagged."
+        "description": "component name, component id, component pattern, or relative directory path. use component pattern to select multiple components.\nwrap the pattern with quotes. use comma to separate patterns and \"!\" to exclude. e.g. \"ui/**, !ui/button\".\nuse '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.\nuse `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.. By default, all new and modified components are tagged."
       }
     ],
     "examples": [
@@ -4171,7 +4171,7 @@
           [
             "n",
             "alias <string>",
-            "relevant when the specified lane is a remote lane. create a local alias for the lane (doesnt affect the lane's name on the remote"
+            "relevant when the specified lane is a remote lane. create a local alias for the lane (doesn't affect the lane's name on the remote)"
           ],
           [
             "",
@@ -4565,7 +4565,7 @@
           ]
         ],
         "description": "revert to a previous history of the current lane. see also \"bit lane checkout\"",
-        "extendedDescription": "revert is similar to \"lane checkout\", but it keeps the versions and only change the files.\nchoose one or the other based on your needs.\nif you want to continue working on this lane and needs the changes from the history to be the head, then use \"lane revert\".\nif you want to fork the lane from a certain point in history, use \"lane checkout\" and create a new lane from it.",
+        "extendedDescription": "revert is similar to \"lane checkout\", but it keeps the versions and only changes the files.\nchoose one or the other based on your needs.\nif you want to continue working on this lane and need the changes from the history to be the head, then use \"lane revert\".\nif you want to fork the lane from a certain point in history, use \"lane checkout\" and create a new lane from it.",
         "group": "ungrouped",
         "private": false,
         "arguments": [
@@ -4667,7 +4667,7 @@
           [
             "",
             "skip-fetch",
-            "use the local state of target-lane if exits locally, without updating it from the remote"
+            "use the local state of target-lane if exists locally, without updating it from the remote"
           ],
           [
             "",
@@ -4696,7 +4696,7 @@
           ]
         ],
         "description": "merge a local or a remote lane to the current lane",
-        "extendedDescription": "by default, the provided lane will be fetched from the remote before merging.\nto merge the lane from the local scope without updating it first, use \"--skip-fetch\" flag.\n\nwhen the current and merge candidate lanes are diverged in history and the files could be merged with no conflicts,\nthese components will be snap-merged to complete the merge. use \"no-auto-snap\" to opt-out, or \"tag\" to tag instead.\n\nwhen the components are not diverged in history, and the current lane is behind the merge candidate, the merge will\nsimply update the components and the heads according to the merge candidate.\nto opt-out, use \"--no-snap\", the components will be written as the merge candidate, and will be left as modified.\n\nin case a component in both ends don't share history (no snap is found in common), the merge will require \"--resolve-unrelated\" flag.\nthis flag keeps the history of one end and saves a reference to the other end. the decision of which end to keep is determined by the following:\n1. if the component exists on main, then the history linked to main will be kept.\nin this case, the strategy of \"--resolve-unrelated\" only determines which source-code to keep. it's not about the history.\n2. if the component doesn't exist on main, then by default, the history of the current lane will be kept.\nunless \"--resolve-unrelated\" is set to \"theirs\", in which case the history of the other lane will be kept.\n2. a. an edge case: if the component is deleted on the current lane, the strategy will always be \"theirs\".\nso then the history (and the source-code) of the other lane will be kept.\n",
+        "extendedDescription": "by default, the provided lane will be fetched from the remote before merging.\nto merge the lane from the local scope without updating it first, use \"--skip-fetch\" flag.\n\nwhen the current and merge candidate lanes are diverged in history and the files could be merged with no conflicts,\nthese components will be snap-merged to complete the merge. use \"no-auto-snap\" to opt-out, or \"tag\" to tag instead.\n\nwhen the components are not diverged in history, and the current lane is behind the merge candidate, the merge will\nsimply update the components and the heads according to the merge candidate.\nto opt-out, use \"--no-snap\", the components will be written as the merge candidate, and will be left as modified.\n\nin case a component on both ends doesn't share history (no snap is found in common), the merge will require \"--resolve-unrelated\" flag.\nthis flag keeps the history of one end and saves a reference to the other end. the decision of which end to keep is determined by the following:\n1. if the component exists on main, then the history linked to main will be kept.\nin this case, the strategy of \"--resolve-unrelated\" only determines which source-code to keep. it's not about the history.\n2. if the component doesn't exist on main, then by default, the history of the current lane will be kept.\nunless \"--resolve-unrelated\" is set to \"theirs\", in which case the history of the other lane will be kept.\n2. a. an edge case: if the component is deleted on the current lane, the strategy will always be \"theirs\".\nso then the history (and the source-code) of the other lane will be kept.\n",
         "private": true,
         "remoteOp": true,
         "arguments": [
@@ -4746,7 +4746,7 @@
           ]
         ],
         "description": "EXPERIMENT. move the current merge state into a new lane. the current lane will be reset",
-        "extendedDescription": "this command is useful when you got a messy merge state that from one hand you don't want\nto loose the changes, but on the other hand, you want to keep your lane without those changes.\nthis command does the following:\n1. create a new lane with the current merge state. including all the filesystem changes. (in practice, it leaves the fs intact)\n2. reset the current lane to the state before the merge. so then once done with the new lane, you can switch to the current lane and it'll be clean.",
+        "extendedDescription": "this command is useful when you got a messy merge state that on one hand you don't want\nto lose the changes, but on the other hand, you want to keep your lane without those changes.\nthis command does the following:\n1. create a new lane with the current merge state. including all the filesystem changes. (in practice, it leaves the fs intact)\n2. reset the current lane to the state before the merge. so then once done with the new lane, you can switch to the current lane and it'll be clean.",
         "remoteOp": true
       }
     ]
@@ -4803,7 +4803,7 @@
       [
         "n",
         "alias <string>",
-        "relevant when the specified lane is a remote lane. create a local alias for the lane (doesnt affect the lane's name on the remote"
+        "relevant when the specified lane is a remote lane. create a local alias for the lane (doesn't affect the lane's name on the remote)"
       ],
       [
         "",
@@ -5328,7 +5328,7 @@
       [
         "",
         "reset-lane-new",
-        "same as reset-new, but it only resets components belong to lanes. main components are left intact"
+        "same as reset-new, but it only resets components belonging to lanes. main components are left intact"
       ],
       [
         "",
@@ -5418,7 +5418,7 @@
           [
             "l",
             "layout <name>",
-            "GraphVis layout. default to \"dot\". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]"
+            "Graphviz layout. default to \"dot\". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]"
           ],
           [
             "",
@@ -5839,7 +5839,7 @@
       [
         "",
         "deprecate",
-        "instead of deleting the original component, deprecating it"
+        "instead of deleting the original component, deprecate it"
       ],
       [
         "p",
@@ -6051,7 +6051,7 @@
           [
             "m",
             "merge",
-            "merge with an existing config if exits. (by default, it replaces overlapping existing configs)"
+            "merge with an existing config if exists. (by default, it replaces overlapping existing configs)"
           ]
         ],
         "description": "set components with an aspect to extend their development tools, metadata and (possibly) artifacts",

--- a/scopes/harmony/cli-reference/cli-reference.mdx
+++ b/scopes/harmony/cli-reference/cli-reference.mdx
@@ -168,9 +168,9 @@ rarely used for manual aspect management as most aspects are configured automati
 | `aspect-id` |                                                                                                                                                                                                                                     the aspect's component id                                                                                                                                                                                                                                      |
 | `config`    |                                                                                                                                                                     the aspect config. enter the config as a stringified JSON (e.g. `{"foo":"bar"}` ). when no config is provided, an aspect is set with an empty config ({}).                                                                                                                                                                     |
 
-| **Option** | **Option alias** | **Description**                                                                                |
-| ---------- | :--------------: | ---------------------------------------------------------------------------------------------- |
-| `--merge`  |       `-m`       | merge with an existing config if exits. (by default, it replaces overlapping existing configs) |
+| **Option** | **Option alias** | **Description**                                                                                 |
+| ---------- | :--------------: | ----------------------------------------------------------------------------------------------- |
+| `--merge`  |       `-m`       | merge with an existing config if exists. (by default, it replaces overlapping existing configs) |
 
 ### aspect unset
 
@@ -602,7 +602,7 @@ to remove components from your local workspace only, use "bit remove" instead.
 | `--range <string>` |                  | EXPERIMENTAL. enter a Semver range to delete specific tags (cannot be used for snaps). see https://www.npmjs.com/package/semver#ranges for the range syntax |
 | `--silent`         |       `-s`       | skip confirmation                                                                                                                                           |
 | `--hard`           |                  | NOT-RECOMMENDED. delete a component completely from a remote scope. careful! this is a permanent change that could corrupt dependents.                      |
-| `--force`          |       `-f`       | relevant for --hard. allow the deletion even if used as a dependency. WARNING: components that depend on this component will corrupt                        |
+| `--force`          |       `-f`       | relevant for --hard. allow the deletion even if used as a dependency. WARNING: components that depend on this component will be corrupted                   |
 | `--snaps <string>` |                  | comma-separated list of snap hashes to mark as deleted (e.g. --snaps "hash1,hash2,hash3")                                                                   |
 
 ---
@@ -918,10 +918,10 @@ use `bit pattern --help` to understand patterns better and `bit pattern <pattern
 
 `bit eject-conf <pattern>`
 
-| **Option**    | **Option alias** | **Description**                                                                                             |
-| ------------- | :--------------: | ----------------------------------------------------------------------------------------------------------- |
-| `--propagate` |       `-p`       | mark propagate true in the config file, so that component.json configs will be merge with workspace configs |
-| `--override`  |       `-o`       | override file if exist                                                                                      |
+| **Option**    | **Option alias** | **Description**                                                                                              |
+| ------------- | :--------------: | ------------------------------------------------------------------------------------------------------------ |
+| `--propagate` |       `-p`       | mark propagate true in the config file, so that component.json configs will be merged with workspace configs |
+| `--override`  |       `-o`       | override the file if it exists                                                                               |
 
 ---
 
@@ -971,8 +971,8 @@ environments control how components are built, tested, linted, and deployed.
 
 **Description**: un-sets an env from components that were previously set by "bit env set" or by a component template  
 keep in mind that this doesn't remove envs that are set via variants.  
-in only removes envs that appear in the .bitmap file, which were previously configured via "bit env set".  
-the purpose of this command is to reset previously assigned envs to either allow variants configure the env or use the base node env.  
+it only removes envs that appear in the .bitmap file, which were previously configured via "bit env set".  
+the purpose of this command is to reset previously assigned envs to either allow variants to configure the env or use the base node env.  
 you can use a `<pattern>` for multiple component ids, such as `bit env unset "org.scope/utils/**"`.  
 use comma to separate patterns and '!' to exclude. e.g. 'ui/\*\*, !ui/button'  
 use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'.  
@@ -1142,7 +1142,7 @@ by default shows only workspace components; use --include-dependencies for full 
 | **Option**               | **Option alias** | **Description**                                                                                              |
 | ------------------------ | :--------------: | ------------------------------------------------------------------------------------------------------------ |
 | `--remote [remoteName]`  |       `-r`       | remote name (name is optional, leave empty when id is specified)                                             |
-| `--layout <name>`        |                  | GraphVis layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]       |
+| `--layout <name>`        |                  | Graphviz layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]       |
 | `--png`                  |                  | save the graph as a png file instead of svg. requires "graphviz" to be installed                             |
 | `--cycles`               |                  | generate a graph of cycles only                                                                              |
 | `--include-local-only`   |                  | DEPRECATED: include only the components in the workspace (or local scope). This is now the default behavior. |
@@ -1194,12 +1194,12 @@ without arguments, fetches all workspace components' latest versions from their 
 | `--dependents`                   |                  | import components found while traversing from the imported components upwards to the workspace components                                                                           |
 | `--dependents-via <string>`      |                  | same as --dependents except the traversal must go through the specified component. to specify multiple components, wrap with quotes and separate by a comma                         |
 | `--dependents-all`               |                  | same as --dependents except not prompting for selecting paths but rather selecting all paths and showing final confirmation before importing                                        |
-| `--dependents-dry-run`           |                  | DEPRECATED. (this is the default now). same as --dependents, except it prints the found dependents and wait for confirmation before importing them                                  |
+| `--dependents-dry-run`           |                  | DEPRECATED. (this is the default now). same as --dependents, except it prints the found dependents and waits for confirmation before importing them                                 |
 | `--silent`                       |                  | no prompt for --dependents/--dependents-via flags                                                                                                                                   |
 | `--filter-envs <envs>`           |                  | only import components that have the specified environment (e.g., "teambit.react/react-env")                                                                                        |
 | `--save-in-lane`                 |                  | when checked out to a lane and the component is not on the remote-lane, save it in the lane (defaults to save on main)                                                              |
 | `--all-history`                  |                  | relevant for fetching all components objects. avoid optimizations, fetch all history versions, always                                                                               |
-| `--fetch-deps`                   |                  | fetch dependencies (bit components) objects to the local scope, but dont add to the workspace. Useful to resolve errors about missing dependency data                               |
+| `--fetch-deps`                   |                  | fetch dependencies (bit components) objects to the local scope, but don't add to the workspace. Useful to resolve errors about missing dependency data                              |
 | `--write-deps <target>`          |                  | write all workspace component dependencies to the specified target ("package.json" or "workspace.jsonc"), resolving conflicts by picking the ranges that match the highest versions |
 | `--track-only`                   |                  | do not write any component files, just create .bitmap entries of the imported components. Useful when the files already exist and just want to re-add the component to the bitmap   |
 | `--include-deprecated`           |                  | when importing with patterns, include deprecated components (default to exclude them)                                                                                               |
@@ -1226,7 +1226,7 @@ supports various reset options to recover from corrupted state or restart from s
 | `--no-package-json`                       |                  | do not generate package.json                                                                                                              |
 | `--reset`                                 |       `-r`       | write missing or damaged Bit files                                                                                                        |
 | `--reset-new`                             |                  | reset .bitmap file as if the components were newly added and remove all model data (objects)                                              |
-| `--reset-lane-new`                        |                  | same as reset-new, but it only resets components belong to lanes. main components are left intact                                         |
+| `--reset-lane-new`                        |                  | same as reset-new, but it only resets components belonging to lanes. main components are left intact                                      |
 | `--reset-hard`                            |                  | delete all Bit files and directories, including Bit configuration, tracking and model data. Useful for re-starting workspace from scratch |
 | `--reset-scope`                           |                  | removes local scope (.bit or .git/bit). tags/snaps that have not been exported will be lost. workspace is left intact                     |
 | `--default-directory <default-directory>` |       `-d`       | set the default directory pattern to import/create components into                                                                        |
@@ -1265,7 +1265,7 @@ automatically imports components, compiles components, links to node_modules, an
 | `--skip-compile`                |                  | do not compile components                                                                              |
 | `--skip-write-config-files`     |                  | do not write config files (such as eslint, tsconfig, prettier, etc...)                                 |
 | `--add-missing-deps`            |       `-a`       | install all missing dependencies                                                                       |
-| `--skip-unavailable`            |                  | when adding missing dependencies, skip those that are not found in the regisry                         |
+| `--skip-unavailable`            |                  | when adding missing dependencies, skip those that are not found in the registry                        |
 | `--add-missing-peers`           |                  | install all missing peer dependencies                                                                  |
 | `--recurring-install`           |                  | automatically run install again if there are non loaded old envs in your workspace                     |
 | `--no-optional [noOptional]`    |                  | do not install optional dependencies (works with pnpm only)                                            |
@@ -1341,7 +1341,7 @@ without a sub-command, lists all available lanes.
 | `--workspace-only`                      |                  | checkout only the components in the workspace to the selected lane                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `--skip-dependency-installation`        |       `-x`       | do not install dependencies of the imported components                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `--pattern <component-pattern>`         |       `-p`       | switch only the lane components matching the specified component-pattern. only works when the workspace is empty component name, component id, component pattern, or relative directory path. use component pattern to select multiple components. wrap the pattern with quotes. use comma to separate patterns and "!" to exclude. e.g. "ui/\*\*, !ui/button". use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern. |
-| `--alias <string>`                      |       `-n`       | relevant when the specified lane is a remote lane. create a local alias for the lane (doesnt affect the lane's name on the remote                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `--alias <string>`                      |       `-n`       | relevant when the specified lane is a remote lane. create a local alias for the lane (doesn't affect the lane's name on the remote)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `--verbose`                             |                  | display detailed information about components that legitimately were not switched                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `--json`                                |       `-j`       | return the output as JSON                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `--branch`                              |                  | create and checkout a new git branch named after the lane                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
@@ -1562,9 +1562,9 @@ run "bit lane history" to find history-ids
 **Usage**: `lane revert <history-id>`
 
 **Description**: revert to a previous history of the current lane. see also "bit lane checkout"  
-revert is similar to "lane checkout", but it keeps the versions and only change the files.  
+revert is similar to "lane checkout", but it keeps the versions and only changes the files.  
 choose one or the other based on your needs.  
-if you want to continue working on this lane and needs the changes from the history to be the head, then use "lane revert".  
+if you want to continue working on this lane and need the changes from the history to be the head, then use "lane revert".  
 if you want to fork the lane from a certain point in history, use "lane checkout" and create a new lane from it.
 
 | **Arg**      |                            **Description**                            |
@@ -1592,7 +1592,7 @@ when the components are not diverged in history, and the current lane is behind 
 simply update the components and the heads according to the merge candidate.  
 to opt-out, use "--no-snap", the components will be written as the merge candidate, and will be left as modified.
 
-in case a component in both ends don't share history (no snap is found in common), the merge will require "--resolve-unrelated" flag.  
+in case a component on both ends doesn't share history (no snap is found in common), the merge will require "--resolve-unrelated" flag.  
 this flag keeps the history of one end and saves a reference to the other end. the decision of which end to keep is determined by the following:
 
 1. if the component exists on main, then the history linked to main will be kept.  
@@ -1626,7 +1626,7 @@ this flag keeps the history of one end and saves a reference to the other end. t
 | `--ignore-config-changes`               |                  | allow merging when components are modified due to config changes (such as dependencies) only and not files                                                  |
 | `--verbose`                             |                  | display detailed information about components that were legitimately unmerged                                                                               |
 | `--skip-dependency-installation`        |       `-x`       | do not install dependencies of the imported components                                                                                                      |
-| `--skip-fetch`                          |                  | use the local state of target-lane if exits locally, without updating it from the remote                                                                    |
+| `--skip-fetch`                          |                  | use the local state of target-lane if exists locally, without updating it from the remote                                                                   |
 | `--include-deps`                        |                  | relevant for "pattern" and "--workspace". merge also dependencies of the specified components                                                               |
 | `--resolve-unrelated [merge-strategy]`  |                  | relevant when a component on a lane and the component on main have nothing in common. merge-strategy can be "ours" (default) or "theirs"                    |
 | `--include-non-lane-comps`              |                  | DEPRECATED (this is now the default). when merging main, include workspace components that are not on the lane (by default only lane components are merged) |
@@ -1652,8 +1652,8 @@ also, checkout the workspace components according to the restored lane state
 **Usage**: `lane merge-move <new-lane-name>`
 
 **Description**: EXPERIMENT. move the current merge state into a new lane. the current lane will be reset  
-this command is useful when you got a messy merge state that from one hand you don't want  
-to loose the changes, but on the other hand, you want to keep your lane without those changes.  
+this command is useful when you got a messy merge state that on one hand you don't want  
+to lose the changes, but on the other hand, you want to keep your lane without those changes.  
 this command does the following:
 
 1. create a new lane with the current merge state. including all the filesystem changes. (in practice, it leaves the fs intact)
@@ -1841,7 +1841,7 @@ supports custom cloud domains, CI/machine authentication, and manual token refre
 | `--port <port>`             |       `-p`       | port number to open for localhost server (default 8085)                                              |
 | `--no-browser`              |                  | do not open a browser for authentication                                                             |
 | `--machine-name <name>`     |                  | specify machine-name to pair with the token (useful for CI to avoid accidentally revoking the token) |
-| `--suppress-browser-launch` |                  | DEPRECATE. use --no-browser instead                                                                  |
+| `--suppress-browser-launch` |                  | DEPRECATED. use --no-browser instead                                                                 |
 
 ---
 
@@ -1995,7 +1995,7 @@ installs dependencies and configures the workspace for immediate development.
 | `--standalone`                   |                  | DEPRECATED. use --skip-git instead                                                                                                  |
 | `--skip-git`                     |       `-s`       | skip generation of Git repository in the new workspace                                                                              |
 | `--empty`                        |       `-e`       | skip template's default component creation (relevant for templates that add components by default)                                  |
-| `--load-from <path-to-template>` |                  | local path to the workspace containing the template. Helpful during a development of a workspace-template                           |
+| `--load-from <path-to-template>` |                  | local path to the workspace containing the template. Helpful during the development of a workspace-template                         |
 | `--current-dir`                  |       `-c`       | create the new workspace in current directory (default is to create a new directory, inside the current dir)                        |
 | `--agent [type]`                 |                  | create an AI agent instructions file. options: claude, cursor, copilot (default: AGENTS.md)                                         |
 
@@ -2176,7 +2176,7 @@ for local components: simply renames the existing component in place.
 | `--preserve`             |                  | avoid renaming files and variables/classes according to the new component name                                                                         |
 | `--ast`                  |                  | use ast to transform files instead of regex                                                                                                            |
 | `--delete`               |                  | DEPRECATED. this is now the default                                                                                                                    |
-| `--deprecate`            |                  | instead of deleting the original component, deprecating it                                                                                             |
+| `--deprecate`            |                  | instead of deleting the original component, deprecate it                                                                                               |
 | `--path <relative-path>` |       `-p`       | relative path in the workspace to place new component in. by default, the directory of the new component is from your workspace's "defaultScope" value |
 
 ---
@@ -2392,7 +2392,7 @@ essential for organizing components and managing component namespaces across tea
 
 **Description**: Sets the scope for specified component/s. If no component is specified, sets the default scope of the workspace  
 default scopes for components are set in the bitmap file. the default scope for a workspace is set in the workspace.jsonc.  
-a component is set with a scope (as oppose to default scope) only once it is versioned.'
+a component is set with a scope (as opposed to default scope) only once it is versioned.
 
 you can use a `<pattern>` for multiple component ids, such as `bit scope set scope-name "org.scope/utils/**"`.  
 use comma to separate patterns and '!' to exclude. e.g. 'ui/\*\*, !ui/button'  
@@ -2444,7 +2444,7 @@ as a result of this change
 | -------------------------------- | :--------------: | --------------------------------------------------------------------------------------------------------------- |
 | `--preserve`                     |                  | avoid renaming files and variables/classes according to the new scope name                                      |
 | `--refactor`                     |       `-r`       | update the import statements in all dependent components to the new package name (i.e. with the new scope name) |
-| `--deprecate`                    |                  | for exported components, instead of deleting the original components, deprecating them                          |
+| `--deprecate`                    |                  | for exported components, instead of deleting the original components, deprecate them                            |
 | `--skip-dependency-installation` |       `-x`       | do not install dependencies after the rename                                                                    |
 
 ### scope rename-owner
@@ -2614,7 +2614,7 @@ includes hot module reloading for development.
 | `--port [port-number]`  |       `-p`       | port of the UI server.                                                                                                                                                     |
 | `--rebuild`             |       `-r`       | rebuild the UI (useful e.g. when updating the workspace UI - can use the dev flag for HMR in this case)                                                                    |
 | `--skip-ui-build`       |                  | skip building UI                                                                                                                                                           |
-| `--verbose`             |       `-v`       | show verbose output for inspection and prints stack trace                                                                                                                  |
+| `--verbose`             |       `-v`       | show verbose output for inspection and print stack trace                                                                                                                   |
 | `--no-browser`          |       `-n`       | do not automatically open browser when ready                                                                                                                               |
 | `--show-internal-urls`  |                  | show urls for all internal dev servers                                                                                                                                     |
 | `--skip-compilation`    |                  | skip the auto-compilation before starting the web-server                                                                                                                   |
@@ -2729,9 +2729,9 @@ use for official releases. for development versions, use 'bit snap' instead.
 
 `bit tag [component-patterns...]`
 
-| **Arg**                 |                                                                                                                                                                                                                                                    **Description**                                                                                                                                                                                                                                                     |
-| ----------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| `component-patterns...` | component name, component id, component pattern, or relative directory path. use component pattern to select multiple components. wrap the pattern with quotes. use comma to separate patterns and "!" to exclude. e.g. "ui/\*\*, !ui/button". use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.. By default, all new and modified are tagged. |
+| **Arg**                 |                                                                                                                                                                                                                                                          **Description**                                                                                                                                                                                                                                                          |
+| ----------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `component-patterns...` | component name, component id, component pattern, or relative directory path. use component pattern to select multiple components. wrap the pattern with quotes. use comma to separate patterns and "!" to exclude. e.g. "ui/\*\*, !ui/button". use '$' prefix to filter by states/attributes, e.g. '$deprecated', '$modified' or '$env:teambit.react/react'. use `bit pattern --help` to understand patterns better and `bit pattern <pattern>` to validate the pattern.. By default, all new and modified components are tagged. |
 
 | **Option**                     | **Option alias** | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | ------------------------------ | :--------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/scopes/harmony/host-initializer/init-cmd.ts
+++ b/scopes/harmony/host-initializer/init-cmd.ts
@@ -42,7 +42,7 @@ supports various reset options to recover from corrupted state or restart from s
     [
       '',
       'reset-lane-new',
-      'same as reset-new, but it only resets components belong to lanes. main components are left intact',
+      'same as reset-new, but it only resets components belonging to lanes. main components are left intact',
     ],
     [
       '',

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -358,9 +358,9 @@ export class LaneCheckoutCmd implements Command {
 export class LaneRevertCmd implements Command {
   name = 'revert <history-id>';
   description = 'revert to a previous history of the current lane. see also "bit lane checkout"';
-  extendedDescription = `revert is similar to "lane checkout", but it keeps the versions and only change the files.
+  extendedDescription = `revert is similar to "lane checkout", but it keeps the versions and only changes the files.
 choose one or the other based on your needs.
-if you want to continue working on this lane and needs the changes from the history to be the head, then use "lane revert".
+if you want to continue working on this lane and need the changes from the history to be the head, then use "lane revert".
 if you want to fork the lane from a certain point in history, use "lane checkout" and create a new lane from it.`;
   arguments = [
     { name: 'history-id', description: 'the history-id to checkout to. run "bit lane history" to list the ids' },

--- a/scopes/lanes/lanes/lanes.docs.mdx
+++ b/scopes/lanes/lanes/lanes.docs.mdx
@@ -86,7 +86,7 @@ Summary of when/what lanes data is saved per command:
 
 Locally, to remove a component from a lane, use `bit remove` command. It will remove the component from the local lane-object.
 This change won't affect the remote scope, even after exporting the lane.
-This is becuase on the remote, the merge-lane process doesn't remove anything, only adds/changes components to the lane object.
+This is because on the remote, the merge-lane process doesn't remove anything, only adds/changes components to the lane object.
 Remember that by default when importing a lane, only the components on the workspace are part of the lane, so the same lane-object, locally can have less components than the remote and obviously in this case we don't want to remove them from the remote on export.
 
 To mark a component as removed on the lane, use `bit remove --delete`, which will modify the component, mark it as removed, then, on the next snap+export, the remote will be updated.
@@ -118,5 +118,5 @@ Obviously, `bit log <comp-id> --one-line` is helpful here to see the distance fr
 
 Similar to file-changes, you can run `bit deps blame` to understhand when a dependency was introduced/deleted/changed from a component.
 Here again, it'll be helpful to import to a new workspace the other lane and run the same there.
-Also, becuase the dependencies merge is pretty complex, during the merge lots of valuable info is printed to the log.
+Also, because the dependencies merge is pretty complex, during the merge lots of valuable info is printed to the log.
 However, to avoid the extra noise it is not logged as "debug" but as "trace". Before you run the merge, you can add `--log=trace` to see these messages on the screen.

--- a/scopes/lanes/lanes/switch.cmd.ts
+++ b/scopes/lanes/lanes/switch.cmd.ts
@@ -49,7 +49,7 @@ ${COMPONENT_PATTERN_HELP}`,
     [
       'n',
       'alias <string>',
-      "relevant when the specified lane is a remote lane. create a local alias for the lane (doesnt affect the lane's name on the remote",
+      "relevant when the specified lane is a remote lane. create a local alias for the lane (doesn't affect the lane's name on the remote)",
     ],
     ['', 'verbose', 'display detailed information about components that legitimately were not switched'],
     ['j', 'json', 'return the output as JSON'],

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -22,7 +22,7 @@ when the components are not diverged in history, and the current lane is behind 
 simply update the components and the heads according to the merge candidate.
 to opt-out, use "--no-snap", the components will be written as the merge candidate, and will be left as modified.
 
-in case a component in both ends don't share history (no snap is found in common), the merge will require "--resolve-unrelated" flag.
+in case a component on both ends doesn't share history (no snap is found in common), the merge will require "--resolve-unrelated" flag.
 this flag keeps the history of one end and saves a reference to the other end. the decision of which end to keep is determined by the following:
 1. if the component exists on main, then the history linked to main will be kept.
 in this case, the strategy of "--resolve-unrelated" only determines which source-code to keep. it's not about the history.
@@ -77,7 +77,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     ],
     ['', 'verbose', 'display detailed information about components that were legitimately unmerged'],
     ['x', 'skip-dependency-installation', 'do not install dependencies of the imported components'],
-    ['', 'skip-fetch', 'use the local state of target-lane if exits locally, without updating it from the remote'],
+    ['', 'skip-fetch', 'use the local state of target-lane if exists locally, without updating it from the remote'],
     [
       '',
       'include-deps',

--- a/scopes/lanes/merge-lanes/merge-move.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-move.cmd.ts
@@ -11,8 +11,8 @@ export type MergeAbortOpts = {
 export class MergeMoveLaneCmd implements Command {
   name = 'merge-move <new-lane-name>';
   description = `EXPERIMENT. move the current merge state into a new lane. the current lane will be reset`;
-  extendedDescription = `this command is useful when you got a messy merge state that from one hand you don't want
-to loose the changes, but on the other hand, you want to keep your lane without those changes.
+  extendedDescription = `this command is useful when you got a messy merge state that on one hand you don't want
+to lose the changes, but on the other hand, you want to keep your lane without those changes.
 this command does the following:
 1. create a new lane with the current merge state. including all the filesystem changes. (in practice, it leaves the fs intact)
 2. reset the current lane to the state before the merge. so then once done with the new lane, you can switch to the current lane and it'll be clean.`;

--- a/scopes/pkg/aspect-docs/pkg/pkg.mdx
+++ b/scopes/pkg/aspect-docs/pkg/pkg.mdx
@@ -10,7 +10,7 @@ This automation includes generating the package name and other properties accord
 - **Efficient `package.json` configuration:** Use the PKG's workspace config API to add or override `package.json` properties to a group of components, all at once.
   Use PKG's 'placeholders' to integrate component-specific data into the component's package configurations.
 - **An API for programmable `package.json` configuration:** Use PKG's API to provide your extensions with "packaging capabilities". Modify the `package.json` to suit your extension's needs, whether it is an environment or any other type of extension.
-- **Automated packing and publishing:** - PKG is registered to your build pipeline. That means every 'build' will also test 'packing' and every tagging of a new release version will also include 'publishing'. Your components and packages versions are alway in-sync.
+- **Automated packing and publishing:** - PKG is registered to your build pipeline. That means every 'build' will also test 'packing' and every tagging of a new release version will also include 'publishing'. Your components and packages versions are always in-sync.
 - **"On-demand" packing and publishing:** - PKG offers the `pack` and `preview` CLI commands for a manual and on-demand usage.
 
 ### Quickstart & configuration

--- a/scopes/pkg/pkg/publish.cmd.tsx
+++ b/scopes/pkg/pkg/publish.cmd.tsx
@@ -30,7 +30,7 @@ export class PublishCmd implements Command {
   async report(args: PublishArgs, options: PublisherOptions) {
     const result = await this.json(args, options);
     const publishResults: ComponentResult[] = result.data;
-    if (!publishResults.length) return 'no components candidates found to publish';
+    if (!publishResults.length) return 'no component candidates found to publish';
 
     const publishOrDryRun = options.dryRun ? 'dry-run' : 'published';
     const title = chalk.white.bold(`successfully ${publishOrDryRun} the following components\n`);

--- a/scopes/preview/preview/exceptions/preview-output-file-not-found.ts
+++ b/scopes/preview/preview/exceptions/preview-output-file-not-found.ts
@@ -8,6 +8,6 @@ export class PreviewOutputFileNotFound extends BitError {
 This is usually a result of an error during the bundling process.
 The error might be an error of another component that uses the same env.
 Run "bit build" with "--dev" to see more info.
-Run "bit envs" to see other components that uses the same env`);
+Run "bit envs" to see other components that use the same env`);
   }
 }

--- a/scopes/react/aspect-docs/react/react.mdx
+++ b/scopes/react/aspect-docs/react/react.mdx
@@ -169,7 +169,7 @@ export class CustomReactExtension {
 }
 ```
 
-{/\* ## Composition Providers
+{/* ## Composition Providers
 
 The React environment is able to "wrap" component compositions with an array of providers, each of which is simply a component which wraps its `children` with functionality, such as a context, styling, theme, etc.
 
@@ -186,43 +186,47 @@ As such, they run in the environment's Preview runtime and not the Main runtime.
 For example, a provider that centers compositions in their rendering page, will look like this:
 
 ```tsx title="A composition provider example"
-import React, { ReactReact, ReactElement } from 'react';
+import React, { ReactReact, ReactElement } from 'react'
 
 const style = {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  height: '100vh',
-};
+  height: '100vh'
+}
 
-export const Center = ({ children }: { children: ReactReact }): ReactElement => {
-  return <div style={style}>{children}</div>;
-};
+export const Center = ({
+  children
+}: {
+  children: ReactReact
+}): ReactElement => {
+  return <div style={style}>{children}</div>
+}
 ```
 
 This `Center` provider component will be registered using the registerProvider method in the React extension's `*.preview.runtime.tsx` file:
 
 ```tsx title="react-with-providers.preview.runtime.tsx"
-import { PreviewRuntime } from '@teambit/preview';
-import { ReactAspect, ReactPreview } from '@teambit/react';
-import { ReactWithProvidersAspect } from './react-with-providers.aspect';
-import { Center } from './composition-providers/center';
+import { PreviewRuntime } from '@teambit/preview'
+import { ReactAspect, ReactPreview } from '@teambit/react'
+import { ReactWithProvidersAspect } from './react-with-providers.aspect'
+import { Center } from './composition-providers/center'
 
 export class ReactWithProvidersPreview {
-  static runtime = PreviewRuntime;
-  static dependencies = [ReactAspect];
+  static runtime = PreviewRuntime
+  static dependencies = [ReactAspect]
 
   static async provider([react]: [ReactPreview]) {
-    react.registerProvider([Center]);
+    react.registerProvider([Center])
 
-    return ReactWithProvidersPreview;
+    return ReactWithProvidersPreview
   }
 }
 
-ReactWithProvidersAspect.addRuntime(ReactWithProvidersPreview);
+ReactWithProvidersAspect.addRuntime(ReactWithProvidersPreview)
 ```
 
-> See the full demo project [here](https://github.com/teambit/react-env-with-providers). \*/}
+> See the full demo project [here](https://github.com/teambit/react-env-with-providers). */}
 
 ### Transformers API docs
 

--- a/scopes/react/aspect-docs/react/react.mdx
+++ b/scopes/react/aspect-docs/react/react.mdx
@@ -33,8 +33,8 @@ bit create <template name> [components...]
 
 ## Runtime (framework) dependencies
 
-As with many Frontend frameworks React requires a singleton instance in your app's runtime. When building reuseable components that means setting `react` and `react-dom` as `peerDependencies`, thus allowing the consuming app to determine the runtime version. Bit's base React environment implements this via the **Dependencies** service which is used to override [dependency-resolver](https://bit.cloud/teambit/dependencies/dependency-resolver) and set your preferred dependencies.
-It is recommended for you to extend the base React environment and define a semantic version rule and range to fit your current tech stack and guidelines for reuseable React components.
+As with many Frontend frameworks React requires a singleton instance in your app's runtime. When building reusable components that means setting `react` and `react-dom` as `peerDependencies`, thus allowing the consuming app to determine the runtime version. Bit's base React environment implements this via the **Dependencies** service which is used to override [dependency-resolver](https://bit.cloud/teambit/dependencies/dependency-resolver) and set your preferred dependencies.
+It is recommended for you to extend the base React environment and define a semantic version rule and range to fit your current tech stack and guidelines for reusable React components.
 
 ## Development services
 
@@ -169,7 +169,7 @@ export class CustomReactExtension {
 }
 ```
 
-{/* ## Composition Providers
+{/\* ## Composition Providers
 
 The React environment is able to "wrap" component compositions with an array of providers, each of which is simply a component which wraps its `children` with functionality, such as a context, styling, theme, etc.
 
@@ -186,47 +186,43 @@ As such, they run in the environment's Preview runtime and not the Main runtime.
 For example, a provider that centers compositions in their rendering page, will look like this:
 
 ```tsx title="A composition provider example"
-import React, { ReactReact, ReactElement } from 'react'
+import React, { ReactReact, ReactElement } from 'react';
 
 const style = {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  height: '100vh'
-}
+  height: '100vh',
+};
 
-export const Center = ({
-  children
-}: {
-  children: ReactReact
-}): ReactElement => {
-  return <div style={style}>{children}</div>
-}
+export const Center = ({ children }: { children: ReactReact }): ReactElement => {
+  return <div style={style}>{children}</div>;
+};
 ```
 
 This `Center` provider component will be registered using the registerProvider method in the React extension's `*.preview.runtime.tsx` file:
 
 ```tsx title="react-with-providers.preview.runtime.tsx"
-import { PreviewRuntime } from '@teambit/preview'
-import { ReactAspect, ReactPreview } from '@teambit/react'
-import { ReactWithProvidersAspect } from './react-with-providers.aspect'
-import { Center } from './composition-providers/center'
+import { PreviewRuntime } from '@teambit/preview';
+import { ReactAspect, ReactPreview } from '@teambit/react';
+import { ReactWithProvidersAspect } from './react-with-providers.aspect';
+import { Center } from './composition-providers/center';
 
 export class ReactWithProvidersPreview {
-  static runtime = PreviewRuntime
-  static dependencies = [ReactAspect]
+  static runtime = PreviewRuntime;
+  static dependencies = [ReactAspect];
 
   static async provider([react]: [ReactPreview]) {
-    react.registerProvider([Center])
+    react.registerProvider([Center]);
 
-    return ReactWithProvidersPreview
+    return ReactWithProvidersPreview;
   }
 }
 
-ReactWithProvidersAspect.addRuntime(ReactWithProvidersPreview)
+ReactWithProvidersAspect.addRuntime(ReactWithProvidersPreview);
 ```
 
-> See the full demo project [here](https://github.com/teambit/react-env-with-providers). */}
+> See the full demo project [here](https://github.com/teambit/react-env-with-providers). \*/}
 
 ### Transformers API docs
 

--- a/scopes/react/bit-react-transformer/bit-react-tranformer.docs.md
+++ b/scopes/react/bit-react-transformer/bit-react-tranformer.docs.md
@@ -5,7 +5,7 @@ labels: ['babel', 'react', 'component-id']
 
 The Bit React transformer is a Babel plugin that adds the component id (as it determined by Bit) as a static property of the React component (both classes and functions).
 
-Having the added metadata is useful for debbuging and [showcasing](/ui/component-highlighter).
+Having the added metadata is useful for debugging and [showcasing](/ui/component-highlighter).
 
 ### Example
 

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -189,7 +189,7 @@ export class ReactMain {
   }
 
   /**
-   * Override the Bit documentation link. See docs: https://bit.dev/refrence/docs/doc-templates
+   * Override the Bit documentation link. See docs: https://bit.dev/reference/docs/doc-templates
    */
   overrideDocsTemplate(templatePath: string) {
     return this.envs.override({

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -532,7 +532,7 @@ export default class ImportComponents {
     if (idsFromAnotherLane.length) {
       throw new BitError(`unable to import the following component(s) as they belong to other lane(s):
 ${idsFromAnotherLane.map((id) => id.toString()).join(', ')}
-if you need this specific snap, find the lane this snap is belong to, then run "bit lane merge <lane-id> [component-id]" to merge this component from the lane.
+if you need this specific snap, find the lane this snap belongs to, then run "bit lane merge <lane-id> [component-id]" to merge this component from the lane.
 if you just want to get a quick look into this snap, create a new workspace and import it by running "bit lane import <lane-id> --pattern <component-id>"`);
     }
   }

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -120,7 +120,7 @@ without arguments, fetches all workspace components' latest versions from their 
     [
       '',
       'dependents-dry-run',
-      'DEPRECATED. (this is the default now). same as --dependents, except it prints the found dependents and wait for confirmation before importing them',
+      'DEPRECATED. (this is the default now). same as --dependents, except it prints the found dependents and waits for confirmation before importing them',
     ],
     ['', 'silent', 'no prompt for --dependents/--dependents-via flags'],
     [
@@ -141,7 +141,7 @@ without arguments, fetches all workspace components' latest versions from their 
     [
       '',
       'fetch-deps',
-      'fetch dependencies (bit components) objects to the local scope, but dont add to the workspace. Useful to resolve errors about missing dependency data',
+      "fetch dependencies (bit components) objects to the local scope, but don't add to the workspace. Useful to resolve errors about missing dependency data",
     ],
     [
       '',

--- a/scopes/scope/network/exceptions/network-error.ts
+++ b/scopes/scope/network/exceptions/network-error.ts
@@ -6,7 +6,7 @@ export default class NetworkError extends BitError {
   showDoctorMessage: boolean;
 
   constructor(remoteErr: string) {
-    super(`error: remote failed with error the following error:\n "${chalk.bold(remoteErr)}"`);
+    super(`error: remote failed with the following error:\n "${chalk.bold(remoteErr)}"`);
     this.remoteErr = remoteErr;
     this.showDoctorMessage = true;
   }

--- a/scopes/scope/scope/exceptions/no-id-match-pattern.ts
+++ b/scopes/scope/scope/exceptions/no-id-match-pattern.ts
@@ -2,6 +2,6 @@ import { BitError } from '@teambit/bit-error';
 
 export class NoIdMatchPattern extends BitError {
   constructor(pattern: string) {
-    super(`unable to find any matching for "${pattern}" pattern`);
+    super(`unable to find any component matching the "${pattern}" pattern`);
   }
 }

--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -86,7 +86,7 @@ export class ScopeComponentLoader {
     const versionOriginId = version.originId;
     if (versionOriginId && !versionOriginId.isEqualWithoutVersion(id)) {
       throw new BitError(
-        `version "${versionStr}" seem to be originated from "${versionOriginId.toString()}", not from "${id.toStringWithoutVersion()}"`
+        `version "${versionStr}" seems to have originated from "${versionOriginId.toString()}", not from "${id.toStringWithoutVersion()}"`
       );
     }
     const snap = await this.getHeadSnap(modelComponent);

--- a/scopes/scope/version-history/version-history-cmd.ts
+++ b/scopes/scope/version-history/version-history-cmd.ts
@@ -97,7 +97,7 @@ export class VersionHistoryGraphCmd implements Command {
     [
       'l',
       'layout <name>',
-      'GraphVis layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
+      'Graphviz layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
     ],
     ['', 'limit <number>', 'limit the number of nodes in the graph (starting from the heads)'],
   ] as CommandOptions;

--- a/scopes/toolbox/fs/link-or-symlink/create-link-or-symlink.ts
+++ b/scopes/toolbox/fs/link-or-symlink/create-link-or-symlink.ts
@@ -48,7 +48,7 @@ export function createLinkOrSymlink(
     const winMsg = IS_WINDOWS ? ' (or maybe copy)' : '';
     const errorHeader = componentId ? `failed to link a component ${componentId}` : 'failed to generate a symlink';
     throw new BitError(`${errorHeader}.
-Symlink${winMsg} from: ${srcPath}, to: ${destPath} was failed.
+Symlink${winMsg} from: ${srcPath}, to: ${destPath} failed.
 Please use "--log=trace" flag to get more info about the error.
 Original error: ${err}`);
   }

--- a/scopes/toolbox/time/timer/exceptions/timer-not-started.ts
+++ b/scopes/toolbox/time/timer/exceptions/timer-not-started.ts
@@ -1,5 +1,5 @@
 export class TimerNotStarted extends Error {
   constructor() {
-    super('timer already running');
+    super('timer not started');
   }
 }

--- a/scopes/typescript/aspect-docs/typescript/typescript.mdx
+++ b/scopes/typescript/aspect-docs/typescript/typescript.mdx
@@ -70,4 +70,4 @@ In the last example, a custom tsconfig.json was merged to the builtin tsconfig.j
 }
 ```
 
-Some more props were changed as well to accomodate this env
+Some more props were changed as well to accommodate this env

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -52,7 +52,7 @@ includes hot module reloading for development.`;
       'rebuild the UI (useful e.g. when updating the workspace UI - can use the dev flag for HMR in this case)',
     ],
     ['', 'skip-ui-build', 'skip building UI'],
-    ['v', 'verbose', 'show verbose output for inspection and prints stack trace'],
+    ['v', 'verbose', 'show verbose output for inspection and print stack trace'],
     ['n', 'no-browser', 'do not automatically open browser when ready'],
     ['', 'show-internal-urls', 'show urls for all internal dev servers'],
     ['', 'skip-compilation', 'skip the auto-compilation before starting the web-server'],

--- a/scopes/webpack/modules/generate-externals/generate-externals.docs.mdx
+++ b/scopes/webpack/modules/generate-externals/generate-externals.docs.mdx
@@ -3,7 +3,7 @@ labels: ['typescript', 'utils', 'webpack']
 description: 'generate webpack externals configuration by a list.'
 ---
 
-Get's a list of dependencies and create an externals object out of them
+Gets a list of dependencies and create an externals object out of them
 
 API:
 
@@ -33,7 +33,7 @@ import { generateExternals } from './generate-externals';
 
 ```js live
 () => {
-  const externals = new generateExternals(['dep1', 'dep2'], { transformName: (depName) => depName.captialize() });
+  const externals = new generateExternals(['dep1', 'dep2'], { transformName: (depName) => depName.capitalize() });
 
   const dataContent = new JSONFormatter(externals, 2);
   return (

--- a/scopes/webpack/modules/generate-externals/generate-externals.docs.mdx
+++ b/scopes/webpack/modules/generate-externals/generate-externals.docs.mdx
@@ -33,7 +33,9 @@ import { generateExternals } from './generate-externals';
 
 ```js live
 () => {
-  const externals = new generateExternals(['dep1', 'dep2'], { transformName: (depName) => depName.capitalize() });
+  const externals = new generateExternals(['dep1', 'dep2'], {
+    transformName: (depName) => depName.charAt(0).toUpperCase() + depName.slice(1),
+  });
 
   const dataContent = new JSONFormatter(externals, 2);
   return (

--- a/scopes/webpack/modules/generate-externals/generate-externals.ts
+++ b/scopes/webpack/modules/generate-externals/generate-externals.ts
@@ -3,7 +3,7 @@ export type GenerateExternalsOptions = {
 };
 
 /**
- * Get's a list of dependencies and create an externals object out of them
+ * Gets a list of dependencies and create an externals object out of them
  * @param dependencies
  * @param options
  * @returns

--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -60,7 +60,7 @@ automatically imports components, compiles components, links to node_modules, an
     ['', 'skip-compile', 'do not compile components'],
     ['', 'skip-write-config-files', 'do not write config files (such as eslint, tsconfig, prettier, etc...)'],
     ['a', 'add-missing-deps', 'install all missing dependencies'],
-    ['', 'skip-unavailable', 'when adding missing dependencies, skip those that are not found in the regisry'],
+    ['', 'skip-unavailable', 'when adding missing dependencies, skip those that are not found in the registry'],
     ['', 'add-missing-peers', 'install all missing peer dependencies'],
     [
       '',
@@ -69,8 +69,16 @@ automatically imports components, compiles components, links to node_modules, an
     ],
     ['', 'no-optional [noOptional]', 'do not install optional dependencies (works with pnpm only)'],
     ['', 'lockfile-only', 'dependencies are not written to node_modules. Only the lockfile is updated'],
-    ['', 'allow-scripts [pkgNames]', 'a comma separated list of package names that are allowed to run installation scripts'],
-    ['', 'disallow-scripts [pkgNames]', 'a comma separated list of package names that are NOT allowed to run installation scripts'],
+    [
+      '',
+      'allow-scripts [pkgNames]',
+      'a comma separated list of package names that are allowed to run installation scripts',
+    ],
+    [
+      '',
+      'disallow-scripts [pkgNames]',
+      'a comma separated list of package names that are NOT allowed to run installation scripts',
+    ],
   ] as CommandOptions;
 
   constructor(
@@ -168,7 +176,7 @@ automatically imports components, compiles components, links to node_modules, an
     return allowScripts;
   }
 
-  private * _parseCommaSeparatedPkgList(pkgList: string): IterableIterator<string> {
+  private *_parseCommaSeparatedPkgList(pkgList: string): IterableIterator<string> {
     for (const pkgName of pkgList.split(',')) {
       const trimmed = pkgName.trim();
       if (trimmed) {

--- a/scopes/workspace/install/link/link.cmd.ts
+++ b/scopes/workspace/install/link/link.cmd.ts
@@ -105,7 +105,7 @@ useful for development when components need to reference each other or when debu
   async json([ids]: [string[]], opts: LinkCommandOpts): Promise<WorkspaceLinkResults> {
     if (!this.workspace) throw new OutsideWorkspaceError();
     this.logger.console(
-      `Linking components and core aspects to node_modules for workspaces: '${chalk.cyan(this.workspace.name)}'`
+      `Linking components and core aspects to node_modules for workspace: '${chalk.cyan(this.workspace.name)}'`
     );
 
     const linkOpts: WorkspaceLinkOptions = {

--- a/scopes/workspace/modules/match-pattern/exceptions/dir-pattern-with-star.ts
+++ b/scopes/workspace/modules/match-pattern/exceptions/dir-pattern-with-star.ts
@@ -3,7 +3,7 @@ import { BitError } from '@teambit/bit-error';
 export class DirPatternWithStar extends BitError {
   constructor(readonly pattern: string) {
     super(
-      `variant "${pattern}" is not valid. glob patterns are not supported for file paths. by default variants applied to all sub-directories`
+      `variant "${pattern}" is not valid. glob patterns are not supported for file paths. by default variants are applied to all sub-directories`
     );
   }
 }

--- a/scopes/workspace/workspace-config-files/ws-config.cmd.ts
+++ b/scopes/workspace/workspace-config-files/ws-config.cmd.ts
@@ -182,7 +182,7 @@ function getWarningForNonImplementingEnvs(envsNotImplementing: string[]) {
   const message =
     chalk.yellow(`Bit cannot determine the correct contents for the config files to write. this may result in incorrect content.
 The following environments need to add support for config files: ${chalk.cyan(envsNotImplementing.join(', '))}.
-Read here how to correct and improve dev-ex - LINK
+consider updating these envs to implement config file writing to improve the dev experience.
 
 `);
   return message;

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -202,9 +202,7 @@ export class BitMap {
     const allVersions = Object.keys(config).filter((id) => id.startsWith(`${aspectId.toStringWithoutVersion()}@`));
     if (allVersions.length > 1) {
       throw new BitError(
-        `error: the same aspect ${
-          aspectId.toStringWithoutVersion
-        } configured multiple times for "${componentId.toString()}"\n${allVersions.join('\n')}`
+        `error: the same aspect ${aspectId.toStringWithoutVersion()} configured multiple times for "${componentId.toString()}"\n${allVersions.join('\n')}`
       );
     }
     return allVersions.length === 1 ? allVersions[0] : undefined;

--- a/scopes/workspace/workspace/component-config-file/exceptions/already-exists.ts
+++ b/scopes/workspace/workspace/component-config-file/exceptions/already-exists.ts
@@ -2,6 +2,6 @@ import { BitError } from '@teambit/bit-error';
 
 export class AlreadyExistsError extends BitError {
   constructor(filePath: string) {
-    super(`config file at ${filePath} already exist. use override in case you want to override it`);
+    super(`config file at ${filePath} already exists. use override in case you want to override it`);
   }
 }

--- a/scopes/workspace/workspace/eject-conf.cmd.ts
+++ b/scopes/workspace/workspace/eject-conf.cmd.ts
@@ -26,9 +26,9 @@ ${PATTERN_HELP('eject-conf')}`;
     [
       'p',
       'propagate',
-      'mark propagate true in the config file, so that component.json configs will be merge with workspace configs',
+      'mark propagate true in the config file, so that component.json configs will be merged with workspace configs',
     ],
-    ['o', 'override', 'override file if exist'],
+    ['o', 'override', 'override the file if it exists'],
   ] as CommandOptions;
 
   constructor(private workspace: Workspace) {}

--- a/scopes/workspace/workspace/envs-subcommands/envs-unset.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-unset.cmd.ts
@@ -16,8 +16,8 @@ export class EnvsUnsetCmd implements Command {
   options = [];
   group = 'component-config';
   extendedDescription = `keep in mind that this doesn't remove envs that are set via variants.
-in only removes envs that appear in the .bitmap file, which were previously configured via "bit env set".
-the purpose of this command is to reset previously assigned envs to either allow variants configure the env or use the base node env.
+it only removes envs that appear in the .bitmap file, which were previously configured via "bit env set".
+the purpose of this command is to reset previously assigned envs to either allow variants to configure the env or use the base node env.
 ${PATTERN_HELP('env unset')}`;
 
   constructor(private workspace: Workspace) {}

--- a/scopes/workspace/workspace/scope-subcommands/scope-set.cmd.ts
+++ b/scopes/workspace/workspace/scope-subcommands/scope-set.cmd.ts
@@ -18,7 +18,7 @@ export class ScopeSetCmd implements Command {
   options = [];
   group = 'component-config';
   extendedDescription = `default scopes for components are set in the bitmap file. the default scope for a workspace is set in the workspace.jsonc.
-a component is set with a scope (as oppose to default scope) only once it is versioned.'
+a component is set with a scope (as opposed to default scope) only once it is versioned.
 
 ${PATTERN_HELP('scope set scope-name')}`;
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -284,7 +284,7 @@ export class Workspace implements ComponentFactory {
     if (this.consumer.isLegacy) return;
     if (isEmpty(this.config))
       throw new BitError(
-        `fatal: workspace config is empty. probably one of bit files is missing. please run "bit init" to rewrite them`
+        `fatal: workspace config is empty. probably one of the bit files is missing. please run "bit init" to rewrite them`
       );
     const defaultScope = this.config.defaultScope;
     if (!defaultScope) throw new BitError('defaultScope is missing');
@@ -1210,7 +1210,7 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
       return envIdFromConfig === env;
     });
     if (!foundComps.length && throwIfNotFound) {
-      throw new BitError(`unable to find components that using "${env}" env.
+      throw new BitError(`unable to find components that use "${env}" env.
 the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}`);
     }
     return foundComps;


### PR DESCRIPTION
Proofread user-facing text (CLI help, error messages, aspect docs, generator templates) and fixed typos and grammar. The generated `cli-reference.*` files were regenerated to match.

Beyond plain typos, a few were actual defects:
- `TimerNotStarted` threw `'timer already running'` — copy-pasted from its sibling, reporting the opposite condition.
- An error interpolated `toStringWithoutVersion` without `()`, printing the function source instead of the id.
- A troubleshooting URL had a stray space after `BASE_DOCS_DOMAIN` (already ends in `/`), rendering a broken split link.
- Correcting `DEPRECATE.` → `DEPRECATED.` on a login flag re-enables the doc generator's deprecated-flag filter, so that flag no longer shows up in the generated skill reference.
- `envs.cmd.ts` declared `examples` as a type annotation instead of a value, so the `envs get` example never rendered — now fixed.
- `ws-config` printed a literal `LINK` placeholder in its warning — reworded to be self-contained.
- The `generate-externals` live doc example called `depName.capitalize()` (not a real String method), which threw at runtime — replaced with a working inline transform.

E2E wildcard-no-match assertions were updated to match the reworded `NoIdMatchPattern` message.
