### PR TITLE
chore(deps): update typescript-compiler to 3.0.2

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -339,7 +339,7 @@
         "@teambit/toolbox.time.time-format": "^0.0.502",
         "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.10",
         "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.2",
-        "@teambit/typescript.typescript-compiler": "^3.0.1",
+        "@teambit/typescript.typescript-compiler": "^3.0.2",
         "@teambit/ui-foundation.ui.constants.z-indexes": "^0.0.504",
         "@teambit/ui-foundation.ui.corner": "^0.0.520",
         "@teambit/ui-foundation.ui.empty-component-gallery": "^0.0.512",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -339,7 +339,7 @@
         "@teambit/toolbox.time.time-format": "^0.0.502",
         "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.10",
         "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.2",
-        "@teambit/typescript.typescript-compiler": "^3.0.0",
+        "@teambit/typescript.typescript-compiler": "^3.0.1",
         "@teambit/ui-foundation.ui.constants.z-indexes": "^0.0.504",
         "@teambit/ui-foundation.ui.corner": "^0.0.520",
         "@teambit/ui-foundation.ui.empty-component-gallery": "^0.0.512",


### PR DESCRIPTION
Bumps `@teambit/typescript.typescript-compiler` to 3.0.2, which includes two fixes:

**Progress counter** — `bit compile`'s progress counter could show a numerator larger than its total (e.g. `(12/4)`). The total was based on this env's seeder capsules, while progress is logged once per invalidated project the TS SolutionBuilder visits across the whole graph (including cross-env dependency capsules). The denominator now uses the full build graph. Display-only.

**Skip project references to non-TypeScript capsules** — when a component compiled with TypeScript project references depends on a component built by a non-TypeScript compiler (e.g. a Babel-only env), that dependency's capsule has no `tsconfig.json`, so `tsc --build` failed with `TS5083: Cannot read file '.../tsconfig.json'`. The build now prunes references to capsules without a tsconfig, letting those dependencies resolve through `node_modules` instead.
