### PR TITLE
fix(envs): recognize a component as an env by its .bit-env plugin file

### DIFF
--- a/e2e/harmony/env.e2e.ts
+++ b/e2e/harmony/env.e2e.ts
@@ -103,6 +103,37 @@ describe('env command', function () {
       });
     });
   });
+  describe('env defined only by a .bit-env plugin file, before it was ever loaded', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.fs.outputFile(
+        'my-env/my-env.bit-env.ts',
+        `export class MyEnv {
+  name = 'my-env';
+}
+export default new MyEnv();
+`
+      );
+      helper.fs.outputFile('my-env/index.ts', `export { MyEnv } from './my-env.bit-env';`);
+      helper.command.addComponent('my-env');
+      helper.command.compile();
+    });
+    // previously, a component was recognized as an env only after it was loaded as an aspect,
+    // which happened only once its own env (env-of-env, e.g. teambit.envs/env or
+    // bitdev.general/envs/bit-env) was configured and loadable. a just-created env with no
+    // env-of-env failed "bit env set" with "the component <id> is not an env", although the
+    // *.bit-env.* plugin file is what defines the env instance and identifies it as an env.
+    it('bit env set should recognize it as an env', () => {
+      expect(() => helper.command.setEnv('comp1', 'my-env')).to.not.throw();
+    });
+    it('the env should be loaded as an aspect and set as the component env', () => {
+      expect(helper.env.getComponentEnv('comp1')).to.have.string('my-env');
+    });
+    it('bit snap should work', () => {
+      expect(() => helper.command.snapAllComponentsWithoutBuild()).to.not.throw();
+    });
+  });
   describe('bit env replace', () => {
     describe('replacing a failed-loaded env', () => {
       before(() => {

--- a/scopes/envs/envs/env.plugin.ts
+++ b/scopes/envs/envs/env.plugin.ts
@@ -9,6 +9,12 @@ import { ServiceHandlerContext as EnvContext } from './services/service-handler-
 import type { Env } from './env-interface';
 import type { EnvsRegistry, ServicesRegistry } from './environments.main.runtime';
 
+/**
+ * the file that defines the env instance. a component containing such a file is an env by
+ * definition (symmetric to how apps are detected by their `*.bit-app.*` files).
+ */
+export const BIT_ENV_PATTERN = '*.bit-env.*';
+
 export class EnvPlugin implements PluginDefinition {
   constructor(
     private envSlot: EnvsRegistry,
@@ -18,7 +24,7 @@ export class EnvPlugin implements PluginDefinition {
     private harmony: Harmony
   ) {}
 
-  pattern = '*.bit-env.*';
+  pattern = BIT_ENV_PATTERN;
 
   runtimes = [MainRuntime.name];
 

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -36,7 +36,7 @@ import { EnvServiceList } from './env-service-list';
 import { EnvsCmd, GetEnvCmd, ListEnvsCmd } from './envs.cmd';
 import { EnvFragment } from './env.fragment';
 import { EnvNotFound, EnvNotConfiguredForComponent } from './exceptions';
-import { EnvPlugin } from './env.plugin';
+import { EnvPlugin, BIT_ENV_PATTERN } from './env.plugin';
 import { EnvJsoncDetector } from './env-jsonc.detector';
 
 export type EnvJsonc = {
@@ -310,6 +310,16 @@ export class EnvsMain {
 
     if (!envJson) return false;
     return true;
+  }
+
+  /**
+   * whether the component has an env plugin file (`*.bit-env.*`). this file is what defines the
+   * env instance (the EnvPlugin loads it when the component is loaded as an aspect), so its
+   * presence identifies the component as an env even before it was ever loaded - symmetric to
+   * how apps are detected by their `*.bit-app.*` files.
+   */
+  hasEnvPluginFile(component: Component): boolean {
+    return component.filesystem.byGlob([BIT_ENV_PATTERN]).length > 0;
   }
 
   getEnvManifest(envComponent: Component): ResolvedEnvJsonc | undefined {
@@ -1045,7 +1055,11 @@ if needed, use "bit env set" command to align the env id`;
     return (
       this.isUsingEnvEnv(component) ||
       this.isEnvRegistered(component.id.toString()) ||
-      this.isEnvRegistered(component.id.toStringWithoutVersion())
+      this.isEnvRegistered(component.id.toStringWithoutVersion()) ||
+      // the env plugin file defines the env instance - the component is an env by definition.
+      // this is also the only reliable signal when the env was not loaded yet (e.g. "bit env-set"
+      // to a just-created env whose own env is not installed, so its env data has no 'env' type).
+      this.hasEnvPluginFile(component)
     );
   }
 

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -506,10 +506,14 @@ export class WorkspaceComponentLoader {
       // a component with an env plugin file (*.bit-env.*) is an env by definition. the env-data
       // type can't be relied on when the env's own env was not loaded yet (e.g. a just-created
       // env whose env-of-env is not installed) - the env-data falls back to the default env.
-      const hasEnvPluginFile = this.envs.hasEnvPluginFile(component);
+      // it's the last operand on purpose - the files are scanned only when the env-data gave no
+      // answer.
       if (
         opts.loadEnvs &&
-        (envsData?.data?.services || envsData?.data?.self || envsData?.data?.type === 'env' || hasEnvPluginFile)
+        (envsData?.data?.services ||
+          envsData?.data?.self ||
+          envsData?.data?.type === 'env' ||
+          this.envs.hasEnvPluginFile(component))
       ) {
         aspectIds.push(idStr);
         this.componentLoadedSelfAsAspects.set(idStr, true);

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -503,7 +503,14 @@ export class WorkspaceComponentLoader {
         this.componentLoadedSelfAsAspects.set(idStr, true);
       }
       const envsData = component.state.aspects.get(EnvsAspect.id);
-      if (opts.loadEnvs && (envsData?.data?.services || envsData?.data?.self || envsData?.data?.type === 'env')) {
+      // a component with an env plugin file (*.bit-env.*) is an env by definition. the env-data
+      // type can't be relied on when the env's own env was not loaded yet (e.g. a just-created
+      // env whose env-of-env is not installed) - the env-data falls back to the default env.
+      const hasEnvPluginFile = this.envs.hasEnvPluginFile(component);
+      if (
+        opts.loadEnvs &&
+        (envsData?.data?.services || envsData?.data?.self || envsData?.data?.type === 'env' || hasEnvPluginFile)
+      ) {
         aspectIds.push(idStr);
         this.componentLoadedSelfAsAspects.set(idStr, true);
       }


### PR DESCRIPTION
A just-created env whose env-of-env (e.g. `teambit.envs/env` or `bitdev.general/envs/bit-env`) is not configured or not installed yet was not recognized as an env: `bit env set` failed with "the component X is not an env", and the component was never self-loaded as an aspect. The `*.bit-env.*` plugin file is what defines the env instance, so its presence identifies the component as an env by definition - symmetric to how apps are detected by their `*.bit-app.*` files.

- export the pattern as `BIT_ENV_PATTERN` and add `EnvsMain.hasEnvPluginFile()`
- use it in `isEnv()` (fixes `bit env set`) and in `loadCompsAsAspects()` (the env self-loads as an aspect)
- e2e reproduces the issue: fails on master, passes with the fix