### PR TITLE
fix(minimal-mode): suppress all notifications, including apollo errors

### DIFF
--- a/scopes/ui-foundation/notifications/aspect/notification.ui.runtime.tsx
+++ b/scopes/ui-foundation/notifications/aspect/notification.ui.runtime.tsx
@@ -1,7 +1,7 @@
 import type { UiUI } from '@teambit/ui';
 import { UIAspect, UIRuntime } from '@teambit/ui';
 import type { ReactNode } from 'react';
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { v1 } from 'uuid';
 
 import { NotificationContext } from '@teambit/ui-foundation.ui.notifications.notification-context';
@@ -89,6 +89,12 @@ export default class NotificationUI implements NotificationsStore {
     const isMinimal = searchParams.get('minimal-mode') === 'true';
     this.dispatch = dispatch;
     this.isMinimal = isMinimal;
+
+    // drop any queued messages when entering minimal mode, so toggling minimal
+    // mode back off later doesn't resurrect stale notifications.
+    useEffect(() => {
+      if (isMinimal) dispatch({ type: 'clear' });
+    }, [isMinimal]);
 
     if (isMinimal) return null;
 

--- a/scopes/ui-foundation/notifications/aspect/notification.ui.runtime.tsx
+++ b/scopes/ui-foundation/notifications/aspect/notification.ui.runtime.tsx
@@ -7,6 +7,7 @@ import { v1 } from 'uuid';
 import { NotificationContext } from '@teambit/ui-foundation.ui.notifications.notification-context';
 import type { NotificationCenterProps } from '@teambit/ui-foundation.ui.notifications.notification-center';
 import { NotificationCenter } from '@teambit/ui-foundation.ui.notifications.notification-center';
+import { useSearchParams } from 'react-router-dom';
 import type { NotificationsStore } from '@teambit/ui-foundation.ui.notifications.store';
 import { MessageLevel } from '@teambit/ui-foundation.ui.notifications.store';
 import type { NotificationAction } from './notification-reducer';
@@ -32,8 +33,16 @@ export default class NotificationUI implements NotificationsStore {
 
   private dispatch?: React.Dispatch<NotificationAction>;
 
+  /**
+   * when the workspace ui runs in minimal mode, no notification should reach the screen,
+   * no matter which aspect (or external hook, e.g. `useDataQuery`) produced it.
+   */
+  private isMinimal = false;
+
   /** adds a full message to the log */
   add = (message: string, level: MessageLevel) => {
+    if (this.isMinimal) return '';
+
     const id = v1();
 
     this.dispatch?.({
@@ -76,7 +85,12 @@ export default class NotificationUI implements NotificationsStore {
   private render = (props: Omit<NotificationCenterProps, 'notifications'>) => {
     // this code assumes a single place of render per instance of NotificationUI
     const [messages, dispatch] = useReducer(notificationReducer, []);
+    const [searchParams] = useSearchParams();
+    const isMinimal = searchParams.get('minimal-mode') === 'true';
     this.dispatch = dispatch;
+    this.isMinimal = isMinimal;
+
+    if (isMinimal) return null;
 
     return <NotificationCenter {...props} notifications={messages} />;
   };


### PR DESCRIPTION
## Problem

Users reported toasts stacking up in minimal mode — specifically repeated `ApolloError: Response not successful: Received status code 404` notifications (see reported screenshot).

The earlier fix (#9950) only suppressed the *component added/removed* toasts by gating `NotificationsBinder` with `!isMinimal` in `workspace.tsx`. GraphQL/Apollo errors reach the notification store through a completely different path: the external `useDataQuery` hook calls `notifications.error(apolloErrorToString(error))` directly, and it does so *during render*, so a failing query re-fires the toast on every re-render — producing the pile seen in the report.

## Fix

Guard at the **source** — the notification store — so every producer is covered, not just the two known call sites:

- The store reads the `minimal-mode` URL search param during its HUD render.
- `add()` becomes a no-op when minimal mode is active, so `log` / `warn` / `error` / `success` all short-circuit.
- `NotificationCenter` renders `null` in minimal mode (belt-and-suspenders — nothing on screen even if a message slipped in).

The HUD item renders before the route components in the React tree, so `isMinimal` is set before any `useDataQuery` in a route can fire. The param is read directly via `react-router-dom` rather than the workspace-scoped `useWorkspaceMode` hook to avoid inverting the `ui-foundation` → `workspace` layering.

The pre-existing `!isMinimal` gate on `NotificationsBinder` in `workspace.tsx` is left in place (now redundant but harmless).

## Verification

- `tsc --noEmit` + `oxlint` clean for the changed file.
- Verified in a sample workspace: no toasts appear with `minimal-mode=true`, normal notifications still work without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)