### PR TITLE
chore: update core-aspect-env to 1.0.2

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -21,21 +21,30 @@
         "scope": "teambit.api-reference",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1096",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
@@ -49,7 +58,10 @@
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -196,14 +208,20 @@
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
@@ -217,7 +235,10 @@
         "scope": "teambit.harmony",
         "version": "2.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "bit-map": {
         "name": "bit-map",
@@ -231,7 +252,10 @@
         "scope": "teambit.pipelines",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
@@ -245,56 +269,80 @@
         "scope": "teambit.compilation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1445",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1066",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.455",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci"
+        "rootDir": "scopes/git/ci",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.570",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1352",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.211",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server"
+        "rootDir": "scopes/mcp/cli-mcp-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
@@ -322,56 +370,80 @@
         "scope": "teambit.cloud",
         "version": "0.0.1362",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.780",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.455",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor"
+        "rootDir": "scopes/component/component-descriptor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-diff": {
         "name": "component-diff",
@@ -399,7 +471,10 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
@@ -413,21 +488,30 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -441,28 +525,40 @@
         "scope": "teambit.compositions",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1527",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.932",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.233",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store"
+        "rootDir": "components/config-store",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "constants": {
         "name": "constants",
@@ -511,7 +607,10 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "dependency-graph": {
         "name": "dependency-graph",
@@ -525,28 +624,40 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "dev-files": {
         "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "doc-parser": {
         "name": "doc-parser",
@@ -560,14 +671,20 @@
         "scope": "teambit.docs",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.750",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor"
+        "rootDir": "scopes/harmony/doctor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "e2e-helper": {
         "name": "e2e-helper",
@@ -581,7 +698,10 @@
         "scope": "teambit.workspace",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
@@ -609,21 +729,30 @@
         "scope": "teambit.envs",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint"
+        "rootDir": "scopes/defender/eslint",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
@@ -644,14 +773,20 @@
         "scope": "teambit.scope",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1451",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "extension-data": {
         "name": "extension-data",
@@ -665,14 +800,20 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
@@ -728,7 +869,10 @@
         "scope": "teambit.generator",
         "version": "1.0.1066",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "get-bit-version": {
         "name": "get-bit-version",
@@ -742,35 +886,50 @@
         "scope": "teambit.git",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1356",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
@@ -833,63 +992,90 @@
         "scope": "teambit.harmony",
         "version": "0.0.778",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer"
+        "rootDir": "scopes/harmony/host-initializer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1066",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.64",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize"
+        "rootDir": "scopes/component/internalize",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
@@ -903,7 +1089,10 @@
         "scope": "teambit.lanes",
         "version": "1.0.1085",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
@@ -917,14 +1106,20 @@
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "loader": {
         "name": "loader",
@@ -952,21 +1147,30 @@
         "scope": "teambit.lanes",
         "version": "1.0.1085",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1068",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.870",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -1253,21 +1457,30 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "network": {
         "name": "network",
@@ -1288,7 +1501,10 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "node": {
         "name": "node",
@@ -1302,14 +1518,20 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.572",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects"
+        "rootDir": "scopes/scope/objects",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
@@ -1323,7 +1545,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.1355",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1365,7 +1590,10 @@
         "scope": "teambit.pkg",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
@@ -1386,14 +1614,20 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1100",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
@@ -1407,7 +1641,10 @@
         "scope": "teambit.preview",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
@@ -1421,7 +1658,10 @@
         "scope": "teambit.harmony",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "react": {
         "name": "react",
@@ -1435,7 +1675,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "readme": {
         "name": "readme",
@@ -1449,7 +1692,10 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "remote-actions": {
         "name": "remote-actions",
@@ -1470,14 +1716,20 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1066",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -1498,14 +1750,20 @@
         "scope": "teambit.cloud",
         "version": "0.0.148",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple"
+        "rootDir": "scopes/cloud/ripple",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "scope-api": {
         "name": "scope-api",
@@ -1519,14 +1777,20 @@
         "scope": "teambit.workspace",
         "version": "0.0.284",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "snap-distance": {
         "name": "snap-distance",
@@ -1540,7 +1804,10 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "sources": {
         "name": "sources",
@@ -1554,14 +1821,20 @@
         "scope": "teambit.component",
         "version": "1.0.1066",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1089",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
@@ -1617,7 +1890,10 @@
         "scope": "teambit.harmony",
         "version": "0.0.1445",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
@@ -1638,14 +1914,20 @@
         "scope": "teambit.scope",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
@@ -1680,7 +1962,10 @@
         "scope": "teambit.component",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
@@ -1701,14 +1986,20 @@
         "scope": "teambit.typescript",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui"
+        "rootDir": "scopes/ui-foundation/ui",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "ui/aspect-box": {
         "name": "ui/aspect-box",
@@ -2121,7 +2412,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "utils": {
         "name": "utils",
@@ -2135,70 +2429,100 @@
         "scope": "teambit.defender",
         "version": "0.0.301",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator"
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1620",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.857",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history"
+        "rootDir": "scopes/scope/version-history",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.431",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue"
+        "rootDir": "scopes/vue/vue",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1656",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1065",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/.bitmap
+++ b/.bitmap
@@ -23,7 +23,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/api-reference",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "api-server": {
@@ -33,7 +33,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/api-server",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "application": {
@@ -43,7 +43,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/application",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "array/duplications-finder": {
@@ -60,7 +60,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "aspect-docs/babel": {
@@ -210,7 +210,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect-loader",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "babel": {
@@ -220,7 +220,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/babel",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "babel/bit-react-transformer": {
@@ -237,7 +237,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "bit-map": {
@@ -254,7 +254,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/builder",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "builder-data": {
@@ -271,7 +271,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/bundler",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "cache": {
@@ -281,7 +281,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cache",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "changelog": {
@@ -291,7 +291,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/changelog",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "checkout": {
@@ -301,7 +301,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/checkout",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "ci": {
@@ -311,7 +311,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/git/ci",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "clear-cache": {
@@ -321,7 +321,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/clear-cache",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "cli": {
@@ -331,7 +331,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "cli-mcp-server": {
@@ -341,7 +341,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/mcp/cli-mcp-server",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "cli-table": {
@@ -372,7 +372,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/cloud/cloud",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "code": {
@@ -382,7 +382,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/code",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "command-bar": {
@@ -392,7 +392,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/command-bar",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "community": {
@@ -402,7 +402,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/community/community",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "compiler": {
@@ -412,7 +412,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/compiler",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component": {
@@ -422,7 +422,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component-compare": {
@@ -432,7 +432,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-compare",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component-descriptor": {
@@ -442,7 +442,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-descriptor",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component-diff": {
@@ -473,7 +473,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-log",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component-package-version": {
@@ -490,7 +490,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-sizer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component-tree": {
@@ -500,7 +500,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-tree",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "component-writer": {
@@ -510,7 +510,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-writer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "composition-card": {
@@ -527,7 +527,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/compositions",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "config": {
@@ -537,7 +537,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/config",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "config-merger": {
@@ -547,7 +547,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/config-merger",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "config-store": {
@@ -557,7 +557,7 @@
         "mainFile": "index.ts",
         "rootDir": "components/config-store",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "constants": {
@@ -609,7 +609,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependencies",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "dependency-graph": {
@@ -626,7 +626,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependency-resolver",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "deprecation": {
@@ -636,7 +636,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/deprecation",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "dev-files": {
@@ -646,7 +646,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/dev-files",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "diagnostic": {
@@ -656,7 +656,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/diagnostic",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "doc-parser": {
@@ -673,7 +673,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/docs",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "doctor": {
@@ -683,7 +683,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/doctor",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "e2e-helper": {
@@ -700,7 +700,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/eject",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "entities/lane-diff": {
@@ -731,7 +731,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/env",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "envs": {
@@ -741,7 +741,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/envs",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "eslint": {
@@ -751,7 +751,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/eslint",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "eslint-config-bit-react": {
@@ -775,7 +775,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/export",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "express": {
@@ -785,7 +785,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/express",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "extension-data": {
@@ -802,7 +802,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/forking",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "formatter": {
@@ -812,7 +812,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/formatter",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "fs/extension-getter": {
@@ -871,7 +871,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/generator/generator",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "get-bit-version": {
@@ -888,7 +888,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/git/git",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "global-config": {
@@ -898,7 +898,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/global-config",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "graph": {
@@ -908,7 +908,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/graph",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "graphql": {
@@ -918,7 +918,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/graphql",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "harmony-ui-app": {
@@ -928,7 +928,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "hooks/use-cloud-scopes": {
@@ -994,7 +994,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/host-initializer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "importer": {
@@ -1004,7 +1004,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/importer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "insights": {
@@ -1014,7 +1014,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/insights",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "install": {
@@ -1024,7 +1024,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/install",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "internalize": {
@@ -1034,7 +1034,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/internalize",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "ipc-events": {
@@ -1044,7 +1044,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/ipc-events",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "isolator": {
@@ -1054,7 +1054,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/isolator",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "issues": {
@@ -1064,7 +1064,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/issues",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "jest": {
@@ -1074,7 +1074,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/jest",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "json/jsonc-utils": {
@@ -1091,7 +1091,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/lanes",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "legacy-component-log": {
@@ -1108,7 +1108,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/linter",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "lister": {
@@ -1118,7 +1118,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/lister",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "loader": {
@@ -1149,7 +1149,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/merge-lanes",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "merging": {
@@ -1159,7 +1159,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/merging",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "mocha": {
@@ -1169,7 +1169,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/mocha",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "model/composition-id": {
@@ -1459,7 +1459,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/mover",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "multi-compiler": {
@@ -1469,7 +1469,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/multi-compiler",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "multi-tester": {
@@ -1479,7 +1479,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/multi-tester",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "network": {
@@ -1503,7 +1503,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/new-component-helper",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "node": {
@@ -1520,7 +1520,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/notifications/aspect",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "objects": {
@@ -1530,7 +1530,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/objects",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
@@ -1547,7 +1547,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/panels",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "panels/composition-gallery": {
@@ -1592,7 +1592,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/pkg/pkg",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "plugins/inject-head-webpack-plugin": {
@@ -1616,7 +1616,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/pnpm",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "prettier": {
@@ -1626,7 +1626,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/prettier",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "prettier/config-mutator": {
@@ -1643,7 +1643,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/preview",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "promise/map-pool": {
@@ -1660,7 +1660,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/pubsub",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "react": {
@@ -1677,7 +1677,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/react-router/react-router",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "readme": {
@@ -1694,7 +1694,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/refactoring",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "remote-actions": {
@@ -1718,7 +1718,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/remove",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "renaming": {
@@ -1728,7 +1728,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/renaming",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "renderers/default-node-renderers": {
@@ -1752,7 +1752,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/cloud/ripple",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "schema": {
@@ -1762,7 +1762,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/semantics/schema",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "scope-api": {
@@ -1779,7 +1779,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/scripts",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "sidebar": {
@@ -1789,7 +1789,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/sidebar",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "snap-distance": {
@@ -1806,7 +1806,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/snapping",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "sources": {
@@ -1823,7 +1823,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/stash",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "status": {
@@ -1833,7 +1833,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/status",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "string/capitalize": {
@@ -1892,7 +1892,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/logger",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "teambit.legacy/logger": {
@@ -1916,7 +1916,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/scope",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "tester": {
@@ -1926,7 +1926,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/tester",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "testing/load-aspect": {
@@ -1964,7 +1964,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/tracker",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "ts-server": {
@@ -1988,7 +1988,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/typescript",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "ui": {
@@ -1998,7 +1998,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/ui",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "ui/aspect-box": {
@@ -2414,7 +2414,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/user-agent",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "utils": {
@@ -2431,7 +2431,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/validator",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "variants": {
@@ -2441,7 +2441,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/variants",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "version-history": {
@@ -2451,7 +2451,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/version-history",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "vue-aspect": {
@@ -2461,7 +2461,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/vue/vue",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "watcher": {
@@ -2471,7 +2471,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/watcher",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "webpack": {
@@ -2481,7 +2481,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/webpack",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "worker": {
@@ -2491,7 +2491,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/worker",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "workspace": {
@@ -2501,7 +2501,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "workspace-config-files": {
@@ -2511,7 +2511,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace-config-files",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "yarn": {
@@ -2521,7 +2521,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/yarn",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@1.0.1": {}
+            "teambit.harmony/envs/core-aspect-env@1.0.2": {}
         }
     },
     "$schema-version": "17.0.0"


### PR DESCRIPTION
Updates `teambit.harmony/envs/core-aspect-env` to 1.0.2 (the fixed release) for all components using it. Done via `bit env update`.

1.0.1 broke the preview build (`GeneratePreview`) because its react/preview chain pulled `bit-react-transformer@1.0.48`, which pins the ESM-compiled `bit-component-meta@0.0.44`; 1.0.2 resolves a transformer that pins the CJS build, so `bit install` recompiles all components cleanly.