### PR TITLE
fix(ripple): show the real error in 'ripple errors' summary

### DIFF
--- a/scopes/cloud/ripple/ripple.main.runtime.ts
+++ b/scopes/cloud/ripple/ripple.main.runtime.ts
@@ -314,10 +314,12 @@ export class RippleMain {
    * to the end, so the whole error block is shown starting at where it began.
    */
   extractErrorsFromLog(messages: string[]): string[] {
-    // markers that denote the start of a real error section, matched case-insensitively.
-    // word boundaries around "error:" avoid false hits on serialized props such as
-    // "isUserError: true" (a common tail of a stringified error object) — matching that
-    // would slice from the very end and drop the real error printed above it.
+    // markers that denote the start of a real error section. most are matched
+    // case-insensitively; the named-Error marker is intentionally case-sensitive so it
+    // catches "TypeError:" / "ReferenceError:" at line start or after whitespace without
+    // matching serialized props such as "isUserError: true" (a common tail of a stringified
+    // error object) — matching that would slice from the very end and drop the real error
+    // printed above it.
     const markers: RegExp[] = [
       /errors were found/i,
       /failed task/i,
@@ -325,7 +327,8 @@ export class RippleMain {
       /responded with the following error/i,
       /unable to find object/i,
       /\berror:/i,
-      /FAIL/,
+      /(^|\s)[A-Z]\w*Error:/,
+      /\bfail\b/i,
     ];
     // pick the earliest line matching any marker (not the first marker in the list) so an
     // incidental late match can't truncate the error that appeared earlier in the log.

--- a/scopes/cloud/ripple/ripple.main.runtime.ts
+++ b/scopes/cloud/ripple/ripple.main.runtime.ts
@@ -310,15 +310,31 @@ export class RippleMain {
 
   /**
    * extract the error section from container log messages.
-   * looks for common error patterns in the build output.
+   * looks for common error markers in the build output and returns from the *earliest* one
+   * to the end, so the whole error block is shown starting at where it began.
    */
   extractErrorsFromLog(messages: string[]): string[] {
-    const patterns = ['errors were found', 'Failed task', 'threw an error', 'Error:', 'FAIL'];
-    for (const pattern of patterns) {
-      const idx = messages.findIndex((m) => stripAnsi(m).includes(pattern));
-      if (idx >= 0) {
-        return messages.slice(idx);
-      }
+    // markers that denote the start of a real error section, matched case-insensitively.
+    // word boundaries around "error:" avoid false hits on serialized props such as
+    // "isUserError: true" (a common tail of a stringified error object) — matching that
+    // would slice from the very end and drop the real error printed above it.
+    const markers: RegExp[] = [
+      /errors were found/i,
+      /failed task/i,
+      /threw an error/i,
+      /responded with the following error/i,
+      /unable to find object/i,
+      /\berror:/i,
+      /FAIL/,
+    ];
+    // pick the earliest line matching any marker (not the first marker in the list) so an
+    // incidental late match can't truncate the error that appeared earlier in the log.
+    const startIdx = messages.findIndex((m) => {
+      const clean = stripAnsi(m);
+      return markers.some((re) => re.test(clean));
+    });
+    if (startIdx >= 0) {
+      return messages.slice(startIdx);
     }
     // last resort: grab the last 30 lines if the log has content
     if (messages.length > 0) {


### PR DESCRIPTION
## Problem
`bit ripple errors` (without `--log`) printed a useless tail instead of the real build error:

```
  scope/some-component
      isUserError: true
    }
```

The real failure was only visible via `bit ripple errors --log`.

## Cause
`extractErrorsFromLog` scanned the container log for markers and returned `messages.slice(idx)` — everything from the first match to the end. Two compounding defects:

1. The case-sensitive `'Error:'` pattern matched the substring inside `isUserError: true` — a serialized property at the very end of the stringified error object. The real markers (lowercase `error:`, `ErrorFromRemote:`) never matched.
2. That accidental match sat near the end, so `slice(idx)` returned only the last couple of lines and discarded the real error printed above it.

## Fix
- Match markers case-insensitively.
- Use a word boundary on `error:` (`\berror:`) so it no longer matches `isUserError:`.
- Add real markers (`responded with the following error`, `unable to find object`).
- Select the **earliest** matching line instead of the first pattern in a priority list, so a late incidental match can't truncate the error above it.