### PR TITLE
chore(deps): bump @teambit/typescript.typescript-compiler to 4.0.0

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -339,7 +339,7 @@
         "@teambit/toolbox.time.time-format": "^0.0.502",
         "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.10",
         "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.2",
-        "@teambit/typescript.typescript-compiler": "^3.0.2",
+        "@teambit/typescript.typescript-compiler": "^4.0.0",
         "@teambit/ui-foundation.ui.constants.z-indexes": "^0.0.504",
         "@teambit/ui-foundation.ui.corner": "^0.0.520",
         "@teambit/ui-foundation.ui.empty-component-gallery": "^0.0.512",


### PR DESCRIPTION
Picks up typescript-compiler v4.0.0: the config writer's `compilerOptions` option is removed (it couldn't serialize TS's numeric enums to a valid tsconfig.json), and generated `include`/`exclude` paths are normalized to POSIX.

No call-site changes needed — this repo's envs (`react.env.ts`, `aspect.env.ts`) pass only `tsconfig` to `TypescriptConfigWriter`. All components compile clean with the new version.