### PR TITLE
docs: add release notes for v2.0.2, v2.0.11, and v2.0.26

### DIFF
--- a/releases-docs/guideline.md
+++ b/releases-docs/guideline.md
@@ -4,7 +4,7 @@ This document provides guidelines for writing consistent and effective release n
 
 ## File Structure
 
-Release-note files in `releases-docs/releases/` contain **section content only** — they start directly with the first `###` section header (see `v2.0.0.md` and later). This is the current convention and matches the `generate-release-notes` skill, which instructs saving the release content without any metadata header.
+Release-note files in `releases-docs/releases/` contain **section content only** — they start directly with the release content's first heading, with no metadata header (see `v2.0.0.md` and later). This is the current convention and matches the `generate-release-notes` skill, which instructs saving the release content without any metadata header. For the heading level to use, see [Section Headers](#section-headers) below (`###` preferred; `##` also acceptable, as in `v2.0.0.md`).
 
 > **Legacy metadata header (optional):** Some older release files (e.g. `v1.10.0.md`) begin with a metadata block followed by a `--` separator. It is no longer required, and new files should omit it:
 >

--- a/releases-docs/guideline.md
+++ b/releases-docs/guideline.md
@@ -4,22 +4,24 @@ This document provides guidelines for writing consistent and effective release n
 
 ## File Structure
 
-Each release note file follows this structure:
+Release-note files in `releases-docs/releases/` contain **section content only** — they start directly with the first `###` section header (see `v2.0.0.md` and later). This is the current convention and matches the `generate-release-notes` skill, which instructs saving the release content without any metadata header.
 
-```
-title: v{VERSION}
-tag: v{VERSION}
-draft: false
-prerelease: false
-immutable: false
-author: {AUTHOR_GITHUB_USERNAME}
-created: {ISO_DATE}
-published: {ISO_DATE}
-url: https://github.com/teambit/bit/releases/tag/v{VERSION}
---
-
-{RELEASE_CONTENT}
-```
+> **Legacy metadata header (optional):** Some older release files (e.g. `v1.10.0.md`) begin with a metadata block followed by a `--` separator. It is no longer required, and new files should omit it:
+>
+> ```
+> title: v{VERSION}
+> tag: v{VERSION}
+> draft: false
+> prerelease: false
+> immutable: false
+> author: {AUTHOR_GITHUB_USERNAME}
+> created: {ISO_DATE}
+> published: {ISO_DATE}
+> url: https://github.com/teambit/bit/releases/tag/v{VERSION}
+> --
+>
+> {RELEASE_CONTENT}
+> ```
 
 ## Section Order
 

--- a/releases-docs/releases/v2.0.11.md
+++ b/releases-docs/releases/v2.0.11.md
@@ -1,12 +1,12 @@
-## Features
+### New Features
 
 - **`bit import --write-to-empty-dir`** — instead of failing when the target directory is occupied, `bit import` writes the component into the next available empty directory (e.g. `renderers/class` → `renderers/class_1`). Aimed at non-interactive clients like the IDE plugin that can't prompt for `--override`; without the flag, behavior is unchanged (#10471)
 
-## Bug Fixes
+### Improvements
+
+- **Core environments on TypeScript 6** — `core-aspect-env`, `node-babel-mocha`, and `node-typescript-mocha` updated to their TS6 releases (`1.0.0`), and `@teambit/typescript.typescript-compiler` to `^3.0.0`. The new toolchain compiles with TypeScript 6.0.3, pins the ambient `@types` the mocha envs need (TS6 no longer auto-includes `node_modules/@types`), and publishes dist-pointing `exports`. Also bumps `@teambit/harmony` to `0.4.12` and migrates remaining components off the legacy core envs (#10473, #10466, #10463, #10470)
+
+### Bug Fixes
 
 - **`bit ci pr --keep-lane` config sync** — env migrations made on main now propagate to the PR lane _with their version_, instead of crashing the snap with `ExternalEnvWithoutVersion` or keeping the stale env (#10469)
 - **`bit ci pr --keep-lane` on fresh runners** — config sync from main now pre-fetches each component's common-ancestor object, so the 3-way merge actually lands instead of silently no-op'ing with `… was not found on the filesystem` (#10464)
-
-## Improvements
-
-- **Core environments on TypeScript 6** — `core-aspect-env`, `node-babel-mocha`, and `node-typescript-mocha` updated to their TS6 releases (`1.0.0`), and `@teambit/typescript.typescript-compiler` to `^3.0.0`. The new toolchain compiles with TypeScript 6.0.3, pins the ambient `@types` the mocha envs need (TS6 no longer auto-includes `node_modules/@types`), and publishes dist-pointing `exports`. Also bumps `@teambit/harmony` to `0.4.12` and migrates remaining components off the legacy core envs (#10473, #10466, #10463, #10470)

--- a/releases-docs/releases/v2.0.11.md
+++ b/releases-docs/releases/v2.0.11.md
@@ -8,5 +8,5 @@
 
 ### Bug Fixes
 
-- **`bit ci pr --keep-lane` config sync** — env migrations made on main now propagate to the PR lane _with their version_, instead of crashing the snap with `ExternalEnvWithoutVersion` or keeping the stale env (#10469)
-- **`bit ci pr --keep-lane` on fresh runners** — config sync from main now pre-fetches each component's common-ancestor object, so the 3-way merge actually lands instead of silently no-op'ing with `… was not found on the filesystem` (#10464)
+- Fix an issue where `bit ci pr --keep-lane` crashed the snap with `ExternalEnvWithoutVersion` (or kept the stale env) instead of propagating env migrations made on main to the PR lane with their version (#10469)
+- Fix an issue where `bit ci pr --keep-lane` on fresh runners silently no-op'd the config sync from main (`… was not found on the filesystem`) instead of landing the 3-way merge, because each component's common-ancestor object wasn't pre-fetched (#10464)

--- a/releases-docs/releases/v2.0.11.md
+++ b/releases-docs/releases/v2.0.11.md
@@ -1,0 +1,12 @@
+## Features
+
+- **`bit import --write-to-empty-dir`** — instead of failing when the target directory is occupied, `bit import` writes the component into the next available empty directory (e.g. `renderers/class` → `renderers/class_1`). Aimed at non-interactive clients like the IDE plugin that can't prompt for `--override`; without the flag, behavior is unchanged (#10471)
+
+## Bug Fixes
+
+- **`bit ci pr --keep-lane` config sync** — env migrations made on main now propagate to the PR lane _with their version_, instead of crashing the snap with `ExternalEnvWithoutVersion` or keeping the stale env (#10469)
+- **`bit ci pr --keep-lane` on fresh runners** — config sync from main now pre-fetches each component's common-ancestor object, so the 3-way merge actually lands instead of silently no-op'ing with `… was not found on the filesystem` (#10464)
+
+## Improvements
+
+- **Core environments on TypeScript 6** — `core-aspect-env`, `node-babel-mocha`, and `node-typescript-mocha` updated to their TS6 releases (`1.0.0`), and `@teambit/typescript.typescript-compiler` to `^3.0.0`. The new toolchain compiles with TypeScript 6.0.3, pins the ambient `@types` the mocha envs need (TS6 no longer auto-includes `node_modules/@types`), and publishes dist-pointing `exports`. Also bumps `@teambit/harmony` to `0.4.12` and migrates remaining components off the legacy core envs (#10473, #10466, #10463, #10470)

--- a/releases-docs/releases/v2.0.2.md
+++ b/releases-docs/releases/v2.0.2.md
@@ -1,0 +1,3 @@
+### Bug Fixes
+
+- Workspace UI version-history now reflects staged (not-yet-snapped) range deprecations, matching `bit log` — previously the per-version deprecation marker only showed up after a tag/snap (#10461)

--- a/releases-docs/releases/v2.0.2.md
+++ b/releases-docs/releases/v2.0.2.md
@@ -1,3 +1,3 @@
 ### Bug Fixes
 
-- Workspace UI version-history now reflects staged (not-yet-snapped) range deprecations, matching `bit log` — previously the per-version deprecation marker only showed up after a tag/snap (#10461)
+- Fix an issue where the Workspace UI version-history didn't reflect staged (not-yet-snapped) range deprecations — the per-version deprecation marker only showed up after a tag/snap, unlike `bit log` (#10461)

--- a/releases-docs/releases/v2.0.26.md
+++ b/releases-docs/releases/v2.0.26.md
@@ -1,0 +1,23 @@
+### Improvements
+
+- Add `--auto-tag-increment` to `bit snap`/`bit tag` to control the version bump level applied to auto-tagged dependents (#10496)
+- Add a git-style pager to `bit diff` and `bit log` for easier navigation of long output (#10472)
+- Correct typos and grammar in various user-facing text (#10498)
+
+### Bug Fixes
+
+- Fix an issue where a component was not recognized as an env by its `.bit-env` plugin file (#10500)
+- Fix an issue where `componentMap` `fullName` collisions across scopes broke component previews (#10497)
+- Fix an issue where `bit init` didn't validate the default-scope name before creating the workspace (#10495)
+- Fix an issue where envs' core-aspect phantom dependencies weren't resolved during `bit install` bootstrap (#10492)
+- Fix an issue where switching to `main` didn't fetch the latest state from the original scope (#10493)
+- Fix an issue where the isolator isolated published-tag dependency-only cycles unnecessarily (#10488)
+- Fix an issue where concurrent exports could cause a lost update by making the export `clientId` collision-safe (#10458)
+
+### Internal
+
+- Update `typescript-compiler` to 3.0.2 (#10499)
+- Resolve aspects/envs from `node_modules` instead of capsules (#10478)
+- Update node babel/mocha envs (#10477, #10476)
+- Migrate remaining components from the react v17 env to react 19 (#10483)
+- E2E/CI stability and coverage improvements (#10489, #10484, #10474)


### PR DESCRIPTION
Archive release notes for the recent small releases that were published as GitHub releases but not yet committed to the repo.

- `v2.0.26.md` — the release just promoted to stable
- `v2.0.11.md` and `v2.0.2.md` — backfilled from their GitHub release bodies

The `v2.0.26` GitHub release + tag are already published: https://github.com/teambit/bit/releases/tag/v2.0.26