### PR TITLE
fix(builder): restore require extension hooks after each build task

### DIFF
--- a/scopes/pipelines/builder/build-pipe.spec.ts
+++ b/scopes/pipelines/builder/build-pipe.spec.ts
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+import Module from 'module';
+import { BuildPipe } from './build-pipe';
+import type { BuildTask, BuiltTaskResult } from './build-task';
+
+// minimal fakes — executeTask only reads the logger methods below, a build-context holding a
+// capsule-network, and an artifact factory invoked on success.
+const logger = {
+  setStatusLine: () => {},
+  debug: () => {},
+  consoleFailure: () => {},
+  consoleSuccess: () => {},
+  createLongProcessLogger: () => ({ logProgress: () => {}, end: () => {}, getProgress: () => '' }),
+} as any;
+
+const artifactFactory = { generate: () => undefined } as any;
+
+const env = { id: 'teambit.harmony/node' } as any;
+
+function makeEnvsBuildContext() {
+  return {
+    [env.id]: {
+      capsuleNetwork: {
+        _originalSeeders: [],
+        capsulesRootDir: '/tmp/build-pipe-spec',
+        seedersCapsules: { getAllComponents: () => [] },
+      },
+    },
+  } as any;
+}
+
+const emptyResult = (): BuiltTaskResult => ({ componentsResults: [], artifacts: [] });
+
+function makeTask(name: string, execute: () => Promise<BuiltTaskResult>): BuildTask {
+  return { aspectId: 'teambit.pipelines/builder', name, execute } as any;
+}
+
+describe('BuildPipe require-extensions isolation', () => {
+  let extensionsSnapshot: Record<string, any>;
+  beforeEach(() => {
+    extensionsSnapshot = { ...(Module as any)._extensions };
+  });
+  afterEach(() => {
+    // a failing assertion must not leave the test process with hijacked loaders
+    const extensions = (Module as any)._extensions;
+    for (const key of Object.keys(extensions)) {
+      if (!(key in extensionsSnapshot)) delete extensions[key];
+    }
+    Object.assign(extensions, extensionsSnapshot);
+  });
+
+  it('confines require-extension hooks installed by a task to that task', async () => {
+    const originalJsLoader = (Module as any)._extensions['.js'];
+    // mimics what @babel/register (via pirates) leaves behind when a tester runs in-process:
+    // a loader that claims ".js" files and compiles them itself
+    const hijackingLoader = () => {
+      throw new Error('hijacked');
+    };
+    const hijackingTask = makeTask('hijack', async () => {
+      (Module as any)._extensions['.js'] = hijackingLoader;
+      (Module as any)._extensions['.fake-ext'] = hijackingLoader;
+      return emptyResult();
+    });
+    let jsLoaderDuringNextTask: any;
+    let fakeExtExistsDuringNextTask: boolean | undefined;
+    const observingTask = makeTask('observe', async () => {
+      jsLoaderDuringNextTask = (Module as any)._extensions['.js'];
+      fakeExtExistsDuringNextTask = '.fake-ext' in (Module as any)._extensions;
+      return emptyResult();
+    });
+    const queue = [
+      { task: hijackingTask, env },
+      { task: observingTask, env },
+    ] as any;
+
+    const pipe = new BuildPipe(queue, makeEnvsBuildContext(), logger, artifactFactory);
+    await pipe.execute();
+
+    expect(jsLoaderDuringNextTask).to.equal(originalJsLoader);
+    expect(fakeExtExistsDuringNextTask).to.be.false;
+    expect((Module as any)._extensions['.js']).to.equal(originalJsLoader);
+  });
+
+  it('restores hooks even when the task fails', async () => {
+    const originalJsLoader = (Module as any)._extensions['.js'];
+    const failingHijackingTask = makeTask('hijack-and-fail', async () => {
+      (Module as any)._extensions['.js'] = () => {
+        throw new Error('hijacked');
+      };
+      throw new Error('task failed');
+    });
+    const queue = [{ task: failingHijackingTask, env }] as any;
+
+    const pipe = new BuildPipe(queue, makeEnvsBuildContext(), logger, artifactFactory);
+    await pipe.execute().catch(() => {});
+
+    expect((Module as any)._extensions['.js']).to.equal(originalJsLoader);
+  });
+});

--- a/scopes/pipelines/builder/build-pipe.ts
+++ b/scopes/pipelines/builder/build-pipe.ts
@@ -2,6 +2,7 @@ import type { EnvDefinition } from '@teambit/envs';
 import type { ComponentMap } from '@teambit/component';
 import { ComponentID } from '@teambit/component';
 import type { Logger, LongProcessLogger } from '@teambit/logger';
+import Module from 'module';
 import mapSeries from 'p-map-series';
 import prettyTime from 'pretty-time';
 import { capitalize } from '@teambit/toolbox.string.capitalize';
@@ -111,6 +112,31 @@ export class BuildPipe {
     longProcessLogger.end();
   }
 
+  /**
+   * in-process build tasks may hijack the Module._extensions loaders and leave them hijacked after
+   * the task ends. e.g. the mocha tester calls @babel/register, whose hook claims all ".js" files
+   * (including node_modules) and compiles files babel declines to transform as CJS scripts —
+   * breaking require() of ESM-only packages for every subsequent task in this process.
+   * snapshotting before each task and restoring after confines such hooks to the task that
+   * installed them. skipped in parallel mode, where another env's still-running task may rely on a
+   * hook it installed.
+   */
+  private snapshotRequireExtensions(): Record<string, unknown> | undefined {
+    if ((this.options?.concurrency ?? 1) > 1) return undefined;
+    return { ...(Module as any)._extensions };
+  }
+
+  private restoreRequireExtensions(snapshot: Record<string, unknown> | undefined) {
+    if (!snapshot) return;
+    const extensions = (Module as any)._extensions;
+    for (const key of Object.keys(extensions)) {
+      if (!(key in snapshot)) delete extensions[key];
+    }
+    for (const [key, loader] of Object.entries(snapshot)) {
+      if (extensions[key] !== loader) extensions[key] = loader;
+    }
+  }
+
   private async executeTask(task: BuildTask, env: EnvDefinition): Promise<void> {
     const taskId = BuildTaskHelper.serializeId(task);
     const envName = this.options?.showEnvNameInOutput ? `(${this.getPrettyEnvName(env.id)}) ` : '';
@@ -144,11 +170,14 @@ export class BuildPipe {
     this.logger.debug(
       `${taskLogPrefix} memory usage: ${Math.round((process.memoryUsage().heapUsed / 1024 / 1024 / 1024) * 100) / 100} GB`
     );
+    const requireExtensionsSnapshot = this.snapshotRequireExtensions();
     try {
       buildTaskResult = await task.execute(buildContext);
     } catch (err) {
       this.logger.consoleFailure(`env: ${env.id}, task "${taskId}" threw an error`);
       throw err;
+    } finally {
+      this.restoreRequireExtensions(requireExtensionsSnapshot);
     }
 
     const endTime = Date.now();


### PR DESCRIPTION
An in-process build task may hijack the \`Module._extensions\` loaders and leave them hijacked after it ends. e.g. a mocha tester calling \`@babel/register\`, whose pirates hook claims all \`.js\` files (including node_modules) and compiles files babel declines to transform as CJS scripts — breaking \`require()\` of ESM-only packages for every subsequent task in the process.

This snapshots the loaders before each task and restores them after (in \`finally\`), confining such hooks to the task that installed them. Skipped in parallel mode, where another env's still-running task may rely on a hook it installed.

The new spec reproduces the leak: without the fix, the hijacked \`.js\` loader installed by one task crashes require() calls made by the pipeline itself and by the next task.