### PR TITLE
fix(install): don't fail install when an env fails to reload

### DIFF
--- a/e2e/harmony/install-reload-env.e2e.ts
+++ b/e2e/harmony/install-reload-env.e2e.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+describe('bit install when a plugin env fails to reload', function () {
+  this.timeout(0);
+  let helper: Helper;
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('a plugin env whose plugin file throws on require', () => {
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.env.setEmptyEnv();
+      helper.fixtures.populateComponents(1);
+      helper.command.setEnv('comp1', 'empty-env');
+      helper.command.install();
+      helper.fs.outputFile(
+        'empty-env/empty-env.bit-env.ts',
+        `throw new Error('intentional plugin failure');
+export class EmptyEnv {}
+export default new EmptyEnv();
+`
+      );
+      helper.command.compile();
+    });
+    // the env reload during install is best-effort. a broken env must not fail the install -
+    // the user needs "bit install" to work in order to fix the env
+    it('should warn about the env reload failure without failing the install', () => {
+      const output = helper.command.install();
+      expect(output).to.have.string('unable to reload the env');
+      expect(output).to.have.string('Successfully');
+    });
+  });
+});

--- a/e2e/harmony/install-reload-env.e2e.ts
+++ b/e2e/harmony/install-reload-env.e2e.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { IssuesClasses } from '@teambit/component-issues';
 import { Helper } from '@teambit/legacy.e2e-helper';
 
 describe('bit install when a plugin env fails to reload', function () {
@@ -30,6 +31,11 @@ export default new EmptyEnv();
       const output = helper.command.install();
       expect(output).to.have.string('unable to reload the env');
       expect(output).to.have.string('Successfully');
+    });
+    // the failure is degraded to a warning, not swallowed - the env keeps being reported as
+    // non-loaded after the install
+    it('should still report the failed env as a component issue', () => {
+      helper.command.expectStatusToHaveIssue(IssuesClasses.NonLoadedEnv.name);
     });
   });
 });

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -696,21 +696,33 @@ export class InstallMain {
     }
     const loadedPlugins = compact(
       await Promise.all(
-        aspects.map((aspectDef) => {
+        aspects.map(async (aspectDef) => {
           const localPath = aspectDef.aspectPath;
           const component = aspectDef.component;
           if (!component) return undefined;
           const plugins = this.aspectLoader.getPlugins(component, localPath);
           if (plugins.has()) {
-            return plugins.load(MainRuntime.name);
+            return { plugins: await plugins.load(MainRuntime.name), id: component.id };
           }
+          return undefined;
         })
       )
     );
     await Promise.all(
-      loadedPlugins.map((plugin) => {
+      loadedPlugins.map(async ({ plugins: plugin, id }) => {
         const runtime = plugin.getRuntime(MainRuntime);
-        return runtime?.provider(undefined, undefined, undefined, this.harmony);
+        if (!runtime) return;
+        // the reload is best-effort (resolveAspects above runs with throwOnError: false). the
+        // provider requires the plugin files, which may not be requirable yet, e.g. an env in a
+        // fresh workspace whose dist was not compiled - it will be loaded later, once compiled.
+        // it must not fail the install.
+        try {
+          await runtime.provider(undefined, undefined, undefined, this.harmony);
+        } catch (err: any) {
+          this.logger.consoleWarning(
+            `unable to reload the env ${id.toString()}, it will be loaded once compiled. error: ${err.message}`
+          );
+        }
       })
     );
   }


### PR DESCRIPTION
During \`bit install\`, non-loaded envs are reloaded after the package installation (\`reloadNonLoadedEnvs\`). The reload invokes the env plugin's provider, which requires the plugin files — and a require failure that the on-load-error recovery can't fix (e.g. a plugin file with a runtime error, or a dist that can't be produced yet) crashed the whole install with the raw plugin error.

This is inconsistent with how the rest of the system treats the exact same failure: \`bit status\` (and every other command) degrades it to a "failed loading env" component issue that says "run bit install" — while \`bit install\` itself dies on it. The user needs install to work in order to fix their env.

The reload is already best-effort by design (\`resolveAspects\` runs with \`throwOnError: false\`, and nothing consumes the provider's result), so align the provider call: catch the error, warn with the env id and the error message, and let the env load once fixed/compiled. The failure stays visible — install prints the warning and the component keeps its NonLoadedEnv issue afterward (both asserted by the e2e).