### PR TITLE
fix: ship referenced non-head dependency snaps when merging a lane to main and exporting

### DIFF
--- a/e2e/harmony/lanes/merge-lane-to-main-stale-dep-ref.e2e.ts
+++ b/e2e/harmony/lanes/merge-lane-to-main-stale-dep-ref.e2e.ts
@@ -1,0 +1,87 @@
+import chai, { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+import chaiFs from 'chai-fs';
+
+chai.use(chaiFs);
+
+/**
+ * When merging a lane to main, the squash rewrites each component's parent chain and drops the
+ * intermediate snaps. If a component's head still pins a non-head (now dropped) snap of a dependency
+ * — e.g. the dependency advanced but the dependent was not re-snapped — that snap is no longer part
+ * of the dependency's exported history. On a lean lane (lane hosted in a separate scope) it lives
+ * only on the lane scope, so exporting the merged result to the components' home scope would omit it
+ * and the remote's dependency-integrity check would fail with "... was not found".
+ *
+ * The merge imports any such missing snap from the lane scope, and the export ships it alongside the
+ * heads.
+ */
+describe('merge lane to main when a component pins a non-head (squashed-out) snap of its dependency', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  /**
+   * Builds a lean lane where comp1 pins comp2@snapA while comp2 advances to snapB (comp1 is not
+   * re-snapped, thanks to --skip-auto-snap). Returns the lane scope name and comp2@snapA.
+   */
+  function setupLaneWithStaleRef(): { laneScopeName: string; laneScopePath: string; comp2SnapA: string } {
+    helper.scopeHelper.setWorkspaceWithRemoteScope();
+    helper.fixtures.populateComponents(2); // comp1 depends on comp2
+    helper.command.tagAllWithoutBuild();
+    helper.command.export();
+
+    const laneScope = helper.scopeHelper.getNewBareScope();
+    helper.scopeHelper.addRemoteScope(laneScope.scopePath);
+    helper.command.createLane();
+    helper.command.changeLaneScope(laneScope.scopeName);
+
+    helper.command.snapAllComponentsWithoutBuild('--unmodified'); // comp1 pins comp2@snapA
+    const comp2SnapA = helper.command.getHeadOfLane('dev', 'comp2');
+    helper.command.export();
+
+    // comp2 advances to snapB without auto-snapping comp1, so comp1 keeps pinning comp2@snapA
+    helper.command.snapComponentWithoutBuild('comp2', '--unmodified --skip-auto-snap');
+    helper.command.export();
+
+    return { laneScopeName: laneScope.scopeName, laneScopePath: laneScope.scopePath, comp2SnapA };
+  }
+
+  describe('the referenced snap is present locally in the merging workspace', () => {
+    let laneScopeName: string;
+    before(() => {
+      ({ laneScopeName } = setupLaneWithStaleRef());
+      helper.command.switchLocalLane('main');
+      helper.command.mergeLaneWithoutBuild(`${laneScopeName}/dev`);
+    });
+    it('should export the merged result without a missing-dependency error', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+
+  describe('the referenced snap is only on the lane scope (fresh import; not local before the merge)', () => {
+    let laneScopeName: string;
+    let laneScopePath: string;
+    let comp2SnapA: string;
+    before(() => {
+      ({ laneScopeName, laneScopePath, comp2SnapA } = setupLaneWithStaleRef());
+      // fresh workspace that imports the lane leanly -> comp2@snapA is not present locally
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.scopeHelper.addRemoteScope(laneScopePath);
+      helper.command.runCmd(`bit lane import ${laneScopeName}/dev -x`);
+    });
+    it('the referenced snap should not be present locally before the merge', () => {
+      expect(() => helper.command.catObject(comp2SnapA)).to.throw();
+    });
+    it('the merge should import it from the lane scope and the export should succeed', () => {
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.mergeLaneWithoutBuild(`${laneScopeName}/dev`, '--ignore-config-changes -x');
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+});

--- a/e2e/harmony/lanes/merge-lane-to-main-stale-dep-ref.e2e.ts
+++ b/e2e/harmony/lanes/merge-lane-to-main-stale-dep-ref.e2e.ts
@@ -28,6 +28,8 @@ describe('merge lane to main when a component pins a non-head (squashed-out) sna
   /**
    * Builds a lean lane where comp1 pins comp2@snapA while comp2 advances to snapB (comp1 is not
    * re-snapped, thanks to --skip-auto-snap). Returns the lane scope name and comp2@snapA.
+   * comp2 gets real file changes on each snap, so snapA references file objects that exist in no
+   * other version — the merge must fetch them (not only the Version object) from the lane scope.
    */
   function setupLaneWithStaleRef(): { laneScopeName: string; laneScopePath: string; comp2SnapA: string } {
     helper.scopeHelper.setWorkspaceWithRemoteScope();
@@ -40,12 +42,14 @@ describe('merge lane to main when a component pins a non-head (squashed-out) sna
     helper.command.createLane();
     helper.command.changeLaneScope(laneScope.scopeName);
 
+    helper.fs.outputFile('comp2/index.js', `module.exports = () => 'comp2 snapA';`);
     helper.command.snapAllComponentsWithoutBuild('--unmodified'); // comp1 pins comp2@snapA
     const comp2SnapA = helper.command.getHeadOfLane('dev', 'comp2');
     helper.command.export();
 
     // comp2 advances to snapB without auto-snapping comp1, so comp1 keeps pinning comp2@snapA
-    helper.command.snapComponentWithoutBuild('comp2', '--unmodified --skip-auto-snap');
+    helper.fs.outputFile('comp2/index.js', `module.exports = () => 'comp2 snapB';`);
+    helper.command.snapComponentWithoutBuild('comp2', '--skip-auto-snap');
     helper.command.export();
 
     return { laneScopeName: laneScope.scopeName, laneScopePath: laneScope.scopePath, comp2SnapA };

--- a/e2e/harmony/lanes/merge-lane-to-main-stale-dep-ref.e2e.ts
+++ b/e2e/harmony/lanes/merge-lane-to-main-stale-dep-ref.e2e.ts
@@ -67,6 +67,87 @@ describe('merge lane to main when a component pins a non-head (squashed-out) sna
     });
   });
 
+  describe('the stale pinned dependency lives in another scope (cross-scope pin)', () => {
+    let anotherRemote: string;
+    let anotherRemotePath: string;
+    let laneScopeName: string;
+    let comp2SnapA: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const newScope = helper.scopeHelper.getNewBareScope();
+      anotherRemote = newScope.scopeName;
+      anotherRemotePath = newScope.scopePath;
+      // wire every scope to know every other scope
+      helper.scopeHelper.addRemoteScope(anotherRemotePath);
+      helper.scopeHelper.addRemoteScope(anotherRemotePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, anotherRemotePath);
+      helper.fixtures.populateComponents(2, false, '', false);
+      helper.command.setScope(anotherRemote, 'comp2'); // comp1 (remote) -> comp2 (anotherRemote)
+      helper.command.linkAndRewire();
+      helper.command.compile();
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      const laneScope = helper.scopeHelper.getNewBareScope();
+      laneScopeName = laneScope.scopeName;
+      helper.scopeHelper.addRemoteScope(laneScope.scopePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, laneScope.scopePath);
+      helper.scopeHelper.addRemoteScope(anotherRemotePath, laneScope.scopePath);
+      helper.command.createLane();
+      helper.command.changeLaneScope(laneScopeName);
+
+      helper.fs.outputFile('comp2/index.js', `module.exports = () => 'comp2 snapA';`);
+      helper.command.snapAllComponentsWithoutBuild('--unmodified'); // comp1 pins comp2@snapA
+      comp2SnapA = helper.command.getHeadOfLane('dev', 'comp2');
+      helper.command.export();
+
+      helper.fs.outputFile('comp2/index.js', `module.exports = () => 'comp2 snapB';`);
+      helper.command.snapComponentWithoutBuild('comp2', '--skip-auto-snap');
+      helper.command.export();
+
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.mergeLaneWithoutBuild(`${laneScopeName}/dev`, '-x');
+    });
+    it('the export should succeed — the remote integrity check skips cross-scope deps', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+    it('the stale snap should not exist on the dependency home scope, only on the lane scope', () => {
+      expect(() => helper.command.catObject(comp2SnapA, false, anotherRemotePath)).to.throw();
+    });
+    // KNOWN LIMITATION (pre-existing, not introduced by the stale-ref fix): the squash orphans a
+    // cross-scope pinned snap — it remains only on the lane scope, and nothing on main points there.
+    // day-to-day consumption is unaffected (import/status tolerate the missing dep version), but the
+    // pinned version itself is unfetchable: its home scope never received it and the fetch-missing-deps
+    // mechanism asks that home scope, not the lane scope. shipping such snaps to the dependency's home
+    // scope would require the export to look across per-scope batches — a possible future enhancement.
+    describe('importing the dependent component later from a fresh workspace', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.scopeHelper.addRemoteScope(anotherRemotePath);
+        // the lane scope is deliberately not configured — after the merge to main, consumers of the
+        // component do not know (and should not need to know) the lane it was developed on.
+      });
+      it('bit import of the dependent should work — the missing pinned dep version is tolerated', () => {
+        const output = helper.command.import(`${helper.scopes.remote}/comp1`);
+        expect(output).to.have.string('successfully');
+      });
+      it('bit status should not report invalid components', () => {
+        const status = helper.command.statusJson();
+        expect(status.invalidComponents).to.have.lengthOf(0);
+      });
+      it('bit import --dependencies should work — the missing pinned dep version is skipped silently', () => {
+        expect(() => helper.command.import(`${helper.scopes.remote}/comp1 --dependencies --override`)).to.not.throw();
+      });
+      it('importing the pinned dep version explicitly should soft-fail as missing and not fetch it', () => {
+        const output = helper.command.import(`${anotherRemote}/comp2@${comp2SnapA}`);
+        expect(output).to.have.string('missing components');
+        expect(output).to.have.string(`${anotherRemote}/comp2`);
+        expect(() => helper.command.catObject(comp2SnapA)).to.throw();
+      });
+    });
+  });
+
   describe('the referenced snap is only on the lane scope (fresh import; not local before the merge)', () => {
     let laneScopeName: string;
     let laneScopePath: string;

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -17,7 +17,9 @@ import { ConfigStoreAspect } from '@teambit/config-store';
 import { getLogForSquash } from '@teambit/harmony.modules.get-basic-log';
 import type { ComponentID } from '@teambit/component-id';
 import { ComponentIdList } from '@teambit/component-id';
-import type { Ref, Lane, Version, Log } from '@teambit/objects';
+import type { Lane, Version, Log } from '@teambit/objects';
+import { Ref } from '@teambit/objects';
+import { isSnap } from '@teambit/component-version';
 import pMapSeries from 'p-map-series';
 import type { Scope as LegacyScope } from '@teambit/legacy.scope';
 import type { ScopeMain } from '@teambit/scope';
@@ -284,9 +286,62 @@ export class MergeLanesMain {
       }
     });
 
+    // A merged head may reference — via its flattened dependencies — a non-head snap of another
+    // component. When merging to main the squash removes intermediate snaps from each component's own
+    // chain, and a bare-scope merge (`bit _merge-lane --push`) exports heads only; in both cases such a
+    // referenced snap wouldn't be exported, and on lean lanes it lives only on the lane scope. Import
+    // any missing one now so the export can ship it (otherwise the remote's dependency-integrity check
+    // would reject the push). Not needed for non-squash workspace merges, which export full history.
+    if (shouldSquash || !this.workspace) {
+      await this.importMissingReferencedDeps(mergedSuccessfullyIds, otherLane);
+    }
+
     await this.workspace?.consumer.onDestroy(`lane-merge (${otherLaneId.name})`);
 
     return { mergeResults, deleteResults, configMergeResults, mergedSuccessfullyIds, conflicts };
+  }
+
+  /**
+   * A merged component head may reference, via its flattened dependencies, a non-head snap of another
+   * component — e.g. a deleted component that keeps pinning an older snap of a dependency that has
+   * since advanced. On lean lanes those snaps live only on the lane scope and are not fetched by the
+   * merge, so the heads-only export (used by `bit _merge-lane --push`) would leave them out and the
+   * remote's dependency-integrity check would fail. Import any such missing snap from the lane scope.
+   */
+  private async importMissingReferencedDeps(ids: ComponentID[], otherLane?: Lane) {
+    // the missing snaps live on the lane scope (lean lanes). without the source lane we don't know
+    // where to fetch them from, so there's nothing to do.
+    if (!otherLane) return;
+    const legacyScope = this.scope.legacyScope;
+    const missingHashes: string[] = [];
+    await pMapSeries(ids, async (id) => {
+      const modelComponent = await legacyScope.getModelComponentIfExist(id);
+      const head = modelComponent?.head;
+      if (!modelComponent || !head) return;
+      const headVersion = await modelComponent.loadVersion(head.toString(), legacyScope.objects, false);
+      if (!headVersion) return;
+      await Promise.all(
+        // direct dependencies only — a stale cross-component reference is a direct dep, and the
+        // flattened list can be huge.
+        headVersion.getAllDependencies().map(async (dep) => {
+          const depId = dep.id;
+          // only snaps can go missing this way — tags live on the home scope and are never squashed
+          // off a lane. (a tag version is a semver string, not an object hash, so Ref.from would be
+          // bogus for it anyway.)
+          if (!depId.version || !isSnap(depId.version)) return;
+          const exists = await legacyScope.objects.has(Ref.from(depId.version));
+          if (!exists) missingHashes.push(depId.version);
+        })
+      );
+    });
+    if (!missingHashes.length) return;
+    this.logger.debug(
+      `importMissingReferencedDeps, importing ${missingHashes.length} non-head dependency snaps referenced by the merged heads from ${otherLane.scope}`
+    );
+    // fetch the raw objects only (by hash, from the lane scope). importManyObjects does not touch
+    // component models/heads, so it can't leave a component pointing at a version whose object is
+    // missing — unlike a component-level import.
+    await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: uniq(missingHashes) });
   }
 
   private validateMergeFlags(otherLaneId: LaneId, currentLaneId: LaneId, options: MergeLaneOptions) {

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -346,6 +346,25 @@ export class MergeLanesMain {
     // component models/heads, so it can't leave a component pointing at a version whose object is
     // missing — unlike a component-level import.
     await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: missingHashes });
+    // a Version object references other objects the export must ship along with it — the file
+    // sources and the flattened-edges/dependencies-graph. fetch the missing ones too. (parents are
+    // not needed — the export doesn't collect them for these versions. artifacts are not needed
+    // either — the export tolerates missing artifacts for such non-local versions.)
+    const missingRefsOfVersions: string[] = [];
+    await pMapSeries(missingHashes, async (hash) => {
+      const versionObject = (await legacyScope.objects.load(Ref.from(hash))) as Version | null;
+      if (!versionObject) return; // the hash could not be fetched after all
+      await Promise.all(
+        versionObject.refsWithOptions(false, false).map(async (ref) => {
+          if (checkedHashes.has(ref.toString())) return;
+          checkedHashes.add(ref.toString());
+          const exists = await legacyScope.objects.has(ref);
+          if (!exists) missingRefsOfVersions.push(ref.toString());
+        })
+      );
+    });
+    if (!missingRefsOfVersions.length) return;
+    await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: missingRefsOfVersions });
   }
 
   private validateMergeFlags(otherLaneId: LaneId, currentLaneId: LaneId, options: MergeLaneOptions) {

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -314,21 +314,25 @@ export class MergeLanesMain {
     if (!otherLane) return;
     const legacyScope = this.scope.legacyScope;
     const missingHashes: string[] = [];
+    // one existence check per unique hash — the same snap appears in the flattened list of many heads
+    const checkedHashes = new Set<string>();
     await pMapSeries(ids, async (id) => {
       const modelComponent = await legacyScope.getModelComponentIfExist(id);
       const head = modelComponent?.head;
       if (!modelComponent || !head) return;
       const headVersion = await modelComponent.loadVersion(head.toString(), legacyScope.objects, false);
       if (!headVersion) return;
+      // flattened (not only direct) to mirror the remote-side check, which validates the flattened
+      // dependencies of every exported head (see throwForMissingLocalDependencies). cheap: only the
+      // heads are loaded and each unique hash is stat-ed once.
       await Promise.all(
-        // direct dependencies only — a stale cross-component reference is a direct dep, and the
-        // flattened list can be huge.
-        headVersion.getAllDependencies().map(async (dep) => {
-          const depId = dep.id;
+        headVersion.getAllFlattenedDependencies().map(async (depId) => {
           // only snaps can go missing this way — tags live on the home scope and are never squashed
           // off a lane. (a tag version is a semver string, not an object hash, so Ref.from would be
           // bogus for it anyway.)
           if (!depId.version || !isSnap(depId.version)) return;
+          if (checkedHashes.has(depId.version)) return;
+          checkedHashes.add(depId.version);
           const exists = await legacyScope.objects.has(Ref.from(depId.version));
           if (!exists) missingHashes.push(depId.version);
         })
@@ -341,7 +345,7 @@ export class MergeLanesMain {
     // fetch the raw objects only (by hash, from the lane scope). importManyObjects does not touch
     // component models/heads, so it can't leave a component pointing at a version whose object is
     // missing — unlike a component-level import.
-    await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: uniq(missingHashes) });
+    await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: missingHashes });
   }
 
   private validateMergeFlags(otherLaneId: LaneId, currentLaneId: LaneId, options: MergeLaneOptions) {

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -327,6 +327,10 @@ export class MergeLanesMain {
       // heads are loaded and each unique hash is stat-ed once.
       await Promise.all(
         headVersion.getAllFlattenedDependencies().map(async (depId) => {
+          // the remote check validates only same-scope deps (it skips `depId.scope !== scope.name`,
+          // cross-scope deps are fetched later by the remote itself), so same-scope is all the export
+          // needs to ship. this also filters out the vast majority of the flattened list.
+          if (depId.scope !== id.scope) return;
           // only snaps can go missing this way — tags live on the home scope and are never squashed
           // off a lane. (a tag version is a semver string, not an object hash, so Ref.from would be
           // bogus for it anyway.)

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -313,11 +313,13 @@ export class MergeLanesMain {
     // where to fetch them from, so there's nothing to do.
     if (!otherLane) return;
     const legacyScope = this.scope.legacyScope;
-    const missingHashes: string[] = [];
     // one existence check per unique hash — the same snap appears in the flattened list of many heads
     const checkedHashes = new Set<string>();
+    const candidateRefs: Ref[] = [];
     await pMapSeries(ids, async (id) => {
-      const modelComponent = await legacyScope.getModelComponentIfExist(id);
+      // strip the version — a versioned lookup (sources.get) returns undefined when that Version
+      // object is missing locally, and only the model is needed here anyway (for its head).
+      const modelComponent = await legacyScope.getModelComponentIfExist(id.changeVersion(undefined));
       const head = modelComponent?.head;
       if (!modelComponent || !head) return;
       const headVersion = await modelComponent.loadVersion(head.toString(), legacyScope.objects, false);
@@ -325,23 +327,24 @@ export class MergeLanesMain {
       // flattened (not only direct) to mirror the remote-side check, which validates the flattened
       // dependencies of every exported head (see throwForMissingLocalDependencies). cheap: only the
       // heads are loaded and each unique hash is stat-ed once.
-      await Promise.all(
-        headVersion.getAllFlattenedDependencies().map(async (depId) => {
-          // the remote check validates only same-scope deps (it skips `depId.scope !== scope.name`,
-          // cross-scope deps are fetched later by the remote itself), so same-scope is all the export
-          // needs to ship. this also filters out the vast majority of the flattened list.
-          if (depId.scope !== id.scope) return;
-          // only snaps can go missing this way — tags live on the home scope and are never squashed
-          // off a lane. (a tag version is a semver string, not an object hash, so Ref.from would be
-          // bogus for it anyway.)
-          if (!depId.version || !isSnap(depId.version)) return;
-          if (checkedHashes.has(depId.version)) return;
-          checkedHashes.add(depId.version);
-          const exists = await legacyScope.objects.has(Ref.from(depId.version));
-          if (!exists) missingHashes.push(depId.version);
-        })
-      );
+      headVersion.getAllFlattenedDependencies().forEach((depId) => {
+        // the remote check validates only same-scope deps (it skips `depId.scope !== scope.name`,
+        // cross-scope deps are fetched later by the remote itself), so same-scope is all the export
+        // needs to ship. this also filters out the vast majority of the flattened list.
+        if (depId.scope !== id.scope) return;
+        // only snaps can go missing this way — tags live on the home scope and are never squashed
+        // off a lane. (a tag version is a semver string, not an object hash, so Ref.from would be
+        // bogus for it anyway.)
+        if (!depId.version || !isSnap(depId.version)) return;
+        if (checkedHashes.has(depId.version)) return;
+        checkedHashes.add(depId.version);
+        candidateRefs.push(Ref.from(depId.version));
+      });
     });
+    // hasMultiple bounds the I/O concurrency, unlike a Promise.all of has() calls
+    const existingRefs = await legacyScope.objects.hasMultiple(candidateRefs);
+    const existingHashes = new Set(existingRefs.map((ref) => ref.toString()));
+    const missingHashes = candidateRefs.map((ref) => ref.toString()).filter((hash) => !existingHashes.has(hash));
     if (!missingHashes.length) return;
     this.logger.debug(
       `importMissingReferencedDeps, importing ${missingHashes.length} non-head dependency snaps referenced by the merged heads from ${otherLane.scope}`
@@ -354,21 +357,20 @@ export class MergeLanesMain {
     // sources and the flattened-edges/dependencies-graph. fetch the missing ones too. (parents are
     // not needed — the export doesn't collect them for these versions. artifacts are not needed
     // either — the export tolerates missing artifacts for such non-local versions.)
-    const missingRefsOfVersions: string[] = [];
+    const subRefs: Ref[] = [];
     await pMapSeries(missingHashes, async (hash) => {
       const versionObject = (await legacyScope.objects.load(Ref.from(hash))) as Version | null;
       if (!versionObject) return; // the hash could not be fetched after all
-      await Promise.all(
-        versionObject.refsWithOptions(false, false).map(async (ref) => {
-          if (checkedHashes.has(ref.toString())) return;
-          checkedHashes.add(ref.toString());
-          const exists = await legacyScope.objects.has(ref);
-          if (!exists) missingRefsOfVersions.push(ref.toString());
-        })
-      );
+      versionObject.refsWithOptions(false, false).forEach((ref) => {
+        if (checkedHashes.has(ref.toString())) return;
+        checkedHashes.add(ref.toString());
+        subRefs.push(ref);
+      });
     });
-    if (!missingRefsOfVersions.length) return;
-    await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: missingRefsOfVersions });
+    const existingSubRefs = new Set((await legacyScope.objects.hasMultiple(subRefs)).map((ref) => ref.toString()));
+    const missingSubRefs = subRefs.map((ref) => ref.toString()).filter((hash) => !existingSubRefs.has(hash));
+    if (!missingSubRefs.length) return;
+    await legacyScope.scopeImporter.importManyObjects({ [otherLane.scope]: missingSubRefs });
   }
 
   private validateMergeFlags(otherLaneId: LaneId, currentLaneId: LaneId, options: MergeLaneOptions) {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -481,6 +481,16 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
           if (!depRef) return;
           if (depComp.entry.refs.find((ref) => ref.isEqual(depRef))) return; // already included
           if (!(await scope.objects.has(depRef))) return; // can only ship what exists locally
+          // the objects this version references (file sources, flattened-edges) get collected along
+          // with it, so they must be present locally as well. if they're not, don't add the ref —
+          // exporting it would fail on the missing objects, and the remote may have this version
+          // already anyway (in which case the export succeeds without shipping it).
+          const depVersion = await depComp.entry.modelComponent.loadVersion(depRef.toString(), scope.objects, false);
+          if (!depVersion) return;
+          const subRefsExist = await Promise.all(
+            depVersion.refsWithOptions(false, false).map((ref) => scope.objects.has(ref))
+          );
+          if (subRefsExist.some((exists) => !exists)) return;
           depComp.entry.refs.push(depRef);
         });
       });

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -7,6 +7,7 @@ import { ScopeAspect } from '@teambit/scope';
 import { BitError } from '@teambit/bit-error';
 import { Analytics } from '@teambit/legacy.analytics';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
+import { isSnap } from '@teambit/component-version';
 import { CENTRAL_BIT_HUB_NAME, CENTRAL_BIT_HUB_URL, getCloudDomain } from '@teambit/legacy.constants';
 import type { Consumer } from '@teambit/legacy.consumer';
 import type { BitMap } from '@teambit/legacy.bit-map';
@@ -460,6 +461,50 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
         const refs = await getVersionsToExport(modelComponent);
         return { modelComponent, refs };
       });
+
+      // A component head may reference — via its dependencies — a non-head snap of another
+      // component in the same export set. This happens when a component pins an older snap of a
+      // dependency that has since advanced (e.g. a squash-merge to main removes intermediate snaps from
+      // the dependency's own chain, so a full-history export no longer includes them; or a heads-only
+      // export selects only each component's head). That snap wouldn't otherwise be selected, so the
+      // remote's dependency-integrity check (throwForMissingLocalDependencies) would reject the export.
+      // Include any such referenced snap that exists locally so it gets shipped alongside the heads.
+      // (Missing ones are fetched earlier during the merge, see MergeLanesMain.importMissingReferencedDeps.)
+      {
+        const compByIdStr = new Map<string, { modelComponent: ModelComponent; refs: Ref[] }>();
+        refsToPotentialExportPerComponent.forEach((entry) => {
+          compByIdStr.set(entry.modelComponent.toComponentId().toStringWithoutVersion(), entry);
+        });
+        const candidatesByKey = new Map<
+          string,
+          { entry: { modelComponent: ModelComponent; refs: Ref[] }; depRef: Ref }
+        >();
+        await mapSeries(refsToPotentialExportPerComponent, async ({ modelComponent, refs }) => {
+          await mapSeries([...refs], async (ref) => {
+            const version = await modelComponent.loadVersion(ref.toString(), scope.objects, false);
+            if (!version) return;
+            // direct dependencies only — a stale cross-component reference is a direct dep, and the
+            // flattened list can be huge.
+            version.getAllDependencies().forEach((dep) => {
+              const depId = dep.id;
+              // only snaps can go missing this way — tags live on the home scope and are never
+              // squashed out of a component's history.
+              if (!depId.version || !isSnap(depId.version)) return;
+              const entry = compByIdStr.get(depId.toStringWithoutVersion());
+              if (!entry) return; // the referenced component is not part of this export set
+              const depRef = entry.modelComponent.getRef(depId.version);
+              if (!depRef) return;
+              if (entry.refs.some((existing) => existing.isEqual(depRef))) return; // already included
+              candidatesByKey.set(`${depId.toStringWithoutVersion()}@${depRef.toString()}`, { entry, depRef });
+            });
+          });
+        });
+        await mapSeries([...candidatesByKey.values()], async ({ entry, depRef }) => {
+          if (entry.refs.some((existing) => existing.isEqual(depRef))) return;
+          if (!(await scope.objects.has(depRef))) return; // can only ship what's present locally
+          entry.refs.push(depRef);
+        });
+      }
 
       const getRefsToExportPerComp = async () => {
         if (!filterOutExistingVersions) {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -435,6 +435,58 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
       return allHashes;
     };
 
+    /**
+     * a component head may reference — via its direct dependencies — a non-head snap of another
+     * component in the same export set. this happens when a component keeps pinning an older snap of
+     * a dependency that has since advanced, and a squash (merge to main) dropped that snap from the
+     * dependency's own parent chain. no history traversal selects it (and a heads-only export selects
+     * only heads to begin with), so without it the remote dependency-integrity check
+     * (throwForMissingLocalDependencies) rejects the export. add any such snap that exists locally so
+     * it is shipped alongside the selected refs. snaps missing locally were fetched during the
+     * lane-merge, see MergeLanesMain.importMissingReferencedDeps().
+     * only direct dependencies are considered (the remote check validates the heads' direct deps, and
+     * the flattened list can be huge), and only snaps — tags are never squashed out of history.
+     */
+    const addReferencedSnapsIfPossible = async (
+      refsPerComponent: Array<{ modelComponent: ModelComponent; refs: Ref[] }>
+    ) => {
+      const entryByCompIdStr = new Map(
+        refsPerComponent.map((entry) => [entry.modelComponent.toComponentId().toStringWithoutVersion(), entry])
+      );
+      const includedHashesByCompIdStr = new Map(
+        refsPerComponent.map((entry) => [
+          entry.modelComponent.toComponentId().toStringWithoutVersion(),
+          new Set(entry.refs.map((ref) => ref.toString())),
+        ])
+      );
+      const referencedSnaps: Array<{ depCompIdStr: string; depRef: Ref }> = [];
+      await mapSeries(refsPerComponent, async ({ modelComponent, refs }) => {
+        await mapSeries(refs, async (ref) => {
+          const version = await modelComponent.loadVersion(ref.toString(), scope.objects, false);
+          if (!version) return;
+          version.getAllDependencies().forEach((dep) => {
+            if (!dep.id.version || !isSnap(dep.id.version)) return;
+            const depCompIdStr = dep.id.toStringWithoutVersion();
+            const depEntry = entryByCompIdStr.get(depCompIdStr);
+            if (!depEntry) return; // the referenced component is not part of this export set
+            const depRef = depEntry.modelComponent.getRef(dep.id.version);
+            if (!depRef) return;
+            if (includedHashesByCompIdStr.get(depCompIdStr)?.has(depRef.toString())) return;
+            referencedSnaps.push({ depCompIdStr, depRef });
+          });
+        });
+      });
+      // deliberately a second pass over the original refs' findings only — the added snaps' own deps
+      // are not walked. the remote check validates heads only, so one level is enough.
+      await mapSeries(referencedSnaps, async ({ depCompIdStr, depRef }) => {
+        const includedHashes = includedHashesByCompIdStr.get(depCompIdStr) as Set<string>;
+        if (includedHashes.has(depRef.toString())) return; // referenced by multiple components
+        if (!(await scope.objects.has(depRef))) return; // can only ship what exists locally
+        includedHashes.add(depRef.toString());
+        entryByCompIdStr.get(depCompIdStr)?.refs.push(depRef);
+      });
+    };
+
     await validateTargetScopeForLanes();
     const groupedByScopeString = Object.keys(idsGroupedByScope)
       .map((scopeName) => `scope "${scopeName}": ${idsGroupedByScope[scopeName].toString()}`)
@@ -462,49 +514,7 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
         return { modelComponent, refs };
       });
 
-      // A component head may reference — via its dependencies — a non-head snap of another
-      // component in the same export set. This happens when a component pins an older snap of a
-      // dependency that has since advanced (e.g. a squash-merge to main removes intermediate snaps from
-      // the dependency's own chain, so a full-history export no longer includes them; or a heads-only
-      // export selects only each component's head). That snap wouldn't otherwise be selected, so the
-      // remote's dependency-integrity check (throwForMissingLocalDependencies) would reject the export.
-      // Include any such referenced snap that exists locally so it gets shipped alongside the heads.
-      // (Missing ones are fetched earlier during the merge, see MergeLanesMain.importMissingReferencedDeps.)
-      {
-        const compByIdStr = new Map<string, { modelComponent: ModelComponent; refs: Ref[] }>();
-        refsToPotentialExportPerComponent.forEach((entry) => {
-          compByIdStr.set(entry.modelComponent.toComponentId().toStringWithoutVersion(), entry);
-        });
-        const candidatesByKey = new Map<
-          string,
-          { entry: { modelComponent: ModelComponent; refs: Ref[] }; depRef: Ref }
-        >();
-        await mapSeries(refsToPotentialExportPerComponent, async ({ modelComponent, refs }) => {
-          await mapSeries([...refs], async (ref) => {
-            const version = await modelComponent.loadVersion(ref.toString(), scope.objects, false);
-            if (!version) return;
-            // direct dependencies only — a stale cross-component reference is a direct dep, and the
-            // flattened list can be huge.
-            version.getAllDependencies().forEach((dep) => {
-              const depId = dep.id;
-              // only snaps can go missing this way — tags live on the home scope and are never
-              // squashed out of a component's history.
-              if (!depId.version || !isSnap(depId.version)) return;
-              const entry = compByIdStr.get(depId.toStringWithoutVersion());
-              if (!entry) return; // the referenced component is not part of this export set
-              const depRef = entry.modelComponent.getRef(depId.version);
-              if (!depRef) return;
-              if (entry.refs.some((existing) => existing.isEqual(depRef))) return; // already included
-              candidatesByKey.set(`${depId.toStringWithoutVersion()}@${depRef.toString()}`, { entry, depRef });
-            });
-          });
-        });
-        await mapSeries([...candidatesByKey.values()], async ({ entry, depRef }) => {
-          if (entry.refs.some((existing) => existing.isEqual(depRef))) return;
-          if (!(await scope.objects.has(depRef))) return; // can only ship what's present locally
-          entry.refs.push(depRef);
-        });
-      }
+      await addReferencedSnapsIfPossible(refsToPotentialExportPerComponent);
 
       const getRefsToExportPerComp = async () => {
         if (!filterOutExistingVersions) {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -35,7 +35,7 @@ import type { DependencyResolverMain } from '@teambit/dependency-resolver';
 import { DependencyResolverAspect } from '@teambit/dependency-resolver';
 import { persistRemotes, validateRemotes, removePendingDirs } from './export-scope-components';
 import { writeLastExport } from './last-export';
-import type { Lane, ModelComponent, ObjectItem, LaneReadmeComponent, BitObject, Ref } from '@teambit/objects';
+import type { Lane, ModelComponent, ObjectItem, LaneReadmeComponent, BitObject, Ref, Version } from '@teambit/objects';
 import { ObjectList } from '@teambit/objects';
 import { Scope, PersistFailed } from '@teambit/legacy.scope';
 import { getAllVersionHashes } from '@teambit/component.snap-distance';
@@ -438,52 +438,50 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
     /**
      * a component head may reference — via its direct dependencies — a non-head snap of another
      * component in the same export set. this happens when a component keeps pinning an older snap of
-     * a dependency that has since advanced, and a squash (merge to main) dropped that snap from the
-     * dependency's own parent chain. no history traversal selects it (and a heads-only export selects
-     * only heads to begin with), so without it the remote dependency-integrity check
+     * a dependency that has since advanced (e.g. the component was soft-removed on the lane, so it
+     * never gets re-snapped), and the squash of a lane-merge dropped that snap from the dependency's
+     * own parent chain. no history traversal selects it (and a heads-only export selects only heads
+     * to begin with), so without it the remote dependency-integrity check
      * (throwForMissingLocalDependencies) rejects the export. add any such snap that exists locally so
      * it is shipped alongside the selected refs. snaps missing locally were fetched during the
      * lane-merge, see MergeLanesMain.importMissingReferencedDeps().
-     * only direct dependencies are considered (the remote check validates the heads' direct deps, and
-     * the flattened list can be huge), and only snaps — tags are never squashed out of history.
+     * this is cheap by design and a no-op for ordinary exports: only heads are inspected (the remote
+     * check validates only versions that are heads, and they're loaded later by the export anyway),
+     * only snaps are considered (tags are never squashed out of history), and a ref is added only
+     * when the dependency's head carries the `squashed` marker — i.e. only after a squashing
+     * lane-merge, the sole flow that removes snaps from a component's history.
      */
     const addReferencedSnapsIfPossible = async (
       refsPerComponent: Array<{ modelComponent: ModelComponent; refs: Ref[] }>
     ) => {
-      const entryByCompIdStr = new Map(
-        refsPerComponent.map((entry) => [entry.modelComponent.toComponentId().toStringWithoutVersion(), entry])
-      );
-      const includedHashesByCompIdStr = new Map(
-        refsPerComponent.map((entry) => [
-          entry.modelComponent.toComponentId().toStringWithoutVersion(),
-          new Set(entry.refs.map((ref) => ref.toString())),
-        ])
-      );
-      const referencedSnaps: Array<{ depCompIdStr: string; depRef: Ref }> = [];
-      await mapSeries(refsPerComponent, async ({ modelComponent, refs }) => {
-        await mapSeries(refs, async (ref) => {
-          const version = await modelComponent.loadVersion(ref.toString(), scope.objects, false);
-          if (!version) return;
-          version.getAllDependencies().forEach((dep) => {
-            if (!dep.id.version || !isSnap(dep.id.version)) return;
-            const depCompIdStr = dep.id.toStringWithoutVersion();
-            const depEntry = entryByCompIdStr.get(depCompIdStr);
-            if (!depEntry) return; // the referenced component is not part of this export set
-            const depRef = depEntry.modelComponent.getRef(dep.id.version);
-            if (!depRef) return;
-            if (includedHashesByCompIdStr.get(depCompIdStr)?.has(depRef.toString())) return;
-            referencedSnaps.push({ depCompIdStr, depRef });
-          });
-        });
+      const headPerCompIdStr = new Map<
+        string,
+        { entry: { modelComponent: ModelComponent; refs: Ref[] }; headVersion: Version }
+      >();
+      await mapSeries(refsPerComponent, async (entry) => {
+        const { modelComponent, refs } = entry;
+        const headRef =
+          laneObject?.getCompHeadIncludeUpdateDependents(modelComponent.toComponentId()) || modelComponent.head;
+        if (!headRef) return;
+        if (!refs.find((ref) => ref.isEqual(headRef))) return; // the head is not part of this export
+        const headVersion = await modelComponent.loadVersion(headRef.toString(), scope.objects, false);
+        if (!headVersion) return;
+        headPerCompIdStr.set(modelComponent.toComponentId().toStringWithoutVersion(), { entry, headVersion });
       });
-      // deliberately a second pass over the original refs' findings only — the added snaps' own deps
-      // are not walked. the remote check validates heads only, so one level is enough.
-      await mapSeries(referencedSnaps, async ({ depCompIdStr, depRef }) => {
-        const includedHashes = includedHashesByCompIdStr.get(depCompIdStr) as Set<string>;
-        if (includedHashes.has(depRef.toString())) return; // referenced by multiple components
-        if (!(await scope.objects.has(depRef))) return; // can only ship what exists locally
-        includedHashes.add(depRef.toString());
-        entryByCompIdStr.get(depCompIdStr)?.refs.push(depRef);
+      const anySquashed = [...headPerCompIdStr.values()].some(({ headVersion }) => headVersion.squashed);
+      if (!anySquashed) return; // no squash in this export set — no snap could have been dropped
+      await mapSeries([...headPerCompIdStr.values()], async ({ headVersion }) => {
+        await mapSeries(headVersion.getAllDependencies(), async (dep) => {
+          if (!dep.id.version || !isSnap(dep.id.version)) return;
+          const depComp = headPerCompIdStr.get(dep.id.toStringWithoutVersion());
+          if (!depComp) return; // the referenced component is not part of this export set
+          if (!depComp.headVersion.squashed) return; // dep history is intact — the pinned snap is on-chain
+          const depRef = depComp.entry.modelComponent.getRef(dep.id.version);
+          if (!depRef) return;
+          if (depComp.entry.refs.find((ref) => ref.isEqual(depRef))) return; // already included
+          if (!(await scope.objects.has(depRef))) return; // can only ship what exists locally
+          depComp.entry.refs.push(depRef);
+        });
       });
     };
 

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -436,7 +436,7 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
     };
 
     /**
-     * a component head may reference — via its direct dependencies — a non-head snap of another
+     * a component head may reference — via its flattened dependencies — a non-head snap of another
      * component in the same export set. this happens when a component keeps pinning an older snap of
      * a dependency that has since advanced (e.g. the component was soft-removed on the lane, so it
      * never gets re-snapped), and the squash of a lane-merge dropped that snap from the dependency's
@@ -445,6 +445,7 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
      * (throwForMissingLocalDependencies) rejects the export. add any such snap that exists locally so
      * it is shipped alongside the selected refs. snaps missing locally were fetched during the
      * lane-merge, see MergeLanesMain.importMissingReferencedDeps().
+     * flattened (not only direct) deps are walked to mirror exactly what the remote check validates.
      * this is cheap by design and a no-op for ordinary exports: only heads are inspected (the remote
      * check validates only versions that are heads, and they're loaded later by the export anyway),
      * only snaps are considered (tags are never squashed out of history), and a ref is added only
@@ -471,12 +472,12 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
       const anySquashed = [...headPerCompIdStr.values()].some(({ headVersion }) => headVersion.squashed);
       if (!anySquashed) return; // no squash in this export set — no snap could have been dropped
       await mapSeries([...headPerCompIdStr.values()], async ({ headVersion }) => {
-        await mapSeries(headVersion.getAllDependencies(), async (dep) => {
-          if (!dep.id.version || !isSnap(dep.id.version)) return;
-          const depComp = headPerCompIdStr.get(dep.id.toStringWithoutVersion());
+        await mapSeries(headVersion.getAllFlattenedDependencies(), async (depId) => {
+          if (!depId.version || !isSnap(depId.version)) return;
+          const depComp = headPerCompIdStr.get(depId.toStringWithoutVersion());
           if (!depComp) return; // the referenced component is not part of this export set
           if (!depComp.headVersion.squashed) return; // dep history is intact — the pinned snap is on-chain
-          const depRef = depComp.entry.modelComponent.getRef(dep.id.version);
+          const depRef = depComp.entry.modelComponent.getRef(depId.version);
           if (!depRef) return;
           if (depComp.entry.refs.find((ref) => ref.isEqual(depRef))) return; // already included
           if (!(await scope.objects.has(depRef))) return; // can only ship what exists locally

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -471,8 +471,11 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
       });
       const anySquashed = [...headPerCompIdStr.values()].some(({ headVersion }) => headVersion.squashed);
       if (!anySquashed) return; // no squash in this export set — no snap could have been dropped
-      await mapSeries([...headPerCompIdStr.values()], async ({ headVersion }) => {
+      await mapSeries([...headPerCompIdStr.values()], async ({ entry: headEntry, headVersion }) => {
         await mapSeries(headVersion.getAllFlattenedDependencies(), async (depId) => {
+          // the remote check validates only same-scope deps (it skips `depId.scope !== scope.name`),
+          // so same-scope is all that needs shipping. also filters out most of the flattened list.
+          if (depId.scope !== headEntry.modelComponent.scope) return;
           if (!depId.version || !isSnap(depId.version)) return;
           const depComp = headPerCompIdStr.get(depId.toStringWithoutVersion());
           if (!depComp) return; // the referenced component is not part of this export set

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -490,10 +490,10 @@ if the scope name is wrong and you've already snapped/tagged, run "bit reset" to
           // already anyway (in which case the export succeeds without shipping it).
           const depVersion = await depComp.entry.modelComponent.loadVersion(depRef.toString(), scope.objects, false);
           if (!depVersion) return;
-          const subRefsExist = await Promise.all(
-            depVersion.refsWithOptions(false, false).map((ref) => scope.objects.has(ref))
-          );
-          if (subRefsExist.some((exists) => !exists)) return;
+          const subRefs = depVersion.refsWithOptions(false, false);
+          // hasMultiple bounds the I/O concurrency, unlike a Promise.all of has() calls
+          const existingSubRefs = await scope.objects.hasMultiple(subRefs);
+          if (existingSubRefs.length !== subRefs.length) return;
           depComp.entry.refs.push(depRef);
         });
       });


### PR DESCRIPTION
When merging a lane to main, the squash rewrites each component's parent chain and drops intermediate snaps. If a component's head still pins a non-head snap of a dependency (e.g. the dependency advanced but the dependent was not re-snapped, or was soft-removed), that snap is no longer part of the dependency's exported history. On a lean lane it exists only on the lane scope, so the export omits it and the remote's dependency-integrity check fails with "the component dependency ... was not found".

- merge: fetch missing referenced snaps (raw objects) from the lane scope, walking the flattened deps of the merged heads.
- export: include any locally-present referenced snap in the export refs, mirroring what the remote check validates (flattened deps of heads).
- cheap by design: only heads are inspected, only snap versions are considered (tags are never squashed out), and export adds refs only when the dependency's head carries the `squashed` marker — a no-op for ordinary exports.

Covered by a new e2e test for both cases: the referenced snap present locally, and only on the lane scope.