### PR TITLE
chore: update node-babel-mocha env to 1.0.3

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -14,7 +14,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.98",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/analytics"
+        "rootDir": "components/legacy/analytics",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "api-reference": {
         "name": "api-reference",
@@ -42,7 +45,10 @@
         "scope": "teambit.toolbox",
         "version": "0.0.7",
         "mainFile": "find-duplications.ts",
-        "rootDir": "scopes/toolbox/array/duplications-finder"
+        "rootDir": "scopes/toolbox/array/duplications-finder",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "aspect": {
         "name": "aspect",
@@ -210,7 +216,10 @@
         "scope": "teambit.react",
         "version": "1.0.56",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/bit-react-transformer"
+        "rootDir": "scopes/react/bit-react-transformer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "bit": {
         "name": "bit",
@@ -224,7 +233,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.194",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/bit-map"
+        "rootDir": "components/legacy/bit-map",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "builder": {
         "name": "builder",
@@ -238,7 +250,10 @@
         "scope": "teambit.pipelines",
         "version": "0.0.410",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/builder-data"
+        "rootDir": "scopes/pipelines/modules/builder-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "bundler": {
         "name": "bundler",
@@ -301,21 +316,30 @@
         "scope": "teambit.toolbox",
         "version": "0.0.54",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/tables/cli-table"
+        "rootDir": "scopes/toolbox/tables/cli-table",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "cli/error": {
         "name": "cli/error",
         "scope": "teambit.legacy",
         "version": "0.0.49",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/cli/error"
+        "rootDir": "components/legacy/cli/error",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "cli/webpack-events-listener": {
         "name": "cli/webpack-events-listener",
         "scope": "teambit.preview",
         "version": "0.0.182",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/cli/webpack-events-listener"
+        "rootDir": "scopes/preview/cli/webpack-events-listener",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "cloud": {
         "name": "cloud",
@@ -378,21 +402,30 @@
         "scope": "teambit.legacy",
         "version": "0.0.193",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-diff"
+        "rootDir": "components/legacy/component-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "component-issues": {
         "name": "component-issues",
         "scope": "teambit.component",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "components/component-issues"
+        "rootDir": "components/component-issues",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "component-list": {
         "name": "component-list",
         "scope": "teambit.legacy",
         "version": "0.0.191",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-list"
+        "rootDir": "components/legacy/component-list",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "component-log": {
         "name": "component-log",
@@ -406,7 +439,10 @@
         "scope": "teambit.component",
         "version": "0.0.454",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-package-version"
+        "rootDir": "scopes/component/component-package-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "component-sizer": {
         "name": "component-sizer",
@@ -469,28 +505,40 @@
         "scope": "teambit.legacy",
         "version": "0.0.34",
         "mainFile": "constants.ts",
-        "rootDir": "components/legacy/constants"
+        "rootDir": "components/legacy/constants",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "consumer": {
         "name": "consumer",
         "scope": "teambit.legacy",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer"
+        "rootDir": "components/legacy/consumer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "consumer-component": {
         "name": "consumer-component",
         "scope": "teambit.legacy",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-component"
+        "rootDir": "components/legacy/consumer-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "consumer-config": {
         "name": "consumer-config",
         "scope": "teambit.legacy",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-config"
+        "rootDir": "components/legacy/consumer-config",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "content/cli-reference": {
         "name": "content/cli-reference",
@@ -518,7 +566,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.140",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/dependency-graph"
+        "rootDir": "components/legacy/dependency-graph",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "dependency-resolver": {
         "name": "dependency-resolver",
@@ -560,7 +611,10 @@
         "scope": "teambit.semantics",
         "version": "0.0.145",
         "mainFile": "index.ts",
-        "rootDir": "components/semantics/doc-parser"
+        "rootDir": "components/semantics/doc-parser",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "docs": {
         "name": "docs",
@@ -595,21 +649,30 @@
         "scope": "teambit.lanes",
         "version": "0.0.193",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/entities/lane-diff"
+        "rootDir": "scopes/lanes/entities/lane-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "entities/semantic-schema": {
         "name": "entities/semantic-schema",
         "scope": "teambit.semantics",
         "version": "0.0.107",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema"
+        "rootDir": "components/entities/semantic-schema",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "entities/semantic-schema-diff": {
         "name": "entities/semantic-schema-diff",
         "scope": "teambit.semantics",
         "version": "0.0.7",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema-diff"
+        "rootDir": "components/entities/semantic-schema-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "env": {
         "name": "env",
@@ -637,14 +700,20 @@
         "scope": "teambit.react",
         "version": "2.0.15",
         "mainFile": "index.js",
-        "rootDir": "scopes/react/eslint-config-bit-react"
+        "rootDir": "scopes/react/eslint-config-bit-react",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "eslint/config-mutator": {
         "name": "eslint/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.127",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint-config-mutator"
+        "rootDir": "scopes/defender/eslint-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "export": {
         "name": "export",
@@ -665,7 +734,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/extension-data"
+        "rootDir": "components/legacy/extension-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "forking": {
         "name": "forking",
@@ -693,7 +765,10 @@
         "scope": "teambit.toolbox",
         "version": "0.0.31",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/hard-link-directory"
+        "rootDir": "scopes/toolbox/fs/hard-link-directory",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "fs/is-dir-empty": {
         "name": "fs/is-dir-empty",
@@ -721,7 +796,10 @@
         "scope": "teambit.dependencies",
         "version": "0.0.64",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/fs/linked-dependencies"
+        "rootDir": "scopes/dependencies/fs/linked-dependencies",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "fs/remove-empty-dir": {
         "name": "fs/remove-empty-dir",
@@ -742,7 +820,10 @@
         "scope": "teambit.bit",
         "version": "0.0.20",
         "mainFile": "index.ts",
-        "rootDir": "components/bit/get-bit-version"
+        "rootDir": "components/bit/get-bit-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "git": {
         "name": "git",
@@ -784,14 +865,20 @@
         "scope": "teambit.cloud",
         "version": "0.0.25",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-cloud-scopes"
+        "rootDir": "scopes/cloud/hooks/use-cloud-scopes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "hooks/use-current-user": {
         "name": "hooks/use-current-user",
         "scope": "teambit.cloud",
         "version": "0.0.30",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-current-user"
+        "rootDir": "scopes/cloud/hooks/use-current-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "hooks/use-lane-components": {
         "name": "hooks/use-lane-components",
@@ -812,7 +899,10 @@
         "scope": "teambit.cloud",
         "version": "0.0.23",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-logout"
+        "rootDir": "scopes/cloud/hooks/use-logout",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "hooks/use-navigation-message-listener": {
         "name": "hooks/use-navigation-message-listener",
@@ -833,7 +923,10 @@
         "scope": "teambit.lanes",
         "version": "0.0.260",
         "mainFile": "index.ts",
-        "rootDir": "components/hooks/use-viewed-lane-from-url_1"
+        "rootDir": "components/hooks/use-viewed-lane-from-url_1",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "host-initializer": {
         "name": "host-initializer",
@@ -903,7 +996,10 @@
         "scope": "teambit.toolbox",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/json/jsonc-utils"
+        "rootDir": "scopes/toolbox/json/jsonc-utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "lanes": {
         "name": "lanes",
@@ -917,7 +1013,10 @@
         "scope": "teambit.component",
         "version": "0.0.422",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy-component-log"
+        "rootDir": "components/legacy-component-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "linter": {
         "name": "linter",
@@ -938,14 +1037,20 @@
         "scope": "teambit.legacy",
         "version": "0.0.23",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/loader"
+        "rootDir": "components/legacy/loader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "mcp-config-writer": {
         "name": "mcp-config-writer",
         "scope": "teambit.mcp",
         "version": "0.0.13",
         "mainFile": "index.ts",
-        "rootDir": "components/mcp/mcp-config-writer"
+        "rootDir": "components/mcp/mcp-config-writer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -987,56 +1092,80 @@
         "scope": "teambit.compositions",
         "version": "0.0.525",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/model/composition-type"
+        "rootDir": "scopes/compositions/model/composition-type",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "models/cloud-scope": {
         "name": "models/cloud-scope",
         "scope": "teambit.cloud",
         "version": "0.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-scope"
+        "rootDir": "scopes/cloud/models/cloud-scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "models/cloud-user": {
         "name": "models/cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-user"
+        "rootDir": "scopes/cloud/models/cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "models/scope-model": {
         "name": "models/scope-model",
         "scope": "teambit.scope",
         "version": "0.0.556",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/models/scope-model"
+        "rootDir": "scopes/scope/models/scope-model",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/babel-compiler": {
         "name": "modules/babel-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.146",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/modules/babel-compiler"
+        "rootDir": "scopes/compilation/modules/babel-compiler",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/component-package-name": {
         "name": "modules/component-package-name",
         "scope": "teambit.pkg",
         "version": "0.0.144",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/component-package-name"
+        "rootDir": "components/modules/component-package-name",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/component-url": {
         "name": "modules/component-url",
         "scope": "teambit.component",
         "version": "0.0.195",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-url"
+        "rootDir": "scopes/component/component-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/concurrency": {
         "name": "modules/concurrency",
         "scope": "teambit.harmony",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/concurrency"
+        "rootDir": "scopes/harmony/modules/concurrency",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/config-mutator": {
         "name": "modules/config-mutator",
@@ -1050,49 +1179,70 @@
         "scope": "teambit.html",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/create-element-from-string"
+        "rootDir": "scopes/html/modules/create-element-from-string",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/create-lane": {
         "name": "modules/create-lane",
         "scope": "teambit.lanes",
         "version": "0.0.172",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/modules/create-lane"
+        "rootDir": "scopes/lanes/modules/create-lane",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/diff": {
         "name": "modules/diff",
         "scope": "teambit.lanes",
         "version": "0.0.642",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/diff"
+        "rootDir": "scopes/lanes/diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/feature-toggle": {
         "name": "modules/feature-toggle",
         "scope": "teambit.harmony",
         "version": "0.0.46",
         "mainFile": "feature-toggle.ts",
-        "rootDir": "scopes/harmony/modules/feature-toggle"
+        "rootDir": "scopes/harmony/modules/feature-toggle",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/fetch-html-from-url": {
         "name": "modules/fetch-html-from-url",
         "scope": "teambit.html",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/fetch-html-from-url"
+        "rootDir": "scopes/html/modules/fetch-html-from-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/find-scope-path": {
         "name": "modules/find-scope-path",
         "scope": "teambit.scope",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/find-scope-path"
+        "rootDir": "components/modules/find-scope-path",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/fs-cache": {
         "name": "modules/fs-cache",
         "scope": "teambit.workspace",
         "version": "0.0.64",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/fs-cache"
+        "rootDir": "scopes/workspace/modules/fs-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/generate-asset-manifest": {
         "name": "modules/generate-asset-manifest",
@@ -1106,14 +1256,20 @@
         "scope": "teambit.webpack",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-expose-loaders"
+        "rootDir": "scopes/webpack/modules/generate-expose-loaders",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/generate-externals": {
         "name": "modules/generate-externals",
         "scope": "teambit.webpack",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-externals"
+        "rootDir": "scopes/webpack/modules/generate-externals",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/generate-style-loaders": {
         "name": "modules/generate-style-loaders",
@@ -1127,70 +1283,100 @@
         "scope": "teambit.harmony",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/get-basic-log"
+        "rootDir": "scopes/harmony/modules/get-basic-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/get-cloud-user": {
         "name": "modules/get-cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/modules/get-cloud-user"
+        "rootDir": "scopes/cloud/modules/get-cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/git-executable": {
         "name": "modules/git-executable",
         "scope": "teambit.git",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/git-executable"
+        "rootDir": "scopes/git/modules/git-executable",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/harmony-root-generator": {
         "name": "modules/harmony-root-generator",
         "scope": "teambit.harmony",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/harmony-root-generator"
+        "rootDir": "components/modules/harmony-root-generator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/ignore-file-reader": {
         "name": "modules/ignore-file-reader",
         "scope": "teambit.git",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/ignore-file-reader"
+        "rootDir": "scopes/git/modules/ignore-file-reader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/in-memory-cache": {
         "name": "modules/in-memory-cache",
         "scope": "teambit.harmony",
         "version": "0.0.38",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/in-memory-cache"
+        "rootDir": "scopes/harmony/modules/in-memory-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/load-trace": {
         "name": "modules/load-trace",
         "scope": "teambit.harmony",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/load-trace"
+        "rootDir": "scopes/harmony/modules/load-trace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/match-pattern": {
         "name": "modules/match-pattern",
         "scope": "teambit.workspace",
         "version": "0.0.526",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/match-pattern"
+        "rootDir": "scopes/workspace/modules/match-pattern",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/merge-component-results": {
         "name": "modules/merge-component-results",
         "scope": "teambit.pipelines",
         "version": "0.0.517",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/merge-component-results"
+        "rootDir": "scopes/pipelines/modules/merge-component-results",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/merge-helper": {
         "name": "modules/merge-helper",
         "scope": "teambit.component",
         "version": "0.0.80",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/modules/merge-helper"
+        "rootDir": "scopes/component/modules/merge-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/module-resolver": {
         "name": "modules/module-resolver",
@@ -1204,56 +1390,80 @@
         "scope": "teambit.workspace",
         "version": "0.0.368",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/node-modules-linker"
+        "rootDir": "scopes/workspace/modules/node-modules-linker",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/requireable-component": {
         "name": "modules/requireable-component",
         "scope": "teambit.harmony",
         "version": "0.0.518",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/requireable-component"
+        "rootDir": "scopes/harmony/modules/requireable-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/resolved-component": {
         "name": "modules/resolved-component",
         "scope": "teambit.harmony",
         "version": "0.0.518",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/resolved-component"
+        "rootDir": "scopes/harmony/modules/resolved-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/semver-helper": {
         "name": "modules/semver-helper",
         "scope": "teambit.pkg",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/modules/semver-helper"
+        "rootDir": "scopes/pkg/modules/semver-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/send-server-sent-events": {
         "name": "modules/send-server-sent-events",
         "scope": "teambit.harmony",
         "version": "0.0.22",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/send-server-sent-events"
+        "rootDir": "scopes/harmony/modules/send-server-sent-events",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/style-regexps": {
         "name": "modules/style-regexps",
         "scope": "teambit.webpack",
         "version": "1.0.25",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/style-regexps"
+        "rootDir": "scopes/webpack/style-regexps",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/ts-config-mutator": {
         "name": "modules/ts-config-mutator",
         "scope": "teambit.typescript",
         "version": "0.0.91",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/modules/ts-config-mutator"
+        "rootDir": "scopes/typescript/modules/ts-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "modules/workspace-locator": {
         "name": "modules/workspace-locator",
         "scope": "teambit.workspace",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/workspace-locator"
+        "rootDir": "scopes/workspace/modules/workspace-locator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "mover": {
         "name": "mover",
@@ -1281,7 +1491,10 @@
         "scope": "teambit.scope",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/network"
+        "rootDir": "scopes/scope/network",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "network/get-port": {
         "name": "network/get-port",
@@ -1379,7 +1592,10 @@
         "scope": "teambit.webpack",
         "version": "0.0.29",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin"
+        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "plugins/manifest-plugin": {
         "name": "plugins/manifest-plugin",
@@ -1407,7 +1623,10 @@
         "scope": "teambit.defender",
         "version": "0.0.121",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier-config-mutator"
+        "rootDir": "scopes/defender/prettier-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "preview": {
         "name": "preview",
@@ -1463,14 +1682,20 @@
         "scope": "teambit.scope",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/remote-actions"
+        "rootDir": "scopes/scope/remote-actions",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "remotes": {
         "name": "remotes",
         "scope": "teambit.scope",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "components/scope/remotes"
+        "rootDir": "components/scope/remotes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "remove": {
         "name": "remove",
@@ -1519,7 +1744,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.192",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope-api"
+        "rootDir": "components/legacy/scope-api",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "scripts": {
         "name": "scripts",
@@ -1540,7 +1768,10 @@
         "scope": "teambit.component",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snap-distance"
+        "rootDir": "scopes/component/snap-distance",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "snapping": {
         "name": "snapping",
@@ -1554,7 +1785,10 @@
         "scope": "teambit.component",
         "version": "0.0.189",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/sources"
+        "rootDir": "scopes/component/sources",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "stash": {
         "name": "stash",
@@ -1631,14 +1865,20 @@
         "scope": "teambit.legacy",
         "version": "0.0.49",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/logger"
+        "rootDir": "components/legacy/logger",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "teambit.legacy/scope": {
         "name": "scope",
         "scope": "teambit.legacy",
         "version": "0.0.137",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope"
+        "rootDir": "components/legacy/scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "teambit.scope/scope": {
         "name": "scope",
@@ -1659,21 +1899,30 @@
         "scope": "teambit.harmony",
         "version": "0.0.403",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/testing/load-aspect"
+        "rootDir": "scopes/harmony/testing/load-aspect",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "testing/mock-components": {
         "name": "testing/mock-components",
         "scope": "teambit.component",
         "version": "0.0.408",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/testing/mock-components"
+        "rootDir": "scopes/component/testing/mock-components",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "testing/mock-workspace": {
         "name": "testing/mock-workspace",
         "scope": "teambit.workspace",
         "version": "0.0.214",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/testing/mock-workspace"
+        "rootDir": "scopes/workspace/testing/mock-workspace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "time/timer": {
         "name": "time/timer",
@@ -1694,7 +1943,10 @@
         "scope": "teambit.typescript",
         "version": "0.0.84",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/ts-server"
+        "rootDir": "scopes/typescript/ts-server",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "types/serializable": {
         "name": "types/serializable",
@@ -2135,7 +2387,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.42",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/utils"
+        "rootDir": "components/legacy/utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@1.0.3": {}
+        }
     },
     "validator": {
         "name": "validator",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2160,8 +2160,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@teambit/node.envs.node-typescript-mocha':
         specifier: 1.0.1
         version: 1.0.1(@babel/core@7.28.3)
@@ -2206,8 +2206,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2240,8 +2240,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2366,8 +2366,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2403,8 +2403,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2621,8 +2621,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2652,8 +2652,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2701,8 +2701,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2774,8 +2774,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2826,8 +2826,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2893,8 +2893,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -2942,8 +2942,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2976,8 +2976,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -3031,8 +3031,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3095,8 +3095,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3156,8 +3156,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3217,8 +3217,8 @@ importers:
         version: 2.1.6
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3372,8 +3372,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3415,8 +3415,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/pretty-time':
         specifier: ^1.1.5
         version: 1.1.5
@@ -3470,8 +3470,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3555,8 +3555,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3619,8 +3619,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3680,8 +3680,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3723,8 +3723,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3763,8 +3763,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -3797,8 +3797,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3871,8 +3871,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -4161,8 +4161,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -4207,8 +4207,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -6501,7 +6501,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -6678,7 +6678,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -6714,13 +6714,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -6768,7 +6768,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -7095,13 +7095,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7110,10 +7110,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7197,7 +7197,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -7293,7 +7293,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -7326,13 +7326,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -7455,7 +7455,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -7632,7 +7632,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -7668,13 +7668,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -7722,7 +7722,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -8055,13 +8055,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8070,10 +8070,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8157,7 +8157,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -8253,7 +8253,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -8286,13 +8286,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -9419,7 +9419,7 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
 
-  node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@1.0.2:
+  node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@1.0.3:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -9471,7 +9471,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -9648,7 +9648,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -9684,13 +9684,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -9738,7 +9738,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -10004,8 +10004,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -10071,13 +10071,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10086,10 +10086,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10173,7 +10173,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -10269,7 +10269,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -10302,13 +10302,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -10455,7 +10455,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -10632,7 +10632,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -10668,13 +10668,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -10722,7 +10722,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -11055,13 +11055,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11070,10 +11070,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11157,7 +11157,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -11253,7 +11253,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -11286,13 +11286,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -11442,7 +11442,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -11619,7 +11619,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -11655,13 +11655,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -11709,7 +11709,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -11976,7 +11976,7 @@ importers:
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.node':
         specifier: 3.0.1
-        version: 3.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -12042,13 +12042,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12057,10 +12057,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12144,7 +12144,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -12240,7 +12240,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -12273,13 +12273,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -12357,10 +12357,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -12369,7 +12369,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -12444,7 +12444,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -12621,7 +12621,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -12657,13 +12657,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -12711,7 +12711,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -13038,7 +13038,7 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.3
         version: 1.1.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -13047,7 +13047,7 @@ importers:
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13056,10 +13056,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13143,7 +13143,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -13239,7 +13239,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -13272,13 +13272,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -13350,10 +13350,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -13362,7 +13362,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -13437,7 +13437,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -13614,7 +13614,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -13650,13 +13650,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(react@19.1.0)
@@ -13704,7 +13704,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.12)(graphql@15.8.0)(react@19.1.0)
@@ -14031,13 +14031,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14046,10 +14046,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14133,7 +14133,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -14229,7 +14229,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -14262,13 +14262,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -14507,8 +14507,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14544,8 +14544,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14578,8 +14578,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14612,8 +14612,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14643,8 +14643,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14674,8 +14674,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15199,8 +15199,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/babel__core':
         specifier: 7.20.0
         version: 7.20.0
@@ -15830,8 +15830,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -15950,8 +15950,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16654,8 +16654,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16996,8 +16996,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -17166,8 +17166,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -17322,8 +17322,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17706,8 +17706,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17859,8 +17859,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -18220,8 +18220,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18780,8 +18780,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -19716,8 +19716,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -19753,8 +19753,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21045,8 +21045,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21076,8 +21076,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21113,8 +21113,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21147,8 +21147,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21178,8 +21178,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21212,8 +21212,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21243,8 +21243,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21274,8 +21274,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21433,8 +21433,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21599,8 +21599,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21630,8 +21630,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21676,8 +21676,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21713,8 +21713,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21938,8 +21938,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -22369,8 +22369,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -22406,8 +22406,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -22486,8 +22486,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -22657,8 +22657,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -22977,8 +22977,8 @@ importers:
         specifier: 7.22.3
         version: 7.22.3
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.19.6)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.19.6)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -23038,8 +23038,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -23885,8 +23885,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23958,8 +23958,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/http-proxy-agent':
         specifier: 2.0.2
         version: 2.0.2
@@ -24101,8 +24101,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -24408,8 +24408,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24488,8 +24488,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24700,8 +24700,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -25185,8 +25185,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -25392,8 +25392,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -25450,8 +25450,8 @@ importers:
         version: 3.16.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26094,8 +26094,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -26128,8 +26128,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -26199,8 +26199,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -26230,8 +26230,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -26711,8 +26711,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -26757,8 +26757,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -26812,8 +26812,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26852,8 +26852,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26935,8 +26935,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)
+        specifier: 1.0.3
+        version: 1.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -35830,8 +35830,8 @@ packages:
   '@teambit/node.deps-detectors.parser-helper@0.0.6':
     resolution: {integrity: sha512-dSHRaKL9ScGkWx2+NE/smUqBrhC+knh9u5aCREKohkBCejt0siZDsu7toQP5/mtwBOrlU97KjJBxbKXr32rIDQ==}
 
-  '@teambit/node.envs.node-babel-mocha@1.0.2':
-    resolution: {integrity: sha512-RdemnPKdAmJeJxjms7QMS20dlynjW0m4P42hXgkohO/degxmtRUwbffZWRzax9qOhN2a+/TJmNk7OBrmB1xfNQ==}
+  '@teambit/node.envs.node-babel-mocha@1.0.3':
+    resolution: {integrity: sha512-ysJ65jofT5nxI4we+mNzsKg7hnuNBL0j0RzNG/VoPMusiXV01osAARqG2HUtzE2CIXp4IDlgyGW0RLHvqdY9fA==}
 
   '@teambit/node.envs.node-typescript-mocha@1.0.1':
     resolution: {integrity: sha512-zrhUK1y0DaF0AkOQttgbG7M1Bos5H23hYfA8nAh2FIw18JhV1PvoXWB4+XZbfaKAfkphnoAZmlBrleYc3KXz9A==}
@@ -57493,7 +57493,7 @@ snapshots:
 
   '@teambit/api-reference.models.api-node-renderer@0.0.53(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
       react: 18.3.1
@@ -57553,7 +57553,7 @@ snapshots:
   '@teambit/api-reference.overview.api-reference-table-of-contents@0.0.41(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -57569,30 +57569,6 @@ snapshots:
       core-js: 3.13.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-
-  '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary@0.0.47(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.parameter': 0.0.67(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.78(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
-      '@teambit/api-reference.utils.group-schema-node-by-signature': 0.0.45
-      '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
-      '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.ui.table-heading-row': 4.0.11(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/semantics.entities.semantic-schema': 0.0.95
-      classnames: 2.2.6
-      core-js: 3.13.0
-      pluralize: 8.0.0
-      react: 18.3.1
-      react-dom: 19.1.0(react@18.3.1)
-      react-syntax-highlighter: 15.6.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@testing-library/react-hooks'
-      - '@types/react'
-      - '@types/react-dom'
-      - react-router-dom
 
   '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary@0.0.47(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)':
     dependencies:
@@ -57616,6 +57592,27 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - react-router-dom
+
+  '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary@0.0.47(@teambit/base-react.navigation.link@2.0.33)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.parameter': 0.0.67(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.78(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
+      '@teambit/api-reference.utils.group-schema-node-by-signature': 0.0.45
+      '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
+      '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/documenter.ui.table-heading-row': 4.0.11(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/semantics.entities.semantic-schema': 0.0.95
+      classnames: 2.2.6
+      core-js: 3.13.0
+      pluralize: 8.0.0
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+      react-syntax-highlighter: 15.6.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary@0.0.47(@teambit/base-react.navigation.link@2.0.33)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
@@ -57850,6 +57847,28 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  '@teambit/api-reference.renderers.api-node-details@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/api-reference.renderers.schema-nodes-index': 0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.utils.code-editor-options': 0.0.16
+      '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/code.ui.code-editor': 0.0.14(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+      react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+
   '@teambit/api-reference.renderers.api-node-details@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)':
     dependencies:
       '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -57871,27 +57890,6 @@ snapshots:
       - '@testing-library/react-hooks'
       - '@types/react'
       - '@types/react-dom'
-
-  '@teambit/api-reference.renderers.api-node-details@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/api-reference.renderers.schema-nodes-index': 0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.utils.code-editor-options': 0.0.16
-      '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/code.ui.code-editor': 0.0.14(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 18.3.1
-      react-dom: 19.1.0(react@18.3.1)
-      react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@testing-library/react-hooks'
-      - '@types/react'
 
   '@teambit/api-reference.renderers.api-node-details@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)':
     dependencies:
@@ -57962,7 +57960,7 @@ snapshots:
       '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/api-reference.renderers.schema-nodes-index': 0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.renderers.schema-nodes-index': 0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.utils.code-editor-options': 0.0.16
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/code.ui.code-editor': 0.0.16(react-dom@19.1.0)(react@18.3.1)
@@ -58193,7 +58191,7 @@ snapshots:
       '@teambit/api-reference.renderers.inference-type': 0.0.66(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.renderers.interface': 0.0.84(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.this': 0.0.71(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.renderers.this': 0.0.71(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.tuple-type': file:components/renderers/tuple-type(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.renderers.type': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.type-array': 0.0.55(react-dom@19.1.0)(react@18.3.1)
@@ -58201,8 +58199,8 @@ snapshots:
       '@teambit/api-reference.renderers.type-literal': 0.0.75(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.type-ref': 0.0.101(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.type-union': 0.0.55(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.unresolved': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.renderers.variable': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.renderers.unresolved': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.renderers.variable': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       core-js: 3.13.0
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
@@ -58268,8 +58266,8 @@ snapshots:
   '@teambit/api-reference.renderers.enum@0.0.84(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.grouped-schema-nodes-summary': 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
@@ -58588,8 +58586,8 @@ snapshots:
   '@teambit/api-reference.renderers.interface@0.0.84(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.grouped-schema-nodes-summary': 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
@@ -58798,7 +58796,7 @@ snapshots:
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.renderers.parameter': 0.0.67(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
       '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
@@ -58973,7 +58971,7 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
-  '@teambit/api-reference.renderers.schema-nodes-index@0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
+  '@teambit/api-reference.renderers.schema-nodes-index@0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.78(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
@@ -58985,11 +58983,9 @@ snapshots:
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
     transitivePeerDependencies:
-      - '@testing-library/react'
       - '@testing-library/react-hooks'
       - '@types/react'
       - '@types/react-dom'
-      - react-router-dom
 
   '@teambit/api-reference.renderers.schema-nodes-index@0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
@@ -59024,6 +59020,23 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
+  '@teambit/api-reference.renderers.this@0.0.71(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.type-ref': 0.0.99(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/semantics.entities.semantic-schema': 0.0.95
+      core-js: 3.13.0
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    transitivePeerDependencies:
+      - '@teambit/base-react.navigation.link'
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
   '@teambit/api-reference.renderers.this@0.0.71(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)':
     dependencies:
       '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -59039,22 +59052,6 @@ snapshots:
       - '@testing-library/react-hooks'
       - '@types/react'
       - '@types/react-dom'
-      - react-router-dom
-
-  '@teambit/api-reference.renderers.this@0.0.71(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.type-ref': 0.0.99(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/semantics.entities.semantic-schema': 0.0.95
-      core-js: 3.13.0
-      react: 18.3.1
-      react-dom: 19.1.0(react@18.3.1)
-    transitivePeerDependencies:
-      - '@teambit/base-react.navigation.link'
-      - '@testing-library/react'
-      - '@testing-library/react-hooks'
-      - '@types/react'
       - react-router-dom
 
   '@teambit/api-reference.renderers.this@0.0.71(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)':
@@ -59150,7 +59147,7 @@ snapshots:
   '@teambit/api-reference.renderers.type-literal@0.0.75(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.renderers.grouped-schema-nodes-summary': 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/api-reference.utils.copy-schema-node': 0.0.45
       '@teambit/semantics.entities.semantic-schema': 0.0.95
@@ -59302,6 +59299,27 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
+  '@teambit/api-reference.renderers.type-ref@0.0.99(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.utils.copy-schema-node': 0.0.45
+      '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/component-id': 1.2.4
+      '@teambit/component.modules.component-url': 0.0.182(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/semantics.entities.semantic-schema': 0.0.95
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
   '@teambit/api-reference.renderers.type-ref@0.0.99(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)':
     dependencies:
       '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -59321,26 +59339,6 @@ snapshots:
       - '@testing-library/react-hooks'
       - '@types/react'
       - '@types/react-dom'
-      - react-router-dom
-
-  '@teambit/api-reference.renderers.type-ref@0.0.99(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/api-reference.hooks.use-api-ref-url': 0.0.25(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.utils.copy-schema-node': 0.0.45
-      '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/component-id': 1.2.4
-      '@teambit/component.modules.component-url': 0.0.182(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/semantics.entities.semantic-schema': 0.0.95
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 18.3.1
-      react-dom: 19.1.0(react@18.3.1)
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@testing-library/react-hooks'
-      - '@types/react'
       - react-router-dom
 
   '@teambit/api-reference.renderers.type-ref@0.0.99(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)':
@@ -59409,8 +59407,8 @@ snapshots:
   '@teambit/api-reference.renderers.type@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/api-reference.overview.renderers.grouped-schema-nodes-overview-summary': 0.0.47(@teambit/base-react.navigation.link@2.0.33)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
       react: 18.3.1
@@ -59472,6 +59470,22 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
+  '@teambit/api-reference.renderers.unresolved@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/semantics.entities.semantic-schema': 0.0.95
+      core-js: 3.13.0
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    transitivePeerDependencies:
+      - '@teambit/base-react.navigation.link'
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
   '@teambit/api-reference.renderers.unresolved@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -59486,21 +59500,6 @@ snapshots:
       - '@testing-library/react-hooks'
       - '@types/react'
       - '@types/react-dom'
-      - react-router-dom
-
-  '@teambit/api-reference.renderers.unresolved@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/semantics.entities.semantic-schema': 0.0.95
-      core-js: 3.13.0
-      react: 18.3.1
-      react-dom: 19.1.0(react@18.3.1)
-    transitivePeerDependencies:
-      - '@teambit/base-react.navigation.link'
-      - '@testing-library/react'
-      - '@testing-library/react-hooks'
-      - '@types/react'
       - react-router-dom
 
   '@teambit/api-reference.renderers.unresolved@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)':
@@ -59533,6 +59532,22 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
+  '@teambit/api-reference.renderers.variable@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
+      '@teambit/semantics.entities.semantic-schema': 0.0.95
+      core-js: 3.13.0
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    transitivePeerDependencies:
+      - '@teambit/base-react.navigation.link'
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
   '@teambit/api-reference.renderers.variable@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -59547,21 +59562,6 @@ snapshots:
       - '@testing-library/react-hooks'
       - '@types/react'
       - '@types/react-dom'
-      - react-router-dom
-
-  '@teambit/api-reference.renderers.variable@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.renderers.api-node-details': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/semantics.entities.semantic-schema': 0.0.95
-      core-js: 3.13.0
-      react: 18.3.1
-      react-dom: 19.1.0(react@18.3.1)
-    transitivePeerDependencies:
-      - '@teambit/base-react.navigation.link'
-      - '@testing-library/react'
-      - '@testing-library/react-hooks'
-      - '@types/react'
       - react-router-dom
 
   '@teambit/api-reference.renderers.variable@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)':
@@ -59701,6 +59701,10 @@ snapshots:
   '@teambit/api-reference.utils.schema-node-signature-transform@0.0.47':
     dependencies:
       '@teambit/semantics.entities.semantic-schema': 0.0.92
+
+  '@teambit/api-reference.utils.sort-api-nodes@0.0.53':
+    dependencies:
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
 
   '@teambit/api-reference.utils.sort-api-nodes@0.0.53(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
@@ -62461,7 +62465,7 @@ snapshots:
       lodash: 4.17.21
       p-limit: 2.3.0
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/component.instructions.exporting-components': 0.0.7(react-dom@19.1.0)(react@19.1.0)
@@ -62470,7 +62474,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -62513,7 +62517,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/component.instructions.exporting-components': 0.0.7(react-dom@19.1.0)(react@19.1.0)
@@ -62522,7 +62526,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -64526,7 +64530,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64548,7 +64552,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64570,7 +64574,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -65203,7 +65207,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -65529,7 +65533,7 @@ snapshots:
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.logger': 0.0.19
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
-      '@teambit/pkg.modules.component-package-name': 0.0.56(graphql@15.8.0)
+      '@teambit/pkg.modules.component-package-name': 0.0.56
       '@teambit/toolbox.fs.link-or-symlink': 0.0.20
       '@teambit/toolbox.fs.remove-empty-dir': 0.0.5
       '@teambit/toolbox.path.path': 0.0.8
@@ -68483,7 +68487,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68768,7 +68772,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
@@ -68800,11 +68804,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -68898,7 +68902,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
@@ -68930,11 +68934,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -69501,18 +69505,18 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -69527,18 +69531,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -69605,18 +69609,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -69655,7 +69659,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@1.6.22)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -69667,7 +69671,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -69683,7 +69687,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -69695,7 +69699,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -69767,7 +69771,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -69779,7 +69783,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -69867,7 +69871,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -69889,7 +69893,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -69911,7 +69915,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -69946,7 +69950,7 @@ snapshots:
     dependencies:
       '@pnpm/dependency-path': 1001.1.10
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
@@ -69967,6 +69971,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/legacy.logger': file:components/legacy/logger
       '@teambit/legacy.utils': file:components/legacy/utils
+      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/node.deps-detectors.detective-es6': 0.0.6
       '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
       '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
@@ -69976,77 +69981,9 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@6.0.3)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      archy: 1.0.0
-      chai: 5.2.1
-      chalk: 4.1.2
-      cli-table: 0.3.6
-      debug: 4.3.4(supports-color@9.4.0)
-      detective-amd: 3.0.1
-      detective-stylus: 1.0.0
-      fs-extra: 10.0.0
-      lodash: 4.17.21
-      module-definition: 3.3.1
-      moment: 2.29.4
-      node-source-walk: 4.2.0
-      p-map-series: 2.1.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      read-pkg-up: 7.0.1
-      resolve-dependency-path: 2.0.0
-      semver: 7.7.1
-      stylus-lookup: 3.0.2
-      table: 6.7.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@pnpm/logger'
-      - domexception
-      - encoding
-      - graphql
-      - postcss
-      - supports-color
-      - typanion
-      - typescript
-
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/bit-error': 0.0.404
-      '@teambit/component-id': 1.2.4
-      '@teambit/component-issues': file:components/component-issues
-      '@teambit/component-package-version': file:scopes/component/component-package-version
-      '@teambit/component-version': 1.0.4
-      '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/component.testing.mock-components': file:scopes/component/testing/mock-components(graphql@15.8.0)
-      '@teambit/harmony': 0.4.12
-      '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
-      '@teambit/legacy.bit-map': file:components/legacy/bit-map(graphql@15.8.0)
-      '@teambit/legacy.constants': file:components/legacy/constants
-      '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
-      '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
-      '@teambit/legacy.dependency-graph': file:components/legacy/dependency-graph(graphql@15.8.0)
-      '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
-      '@teambit/legacy.logger': file:components/legacy/logger
-      '@teambit/legacy.utils': file:components/legacy/utils
-      '@teambit/node.deps-detectors.detective-es6': 0.0.6
-      '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-sass': 0.0.9(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-scss': 0.0.9(postcss@8.4.45)
-      '@teambit/styling.deps-lookups.lookup-styling': 0.0.4
-      '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
-      '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
-      '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
-      '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -70103,6 +70040,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/legacy.logger': file:components/legacy/logger
       '@teambit/legacy.utils': file:components/legacy/utils
+      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/node.deps-detectors.detective-es6': 0.0.6
       '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
       '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
@@ -70174,7 +70112,6 @@ snapshots:
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
       '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
-      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/pkg.entities.registry': 0.0.4
       '@teambit/pkg.modules.component-package-name': file:components/modules/component-package-name(graphql@15.8.0)
       '@teambit/pkg.modules.semver-helper': file:scopes/pkg/modules/semver-helper
@@ -70241,7 +70178,6 @@ snapshots:
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
       '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
-      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/pkg.entities.registry': 0.0.4
       '@teambit/pkg.modules.component-package-name': file:components/modules/component-package-name(graphql@15.8.0)
       '@teambit/pkg.modules.semver-helper': file:scopes/pkg/modules/semver-helper
@@ -70308,7 +70244,6 @@ snapshots:
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
       '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
-      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/pkg.entities.registry': 0.0.4
       '@teambit/pkg.modules.component-package-name': file:components/modules/component-package-name(graphql@15.8.0)
       '@teambit/pkg.modules.semver-helper': file:scopes/pkg/modules/semver-helper
@@ -74626,22 +74561,6 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@types/react': 19.2.14
-      classnames: 2.5.1
-      prism-react-renderer: 1.3.5(react@19.1.0)
-      react: 19.1.0
-      react-live: 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
-      use-debounce: 9.0.4(react@19.1.0)
-    transitivePeerDependencies:
-      - react-dom
-      - typescript
-
   '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
@@ -74762,9 +74681,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -74775,9 +74694,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -74821,19 +74740,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-syntax-highlighter'
@@ -75011,11 +74917,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@mdx-js/react': 1.6.22(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -75040,11 +74946,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 1.6.22(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -75098,11 +75004,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -75127,11 +75033,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -75207,35 +75113,6 @@ snapshots:
       '@types/react': 19.2.14
       classnames: 2.5.1
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
-      '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.image': 4.0.4(react@19.1.0)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
-      '@teambit/documenter.ui.italic': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.ol': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.separator': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.sup': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.table.base-table': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.table.td': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.table.tr': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.ul': 4.1.7(react@19.1.0)
-      '@types/react': 19.2.14
-      classnames: 2.5.1
-      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-dom'
@@ -76209,33 +76086,6 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/harmony': 0.4.12
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
-      eslint-mdx: 1.17.1(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
-      eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
-      eslint-plugin-react: 7.33.2(eslint@8.56.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-    transitivePeerDependencies:
-      - eslint
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-      - typescript
-
   '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
@@ -76278,7 +76128,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77347,7 +77197,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77841,7 +77691,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77863,7 +77713,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -78512,7 +78362,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -80786,7 +80636,7 @@ snapshots:
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.utils': 0.0.21
       '@teambit/scope.remotes': 0.0.49(graphql@15.8.0)
-      '@teambit/semantics.doc-parser': 0.0.57(graphql@15.8.0)
+      '@teambit/semantics.doc-parser': 0.0.57
       '@teambit/toolbox.crypto.sha1': 0.0.7
       '@teambit/toolbox.fs.last-modified': 0.0.5
       '@teambit/toolbox.path.path': 0.0.8
@@ -81561,7 +81411,7 @@ snapshots:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -82167,10 +82017,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@mdx-js/react': 1.6.22(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.0.7(@types/react@19.2.14)(react@19.1.0)
       core-js: 3.13.0
@@ -82183,10 +82033,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 1.6.22(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.0.7(@types/react@19.2.14)(react@19.1.0)
       core-js: 3.13.0
@@ -82240,22 +82090,6 @@ snapshots:
       core-js: 3.13.0
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - typescript
-
-  '@teambit/mdx.ui.docs.snippet@0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-scope-context': 1.0.7(@types/react@19.2.14)(react@19.1.0)
-      core-js: 3.13.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
@@ -82370,11 +82204,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@types/react': 19.2.14
       react: 19.1.0
     transitivePeerDependencies:
@@ -82385,11 +82219,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       react: 19.1.0
     transitivePeerDependencies:
@@ -82415,11 +82249,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@types/react': 19.2.14
       react: 19.1.0
     transitivePeerDependencies:
@@ -82430,11 +82264,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       react: 19.1.0
     transitivePeerDependencies:
@@ -82467,21 +82301,6 @@ snapshots:
       '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@mdx-js/react'
-      - '@testing-library/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/mdx.ui.mdx-layout@1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.511(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@types/react': 19.2.14
-      react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
       - '@testing-library/react'
@@ -82875,7 +82694,7 @@ snapshots:
 
   '@teambit/node.deps-detectors.parser-helper@0.0.6': {}
 
-  '@teambit/node.envs.node-babel-mocha@1.0.2(@babel/core@7.19.6)':
+  '@teambit/node.envs.node-babel-mocha@1.0.3(@babel/core@7.19.6)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.19.6)
       '@babel/preset-env': 7.28.3(@babel/core@7.19.6)
@@ -82890,7 +82709,7 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
       '@types/mocha': 10.0.10
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -82907,7 +82726,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@teambit/node.envs.node-babel-mocha@1.0.2(@babel/core@7.28.3)':
+  '@teambit/node.envs.node-babel-mocha@1.0.3(@babel/core@7.28.3)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
@@ -82922,7 +82741,7 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
       '@types/mocha': 10.0.10
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -82974,7 +82793,7 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  '@teambit/node.node@3.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@3.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -82991,7 +82810,7 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@5.5.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
@@ -82999,13 +82818,13 @@ snapshots:
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -83553,7 +83372,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -83589,7 +83408,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -83643,7 +83462,7 @@ snapshots:
 
   '@teambit/pkg.entities.registry@0.0.4': {}
 
-  '@teambit/pkg.modules.component-package-name@0.0.56(graphql@15.8.0)':
+  '@teambit/pkg.modules.component-package-name@0.0.56':
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/legacy.constants': 0.0.11
@@ -83652,10 +83471,7 @@ snapshots:
       '@teambit/legacy.utils': 0.0.21
       '@teambit/toolbox.path.path': 0.0.8
     transitivePeerDependencies:
-      - domexception
       - encoding
-      - graphql
-      - supports-color
 
   '@teambit/pkg.modules.component-package-name@file:components/modules/component-package-name(graphql@15.8.0)':
     dependencies:
@@ -84121,7 +83937,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -84465,13 +84281,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@5.5.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -85769,7 +85585,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -85898,26 +85714,6 @@ snapshots:
       - eslint-plugin-jsx-a11y
       - eslint-plugin-react
       - eslint-plugin-react-hooks
-      - supports-color
-      - typescript
-
-  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
-      eslint: 8.56.0
-      eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
-      eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-    transitivePeerDependencies:
-      - jest
       - supports-color
       - typescript
 
@@ -87497,27 +87293,6 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      classnames: 2.5.1
-      core-js: 3.13.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    transitivePeerDependencies:
-      - '@mdx-js/react'
-      - '@testing-library/react'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - encoding
-      - graphql
-      - typescript
-
   '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
@@ -87539,13 +87314,34 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      classnames: 2.5.1
+      core-js: 3.13.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@mdx-js/react'
+      - '@testing-library/react'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - encoding
+      - graphql
+      - typescript
+
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -87581,13 +87377,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -87885,24 +87681,6 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      core-js: 3.13.0
-      lodash: 4.17.21
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-error-boundary: 3.1.4(react@19.1.0)
-    transitivePeerDependencies:
-      - '@mdx-js/react'
-      - '@testing-library/react'
-      - '@types/react-syntax-highlighter'
-      - typescript
-
   '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
@@ -87921,10 +87699,28 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@1.6.22)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      core-js: 3.13.0
+      lodash: 4.17.21
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-error-boundary: 3.1.4(react@19.1.0)
+    transitivePeerDependencies:
+      - '@mdx-js/react'
+      - '@testing-library/react'
+      - '@types/react-syntax-highlighter'
+      - typescript
+
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -87957,10 +87753,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -88055,11 +87851,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -88071,11 +87867,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -89605,7 +89401,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
       '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
@@ -89614,7 +89410,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@5.5.3)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -89622,7 +89418,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -89637,7 +89433,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -92141,7 +91937,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
 
-  '@teambit/semantics.doc-parser@0.0.57(graphql@15.8.0)':
+  '@teambit/semantics.doc-parser@0.0.57':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component.sources': 0.0.101(graphql@15.8.0)
@@ -92153,9 +91949,7 @@ snapshots:
       fs-extra: 10.0.0
       react-docgen: 5.3.1
     transitivePeerDependencies:
-      - domexception
       - encoding
-      - graphql
       - supports-color
 
   '@teambit/semantics.doc-parser@file:components/semantics/doc-parser':
@@ -92520,7 +92314,7 @@ snapshots:
       - '@apollo/client'
       - '@teambit/base-react.navigation.link'
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
@@ -92528,9 +92322,9 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -92606,7 +92400,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
@@ -92614,9 +92408,9 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -93089,7 +92883,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -93219,7 +93013,7 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/compilation.compiler-task': 1.0.12
       comment-json: 4.2.3
-      fs-extra: 11.3.0
+      fs-extra: 11.3.4
       get-tsconfig: 4.2.0
       glob: 10.4.5
       globby: 11.1.0
@@ -93233,7 +93027,7 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/compilation.compiler-task': 1.0.12
       comment-json: 4.2.3
-      fs-extra: 11.3.0
+      fs-extra: 11.3.4
       get-tsconfig: 4.2.0
       glob: 10.4.5
       globby: 11.1.0
@@ -93247,7 +93041,7 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/compilation.compiler-task': 1.0.12
       comment-json: 4.2.3
-      fs-extra: 11.3.0
+      fs-extra: 11.3.4
       get-tsconfig: 4.2.0
       glob: 10.4.5
       globby: 11.1.0
@@ -95222,7 +95016,7 @@ snapshots:
     dependencies:
       url-parse: 1.5.3
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -95276,7 +95070,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -95392,7 +95186,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -95446,7 +95240,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -95610,7 +95404,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -95626,7 +95420,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      vue-component-meta: 2.2.10(typescript@5.5.3)
+      vue-component-meta: 2.2.10(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -96401,37 +96195,6 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
-    dependencies:
-      '@teambit/toolbox.path.path': 0.0.8
-      '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@19.1.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      find-root: 1.1.0
-      html-webpack-plugin: 5.6.3(@rspack/core@1.7.5)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - lightningcss
-      - react
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-
   '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
@@ -96621,7 +96384,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
@@ -96658,7 +96421,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       stream-browserify: 3.0.0
@@ -96751,7 +96514,7 @@ snapshots:
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.12(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -99425,19 +99188,6 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-
-  '@vue/language-core@2.2.10(typescript@5.5.3)':
-    dependencies:
-      '@volar/language-core': 2.4.14
-      '@vue/compiler-dom': 3.5.17
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.17
-      alien-signals: 1.0.13
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.5.3
 
   '@vue/language-core@2.2.10(typescript@5.9.2)':
     dependencies:
@@ -103072,7 +102822,7 @@ snapshots:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.39.0)(eslint@8.56.0)
       object.assign: 4.1.5
       object.entries: 1.1.8
 
@@ -103287,17 +103037,6 @@ snapshots:
       eslint: 8.56.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.5.3)
-      eslint: 8.56.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -112710,15 +112449,6 @@ snapshots:
   vscode-languageserver-types@3.16.0: {}
 
   vscode-uri@3.1.0: {}
-
-  vue-component-meta@2.2.10(typescript@5.5.3):
-    dependencies:
-      '@volar/typescript': 2.4.14
-      '@vue/language-core': 2.2.10(typescript@5.5.3)
-      path-browserify: 1.0.1
-      vue-component-type-helpers: 2.2.10
-    optionalDependencies:
-      typescript: 5.5.3
 
   vue-component-meta@2.2.10(typescript@5.9.2):
     dependencies:


### PR DESCRIPTION
Updates the `teambit.node/envs/node-babel-mocha` env from 1.0.2 to 1.0.3 via `bit envs update`, followed by `bit install`. Changes are in `.bitmap` and the lockfile.