### PR TITLE
fix(envs): clean status for components using a .bit-env plugin-file env

### DIFF
--- a/e2e/harmony/env.e2e.ts
+++ b/e2e/harmony/env.e2e.ts
@@ -7,6 +7,21 @@ import chaiString from 'chai-string';
 chai.use(chaiFs);
 chai.use(chaiString);
 
+/** create an env defined solely by a *.bit-env.* plugin file (no env-of-env configured) */
+function createBitEnvPluginEnv(helper: Helper) {
+  helper.fs.outputFile(
+    'my-env/my-env.bit-env.ts',
+    `export class MyEnv {
+  name = 'my-env';
+}
+export default new MyEnv();
+`
+  );
+  helper.fs.outputFile('my-env/index.ts', `export { MyEnv } from './my-env.bit-env';`);
+  helper.command.addComponent('my-env');
+  helper.command.compile();
+}
+
 describe('env command', function () {
   this.timeout(0);
   let helper: Helper;
@@ -107,17 +122,7 @@ describe('env command', function () {
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();
       helper.fixtures.populateComponents(1, false);
-      helper.fs.outputFile(
-        'my-env/my-env.bit-env.ts',
-        `export class MyEnv {
-  name = 'my-env';
-}
-export default new MyEnv();
-`
-      );
-      helper.fs.outputFile('my-env/index.ts', `export { MyEnv } from './my-env.bit-env';`);
-      helper.command.addComponent('my-env');
-      helper.command.compile();
+      createBitEnvPluginEnv(helper);
     });
     // previously, a component was recognized as an env only after it was loaded as an aspect,
     // which happened only once its own env (env-of-env, e.g. teambit.envs/env or
@@ -138,17 +143,7 @@ export default new MyEnv();
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();
       helper.fixtures.populateComponents(1, false);
-      helper.fs.outputFile(
-        'my-env/my-env.bit-env.ts',
-        `export class MyEnv {
-  name = 'my-env';
-}
-export default new MyEnv();
-`
-      );
-      helper.fs.outputFile('my-env/index.ts', `export { MyEnv } from './my-env.bit-env';`);
-      helper.command.addComponent('my-env');
-      helper.command.compile();
+      createBitEnvPluginEnv(helper);
       helper.command.setEnv('comp1', 'my-env');
       helper.command.install();
       helper.command.tagAllWithoutBuild();
@@ -160,14 +155,10 @@ export default new MyEnv();
       const output = helper.command.status();
       expect(output).to.not.have.string('is not of type env');
     });
-    // my-env provides no compiler, so comp1 is consumed as-source - there are no dists to miss,
-    // and "bit compile" would not produce any
-    it('should not have a MissingDists issue', () => {
-      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MissingDists.name);
-    });
+    // this covers MissingDists as well: my-env provides no compiler, so comp1 is consumed
+    // as-source - there are no dists to miss, and "bit compile" would not produce any
     it('should have no component issues at all', () => {
-      const status = helper.command.statusJson();
-      expect(status.componentsWithIssues).to.have.lengthOf(0);
+      helper.command.expectStatusToNotHaveIssues();
     });
   });
   describe('bit env replace', () => {

--- a/e2e/harmony/env.e2e.ts
+++ b/e2e/harmony/env.e2e.ts
@@ -134,6 +134,42 @@ export default new MyEnv();
       expect(() => helper.command.snapAllComponentsWithoutBuild()).to.not.throw();
     });
   });
+  describe('component using a .bit-env plugin-file env should have a clean status', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.fs.outputFile(
+        'my-env/my-env.bit-env.ts',
+        `export class MyEnv {
+  name = 'my-env';
+}
+export default new MyEnv();
+`
+      );
+      helper.fs.outputFile('my-env/index.ts', `export { MyEnv } from './my-env.bit-env';`);
+      helper.command.addComponent('my-env');
+      helper.command.compile();
+      helper.command.setEnv('comp1', 'my-env');
+      helper.command.install();
+      helper.command.tagAllWithoutBuild();
+    });
+    // the plugin file identifies the component as an env - it must not be reported as
+    // misconfigured just because its own env is not an env-env (teambit.envs/env or
+    // bitdev.general/envs/bit-env)
+    it('should not warn that the env is not of type env', () => {
+      const output = helper.command.status();
+      expect(output).to.not.have.string('is not of type env');
+    });
+    // my-env provides no compiler, so comp1 is consumed as-source - there are no dists to miss,
+    // and "bit compile" would not produce any
+    it('should not have a MissingDists issue', () => {
+      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MissingDists.name);
+    });
+    it('should have no component issues at all', () => {
+      const status = helper.command.statusJson();
+      expect(status.componentsWithIssues).to.have.lengthOf(0);
+    });
+  });
   describe('bit env replace', () => {
     describe('replacing a failed-loaded env', () => {
       before(() => {

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -91,7 +91,10 @@ export class CompilerMain {
    */
   getRelativeDistFolder(component: Component): string {
     const environment = this.envs.getOrCalculateEnv(component).env;
-    const compilerInstance: Compiler | undefined = environment.getCompiler?.();
+    return this.getDistDirOfCompiler(environment.getCompiler?.());
+  }
+
+  private getDistDirOfCompiler(compilerInstance: Compiler | undefined): string {
     if (!compilerInstance || !compilerInstance.getDistDir) return DEFAULT_DIST_DIRNAME;
     return compilerInstance.getDistDir();
   }
@@ -99,13 +102,16 @@ export class CompilerMain {
   /**
    * Check if the dist folder (in the component package under node_modules) exist
    * @param component
+   * @param precomputedCompiler pass when the compiler was already resolved, to avoid resolving the env again
    * @returns
    */
-  async isDistDirExists(component: Component): Promise<boolean> {
+  async isDistDirExists(component: Component, precomputedCompiler?: Compiler): Promise<boolean> {
     const packageDir = await this.workspace.getComponentPackagePath(component);
-    const distDir = this.getRelativeDistFolder(component);
+    const distDir = precomputedCompiler
+      ? this.getDistDirOfCompiler(precomputedCompiler)
+      : this.getRelativeDistFolder(component);
     const pathToCheck = path.join(packageDir, distDir);
-    return fs.existsSync(pathToCheck);
+    return fs.pathExists(pathToCheck);
   }
 
   async getDistsFiles(component: Component): Promise<DistArtifact> {
@@ -125,9 +131,7 @@ export class CompilerMain {
         // return undefined.
         const compilerInstance: Compiler | undefined = environment.getCompiler?.();
         if (!compilerInstance) return;
-        const packageDir = await this.workspace.getComponentPackagePath(component);
-        const distDir = compilerInstance.getDistDir ? compilerInstance.getDistDir() : DEFAULT_DIST_DIRNAME;
-        const exist = fs.existsSync(path.join(packageDir, distDir));
+        const exist = await this.isDistDirExists(component, compilerInstance);
         if (!exist) {
           component.state.issues.getOrCreate(IssuesClasses.MissingDists).data = true;
         }

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -119,6 +119,11 @@ export class CompilerMain {
     if (issuesToIgnore.includes(IssuesClasses.MissingDists.name)) return;
     await Promise.all(
       components.map(async (component) => {
+        const environment = this.envs.getOrCalculateEnv(component).env;
+        // an env without a compiler has no dists - the component is consumed as-source, and
+        // "bit compile" would not produce anything. getCompiler may also be implemented but
+        // return undefined.
+        if (!environment.getCompiler?.()) return;
         const exist = await this.isDistDirExists(component);
         if (!exist) {
           component.state.issues.getOrCreate(IssuesClasses.MissingDists).data = true;

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -123,8 +123,11 @@ export class CompilerMain {
         // an env without a compiler has no dists - the component is consumed as-source, and
         // "bit compile" would not produce anything. getCompiler may also be implemented but
         // return undefined.
-        if (!environment.getCompiler?.()) return;
-        const exist = await this.isDistDirExists(component);
+        const compilerInstance: Compiler | undefined = environment.getCompiler?.();
+        if (!compilerInstance) return;
+        const packageDir = await this.workspace.getComponentPackagePath(component);
+        const distDir = compilerInstance.getDistDir ? compilerInstance.getDistDir() : DEFAULT_DIST_DIRNAME;
+        const exist = fs.existsSync(path.join(packageDir, distDir));
         if (!exist) {
           component.state.issues.getOrCreate(IssuesClasses.MissingDists).data = true;
         }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1709,7 +1709,10 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
     } catch {
       return; // unable to get the component for some reason. don't sweat it. forget about the warning
     }
-    if (!this.envs.isUsingEnvEnv(env)) {
+    // isEnv covers all the signals identifying an env, including the *.bit-env.* plugin file -
+    // an env recognized by any of them is not misconfigured (isUsingEnvEnv alone misses plugin
+    // envs whose own env is not an env-env).
+    if (!this.envs.isEnv(env)) {
       this.warnedAboutMisconfiguredEnvs.push(envId);
       this.logger.consoleWarning(
         `env "${envId}" is not of type env. (correct the env's type, or component config with "bit env set ${envId} bitdev.general/envs/bit-env")`


### PR DESCRIPTION
Follow-up to #10500, which recognized a component as an env by its \`*.bit-env.*\` plugin file. Two consumers were missed, so a workspace using such an env (whose own env is not an env-env) still wasn't clean:

- \`warnAboutMisconfiguredEnv\` only accepted \`isUsingEnvEnv\`, warning \`env "..." is not of type env\` on every command for a perfectly valid plugin-file env. It now uses \`envs.isEnv()\`, which covers all recognition signals including the plugin file.
- \`addMissingDistsIssue\` flagged \`MissingDists\` for components of a compiler-less env after install+tag — misleading, since such components are consumed as-source and \`bit compile\` produces nothing for them. It now skips components whose env exposes no compiler.

The added e2e covers the full flow (add env → compile → env set → install → tag) and asserts no misconfiguration warning, no MissingDists, and zero component issues — all three failed before the fix.