### PR TITLE
ci: identify install requests with custom user agents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ commands:
             pnpm init &&
             echo "node-linker=hoisted" >> .npmrc &&
             echo "registry=https://node-registry.bit.cloud" >> .npmrc &&
+            echo "user-agent=bvm-bundle-circleci" >> .npmrc &&
             pnpm dlx @ialdama/jsonmod --key pnpm.overrides.uri-js --values npm:uri-js-replace &&
             pnpm dlx @ialdama/jsonmod --key "pnpm.overrides.cross-spawn@7" --values "^7.0.5" &&
             pnpm dlx @ialdama/jsonmod --key "pnpm.overrides.lodash@4" --values "4.17.21" &&
@@ -133,6 +134,7 @@ commands:
             pnpm init &&
             echo "node-linker=hoisted" >> .npmrc &&
             echo "registry=https://node-registry.bit.cloud" >> .npmrc &&
+            echo "user-agent=bvm-bundle-circleci" >> .npmrc &&
             echo "prefer-symlinked-executables=false" >> .npmrc &&
             pnpm dlx @ialdama/jsonmod --key pnpm.neverBuiltDependencies --values cpu-features --values ssh2 &&
             pnpm dlx @ialdama/jsonmod --key pnpm.overrides.uri-js --values npm:uri-js-replace &&
@@ -577,7 +579,7 @@ jobs:
       - run: cd bit && bbit init
       - run:
           name: bbit install
-          command: cd bit && bbit install
+          command: cd bit && echo "user-agent=bit-repo-circleci" >> .npmrc && bbit install
       # - run: cd bit && bbit compile
       # the following 3 commands should help debugging a random error on Circle: "sh: 1: babel: not found"
       # - run: cd bit && ls -l node_modules/@babel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,9 @@ commands:
       # - run: 'ssh-add ~/.ssh/id_rsa'
       - run: 'cd bit && mkdir junit'
       - run: 'bit config set package-manager.cache /home/circleci/package-manager-cache'
+      - run:
+          name: set user agent for Bit processes in e2e tests
+          command: echo "user-agent=bit-e2e-circleci" >> ~/.npmrc
       # Make sure when we run bit from e2e tests we run it from the global not from here
       # - run: 'rm -rf bit/node_modules/.bin/bit'
       - run:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+user-agent=bit-repo-local

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -291,13 +291,14 @@ export class PnpmPackageManager implements PackageManager {
 
   async getNetworkConfig?(): Promise<PackageManagerNetworkConfig> {
     const { config } = await this.readConfig();
-    if (!this.username) {
+    const configuredUserAgent = config.rawConfig['user-agent'];
+    if (!configuredUserAgent && !this.username) {
       this.username = (await this.cloud.getCurrentUser())?.username ?? 'anonymous';
     }
     // We need to use config.rawConfig as it will only contain the settings defined by the user.
     // config contains default values of the settings when they are not defined by the user.
     const result: PackageManagerNetworkConfig = {
-      userAgent: config.rawConfig['user-agent'] ?? `bit user/${this.username}`,
+      userAgent: configuredUserAgent ?? `bit user/${this.username}`,
     };
     if (config.rawConfig['max-sockets'] != null) {
       result.maxSockets = config.rawConfig['max-sockets'];

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -297,7 +297,7 @@ export class PnpmPackageManager implements PackageManager {
     // We need to use config.rawConfig as it will only contain the settings defined by the user.
     // config contains default values of the settings when they are not defined by the user.
     const result: PackageManagerNetworkConfig = {
-      userAgent: `bit user/${this.username}`,
+      userAgent: config.rawConfig['user-agent'] ?? `bit user/${this.username}`,
     };
     if (config.rawConfig['max-sockets'] != null) {
       result.maxSockets = config.rawConfig['max-sockets'];


### PR DESCRIPTION
## Summary

- send `bit-repo-local` from local `bit install` runs in the Bit repository
- override it with `bit-repo-circleci` for the repository install in CircleCI
- send `bit-e2e-circleci` from Bit processes in regular, released-binary, and cleaned-bundle E2E tests
- send `bvm-bundle-circleci` from pnpm while creating BVM bundles on Linux, macOS, and Windows
- allow Bit’s embedded pnpm client to honor an explicitly configured `user-agent`, while retaining `bit user/<username>` as its fallback
- avoid resolving the cloud username when an explicit user agent is configured

## Verification

- captured `user-agent: bvm-bundle-circleci` from an actual pnpm request to a local HTTP registry
- parsed `.circleci/config.yml` successfully
- `git diff --check` passes

Component compilation was attempted, but the local workspace reports an outdated `teambit.dependencies/pnpm@1.0.1113` object and requires `bit import`.