### PR TITLE
chore: update core envs and typescript-compiler to TS7-based majors

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -14,42 +14,60 @@
         "scope": "teambit.legacy",
         "version": "0.0.99",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/analytics"
+        "rootDir": "components/legacy/analytics",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "api-reference": {
         "name": "api-reference",
         "scope": "teambit.api-reference",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1108",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
         "scope": "teambit.toolbox",
         "version": "0.0.8",
         "mainFile": "find-duplications.ts",
-        "rootDir": "scopes/toolbox/array/duplications-finder"
+        "rootDir": "scopes/toolbox/array/duplications-finder",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "aspect": {
         "name": "aspect",
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -196,238 +214,340 @@
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
         "scope": "teambit.react",
         "version": "1.0.57",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/bit-react-transformer"
+        "rootDir": "scopes/react/bit-react-transformer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "bit": {
         "name": "bit",
         "scope": "teambit.harmony",
         "version": "2.0.44",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "bit-map": {
         "name": "bit-map",
         "scope": "teambit.legacy",
         "version": "0.0.195",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/bit-map"
+        "rootDir": "components/legacy/bit-map",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "builder": {
         "name": "builder",
         "scope": "teambit.pipelines",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
         "scope": "teambit.pipelines",
         "version": "0.0.411",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/builder-data"
+        "rootDir": "scopes/pipelines/modules/builder-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "bundler": {
         "name": "bundler",
         "scope": "teambit.compilation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1448",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.467",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci"
+        "rootDir": "scopes/git/ci",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.572",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1355",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.216",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server"
+        "rootDir": "scopes/mcp/cli-mcp-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
         "scope": "teambit.toolbox",
         "version": "0.0.55",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/tables/cli-table"
+        "rootDir": "scopes/toolbox/tables/cli-table",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "cli/error": {
         "name": "cli/error",
         "scope": "teambit.legacy",
         "version": "0.0.50",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/cli/error"
+        "rootDir": "components/legacy/cli/error",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "cli/webpack-events-listener": {
         "name": "cli/webpack-events-listener",
         "scope": "teambit.preview",
         "version": "0.0.183",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/cli/webpack-events-listener"
+        "rootDir": "scopes/preview/cli/webpack-events-listener",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "cloud": {
         "name": "cloud",
         "scope": "teambit.cloud",
         "version": "0.0.1375",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.783",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.456",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor"
+        "rootDir": "scopes/component/component-descriptor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component-diff": {
         "name": "component-diff",
         "scope": "teambit.legacy",
         "version": "0.0.194",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-diff"
+        "rootDir": "components/legacy/component-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "component-issues": {
         "name": "component-issues",
         "scope": "teambit.component",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "components/component-issues"
+        "rootDir": "components/component-issues",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "component-list": {
         "name": "component-list",
         "scope": "teambit.legacy",
         "version": "0.0.192",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-list"
+        "rootDir": "components/legacy/component-list",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "component-log": {
         "name": "component-log",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
         "scope": "teambit.component",
         "version": "0.0.455",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-package-version"
+        "rootDir": "scopes/component/component-package-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "component-sizer": {
         "name": "component-sizer",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -441,56 +561,80 @@
         "scope": "teambit.compositions",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1530",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.944",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.236",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store"
+        "rootDir": "components/config-store",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "constants": {
         "name": "constants",
         "scope": "teambit.legacy",
         "version": "0.0.35",
         "mainFile": "constants.ts",
-        "rootDir": "components/legacy/constants"
+        "rootDir": "components/legacy/constants",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "consumer": {
         "name": "consumer",
         "scope": "teambit.legacy",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer"
+        "rootDir": "components/legacy/consumer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "consumer-component": {
         "name": "consumer-component",
         "scope": "teambit.legacy",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-component"
+        "rootDir": "components/legacy/consumer-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "consumer-config": {
         "name": "consumer-config",
         "scope": "teambit.legacy",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-config"
+        "rootDir": "components/legacy/consumer-config",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "content/cli-reference": {
         "name": "content/cli-reference",
@@ -504,294 +648,420 @@
         "scope": "teambit.toolbox",
         "version": "0.0.18",
         "mainFile": "index.ts",
-        "rootDir": "components/crypto/sha1"
+        "rootDir": "components/crypto/sha1",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "dependencies": {
         "name": "dependencies",
         "scope": "teambit.dependencies",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "dependency-graph": {
         "name": "dependency-graph",
         "scope": "teambit.legacy",
         "version": "0.0.141",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/dependency-graph"
+        "rootDir": "components/legacy/dependency-graph",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "dependency-resolver": {
         "name": "dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "deps-detectors/detective-mdx": {
         "name": "deps-detectors/detective-mdx",
         "scope": "teambit.mdx",
         "version": "0.0.1",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/deps-detectors/detective-mdx"
+        "rootDir": "scopes/mdx/deps-detectors/detective-mdx",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "dev-files": {
         "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "doc-parser": {
         "name": "doc-parser",
         "scope": "teambit.semantics",
         "version": "0.0.146",
         "mainFile": "index.ts",
-        "rootDir": "components/semantics/doc-parser"
+        "rootDir": "components/semantics/doc-parser",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "docs": {
         "name": "docs",
         "scope": "teambit.docs",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.762",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor"
+        "rootDir": "scopes/harmony/doctor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "e2e-helper": {
         "name": "e2e-helper",
         "scope": "teambit.legacy",
         "version": "0.0.188",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/e2e-helper"
+        "rootDir": "components/legacy/e2e-helper",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "eject": {
         "name": "eject",
         "scope": "teambit.workspace",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
         "scope": "teambit.lanes",
         "version": "0.0.194",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/entities/lane-diff"
+        "rootDir": "scopes/lanes/entities/lane-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "entities/semantic-schema": {
         "name": "entities/semantic-schema",
         "scope": "teambit.semantics",
         "version": "0.0.108",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema"
+        "rootDir": "components/entities/semantic-schema",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "entities/semantic-schema-diff": {
         "name": "entities/semantic-schema-diff",
         "scope": "teambit.semantics",
         "version": "0.0.8",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema-diff"
+        "rootDir": "components/entities/semantic-schema-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "env": {
         "name": "env",
         "scope": "teambit.envs",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint"
+        "rootDir": "scopes/defender/eslint",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
         "scope": "teambit.react",
         "version": "2.0.16",
         "mainFile": "index.js",
-        "rootDir": "scopes/react/eslint-config-bit-react"
+        "rootDir": "scopes/react/eslint-config-bit-react",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "eslint/config-mutator": {
         "name": "eslint/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.128",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint-config-mutator"
+        "rootDir": "scopes/defender/eslint-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "export": {
         "name": "export",
         "scope": "teambit.scope",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1454",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "extension-data": {
         "name": "extension-data",
         "scope": "teambit.legacy",
         "version": "0.0.140",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/extension-data"
+        "rootDir": "components/legacy/extension-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "forking": {
         "name": "forking",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/extension-getter"
+        "rootDir": "scopes/toolbox/fs/extension-getter",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "fs/hard-link-directory": {
         "name": "fs/hard-link-directory",
         "scope": "teambit.toolbox",
         "version": "0.0.32",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/hard-link-directory"
+        "rootDir": "scopes/toolbox/fs/hard-link-directory",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "fs/is-dir-empty": {
         "name": "fs/is-dir-empty",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/is-dir-empty"
+        "rootDir": "scopes/toolbox/fs/is-dir-empty",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "fs/last-modified": {
         "name": "fs/last-modified",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/last-modified"
+        "rootDir": "scopes/toolbox/fs/last-modified",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "fs/link-or-symlink": {
         "name": "fs/link-or-symlink",
         "scope": "teambit.toolbox",
         "version": "0.0.57",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/link-or-symlink"
+        "rootDir": "scopes/toolbox/fs/link-or-symlink",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "fs/linked-dependencies": {
         "name": "fs/linked-dependencies",
         "scope": "teambit.dependencies",
         "version": "0.0.65",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/fs/linked-dependencies"
+        "rootDir": "scopes/dependencies/fs/linked-dependencies",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "fs/remove-empty-dir": {
         "name": "fs/remove-empty-dir",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/remove-empty-dir"
+        "rootDir": "scopes/toolbox/fs/remove-empty-dir",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "generator": {
         "name": "generator",
         "scope": "teambit.generator",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "get-bit-version": {
         "name": "get-bit-version",
         "scope": "teambit.bit",
         "version": "0.0.21",
         "mainFile": "index.ts",
-        "rootDir": "components/bit/get-bit-version"
+        "rootDir": "components/bit/get-bit-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "git": {
         "name": "git",
         "scope": "teambit.git",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1359",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
         "scope": "teambit.cloud",
         "version": "0.0.26",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-cloud-scopes"
+        "rootDir": "scopes/cloud/hooks/use-cloud-scopes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "hooks/use-current-user": {
         "name": "hooks/use-current-user",
         "scope": "teambit.cloud",
         "version": "0.0.31",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-current-user"
+        "rootDir": "scopes/cloud/hooks/use-current-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "hooks/use-lane-components": {
         "name": "hooks/use-lane-components",
@@ -812,7 +1082,10 @@
         "scope": "teambit.cloud",
         "version": "0.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-logout"
+        "rootDir": "scopes/cloud/hooks/use-logout",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "hooks/use-navigation-message-listener": {
         "name": "hooks/use-navigation-message-listener",
@@ -833,119 +1106,170 @@
         "scope": "teambit.lanes",
         "version": "0.0.261",
         "mainFile": "index.ts",
-        "rootDir": "components/hooks/use-viewed-lane-from-url_1"
+        "rootDir": "components/hooks/use-viewed-lane-from-url_1",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "host-initializer": {
         "name": "host-initializer",
         "scope": "teambit.harmony",
         "version": "0.0.790",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer"
+        "rootDir": "scopes/harmony/host-initializer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.76",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize"
+        "rootDir": "scopes/component/internalize",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
         "scope": "teambit.toolbox",
         "version": "0.0.7",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/json/jsonc-utils"
+        "rootDir": "scopes/toolbox/json/jsonc-utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "lanes": {
         "name": "lanes",
         "scope": "teambit.lanes",
         "version": "1.0.1097",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
         "scope": "teambit.component",
         "version": "0.0.423",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy-component-log"
+        "rootDir": "components/legacy-component-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "linter": {
         "name": "linter",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "loader": {
         "name": "loader",
         "scope": "teambit.legacy",
         "version": "0.0.24",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/loader"
+        "rootDir": "components/legacy/loader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "mcp-config-writer": {
         "name": "mcp-config-writer",
         "scope": "teambit.mcp",
         "version": "0.0.14",
         "mainFile": "index.ts",
-        "rootDir": "components/mcp/mcp-config-writer"
+        "rootDir": "components/mcp/mcp-config-writer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -959,21 +1283,30 @@
         "scope": "teambit.lanes",
         "version": "1.0.1097",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1080",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.873",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -987,315 +1320,450 @@
         "scope": "teambit.compositions",
         "version": "0.0.526",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/model/composition-type"
+        "rootDir": "scopes/compositions/model/composition-type",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "models/cloud-scope": {
         "name": "models/cloud-scope",
         "scope": "teambit.cloud",
         "version": "0.0.25",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-scope"
+        "rootDir": "scopes/cloud/models/cloud-scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "models/cloud-user": {
         "name": "models/cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.25",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-user"
+        "rootDir": "scopes/cloud/models/cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "models/scope-model": {
         "name": "models/scope-model",
         "scope": "teambit.scope",
         "version": "0.0.557",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/models/scope-model"
+        "rootDir": "scopes/scope/models/scope-model",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/babel-compiler": {
         "name": "modules/babel-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.147",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/modules/babel-compiler"
+        "rootDir": "scopes/compilation/modules/babel-compiler",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/component-package-name": {
         "name": "modules/component-package-name",
         "scope": "teambit.pkg",
         "version": "0.0.145",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/component-package-name"
+        "rootDir": "components/modules/component-package-name",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/component-url": {
         "name": "modules/component-url",
         "scope": "teambit.component",
         "version": "0.0.196",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-url"
+        "rootDir": "scopes/component/component-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/concurrency": {
         "name": "modules/concurrency",
         "scope": "teambit.harmony",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/concurrency"
+        "rootDir": "scopes/harmony/modules/concurrency",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/config-mutator": {
         "name": "modules/config-mutator",
         "scope": "teambit.webpack",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/config-mutator"
+        "rootDir": "scopes/webpack/config-mutator",
+        "config": {
+            "teambit.node/node@4.0.0": {}
+        }
     },
     "modules/create-element-from-string": {
         "name": "modules/create-element-from-string",
         "scope": "teambit.html",
         "version": "0.0.130",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/create-element-from-string"
+        "rootDir": "scopes/html/modules/create-element-from-string",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/create-lane": {
         "name": "modules/create-lane",
         "scope": "teambit.lanes",
         "version": "0.0.173",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/modules/create-lane"
+        "rootDir": "scopes/lanes/modules/create-lane",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/diff": {
         "name": "modules/diff",
         "scope": "teambit.lanes",
         "version": "0.0.643",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/diff"
+        "rootDir": "scopes/lanes/diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/feature-toggle": {
         "name": "modules/feature-toggle",
         "scope": "teambit.harmony",
         "version": "0.0.47",
         "mainFile": "feature-toggle.ts",
-        "rootDir": "scopes/harmony/modules/feature-toggle"
+        "rootDir": "scopes/harmony/modules/feature-toggle",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/fetch-html-from-url": {
         "name": "modules/fetch-html-from-url",
         "scope": "teambit.html",
         "version": "0.0.130",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/fetch-html-from-url"
+        "rootDir": "scopes/html/modules/fetch-html-from-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/find-scope-path": {
         "name": "modules/find-scope-path",
         "scope": "teambit.scope",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/find-scope-path"
+        "rootDir": "components/modules/find-scope-path",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/fs-cache": {
         "name": "modules/fs-cache",
         "scope": "teambit.workspace",
         "version": "0.0.65",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/fs-cache"
+        "rootDir": "scopes/workspace/modules/fs-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/generate-asset-manifest": {
         "name": "modules/generate-asset-manifest",
         "scope": "teambit.rspack",
         "version": "0.0.7",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/generate-asset-manifest"
+        "rootDir": "components/modules/generate-asset-manifest",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "modules/generate-expose-loaders": {
         "name": "modules/generate-expose-loaders",
         "scope": "teambit.webpack",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-expose-loaders"
+        "rootDir": "scopes/webpack/modules/generate-expose-loaders",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/generate-externals": {
         "name": "modules/generate-externals",
         "scope": "teambit.webpack",
         "version": "0.0.38",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-externals"
+        "rootDir": "scopes/webpack/modules/generate-externals",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/generate-style-loaders": {
         "name": "modules/generate-style-loaders",
         "scope": "teambit.webpack",
         "version": "1.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-style-loaders"
+        "rootDir": "scopes/webpack/modules/generate-style-loaders",
+        "config": {
+            "teambit.node/node@4.0.0": {}
+        }
     },
     "modules/get-basic-log": {
         "name": "modules/get-basic-log",
         "scope": "teambit.harmony",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/get-basic-log"
+        "rootDir": "scopes/harmony/modules/get-basic-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/get-cloud-user": {
         "name": "modules/get-cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/modules/get-cloud-user"
+        "rootDir": "scopes/cloud/modules/get-cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/git-executable": {
         "name": "modules/git-executable",
         "scope": "teambit.git",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/git-executable"
+        "rootDir": "scopes/git/modules/git-executable",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/harmony-root-generator": {
         "name": "modules/harmony-root-generator",
         "scope": "teambit.harmony",
         "version": "0.0.38",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/harmony-root-generator"
+        "rootDir": "components/modules/harmony-root-generator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/ignore-file-reader": {
         "name": "modules/ignore-file-reader",
         "scope": "teambit.git",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/ignore-file-reader"
+        "rootDir": "scopes/git/modules/ignore-file-reader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/in-memory-cache": {
         "name": "modules/in-memory-cache",
         "scope": "teambit.harmony",
         "version": "0.0.39",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/in-memory-cache"
+        "rootDir": "scopes/harmony/modules/in-memory-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/load-trace": {
         "name": "modules/load-trace",
         "scope": "teambit.harmony",
         "version": "0.0.7",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/load-trace"
+        "rootDir": "scopes/harmony/modules/load-trace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/match-pattern": {
         "name": "modules/match-pattern",
         "scope": "teambit.workspace",
         "version": "0.0.527",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/match-pattern"
+        "rootDir": "scopes/workspace/modules/match-pattern",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/merge-component-results": {
         "name": "modules/merge-component-results",
         "scope": "teambit.pipelines",
         "version": "0.0.518",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/merge-component-results"
+        "rootDir": "scopes/pipelines/modules/merge-component-results",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/merge-helper": {
         "name": "modules/merge-helper",
         "scope": "teambit.component",
         "version": "0.0.81",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/modules/merge-helper"
+        "rootDir": "scopes/component/modules/merge-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/module-resolver": {
         "name": "modules/module-resolver",
         "scope": "teambit.toolbox",
         "version": "0.0.22",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/modules/module-resolver"
+        "rootDir": "scopes/toolbox/modules/module-resolver",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "modules/node-modules-linker": {
         "name": "modules/node-modules-linker",
         "scope": "teambit.workspace",
         "version": "0.0.369",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/node-modules-linker"
+        "rootDir": "scopes/workspace/modules/node-modules-linker",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/requireable-component": {
         "name": "modules/requireable-component",
         "scope": "teambit.harmony",
         "version": "0.0.519",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/requireable-component"
+        "rootDir": "scopes/harmony/modules/requireable-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/resolved-component": {
         "name": "modules/resolved-component",
         "scope": "teambit.harmony",
         "version": "0.0.519",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/resolved-component"
+        "rootDir": "scopes/harmony/modules/resolved-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/semver-helper": {
         "name": "modules/semver-helper",
         "scope": "teambit.pkg",
         "version": "0.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/modules/semver-helper"
+        "rootDir": "scopes/pkg/modules/semver-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/send-server-sent-events": {
         "name": "modules/send-server-sent-events",
         "scope": "teambit.harmony",
         "version": "0.0.23",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/send-server-sent-events"
+        "rootDir": "scopes/harmony/modules/send-server-sent-events",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/style-regexps": {
         "name": "modules/style-regexps",
         "scope": "teambit.webpack",
         "version": "1.0.26",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/style-regexps"
+        "rootDir": "scopes/webpack/style-regexps",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/ts-config-mutator": {
         "name": "modules/ts-config-mutator",
         "scope": "teambit.typescript",
         "version": "0.0.92",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/modules/ts-config-mutator"
+        "rootDir": "scopes/typescript/modules/ts-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "modules/workspace-locator": {
         "name": "modules/workspace-locator",
         "scope": "teambit.workspace",
         "version": "0.0.36",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/workspace-locator"
+        "rootDir": "scopes/workspace/modules/workspace-locator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "mover": {
         "name": "mover",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "network": {
         "name": "network",
         "scope": "teambit.scope",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/network"
+        "rootDir": "scopes/scope/network",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "network/get-port": {
         "name": "network/get-port",
         "scope": "teambit.toolbox",
         "version": "1.0.23",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/network/get-port"
+        "rootDir": "scopes/toolbox/network/get-port",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "new-component-helper": {
         "name": "new-component-helper",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "node": {
         "name": "node",
@@ -1309,14 +1777,20 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.584",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects"
+        "rootDir": "scopes/scope/objects",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
@@ -1330,7 +1804,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.1358",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1344,91 +1821,130 @@
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/is-path-inside"
+        "rootDir": "scopes/toolbox/path/is-path-inside",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "path/match-patterns": {
         "name": "path/match-patterns",
         "scope": "teambit.toolbox",
         "version": "0.0.30",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/match-patterns"
+        "rootDir": "scopes/toolbox/path/match-patterns",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "path/path": {
         "name": "path/path",
         "scope": "teambit.toolbox",
         "version": "0.0.19",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/path"
+        "rootDir": "scopes/toolbox/path/path",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "path/to-windows-compatible-path": {
         "name": "path/to-windows-compatible-path",
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/to-windows-compatible-path"
+        "rootDir": "scopes/toolbox/path/to-windows-compatible-path",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "pkg": {
         "name": "pkg",
         "scope": "teambit.pkg",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
         "scope": "teambit.webpack",
         "version": "0.0.30",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin"
+        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "plugins/manifest-plugin": {
         "name": "plugins/manifest-plugin",
         "scope": "teambit.rspack",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "components/plugins/manifest-plugin"
+        "rootDir": "components/plugins/manifest-plugin",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "pnpm": {
         "name": "pnpm",
         "scope": "teambit.dependencies",
         "version": "1.0.1113",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.122",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier-config-mutator"
+        "rootDir": "scopes/defender/prettier-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "preview": {
         "name": "preview",
         "scope": "teambit.preview",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/promise/map-pool"
+        "rootDir": "scopes/toolbox/promise/map-pool",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "pubsub": {
         "name": "pubsub",
         "scope": "teambit.harmony",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "react": {
         "name": "react",
@@ -1442,7 +1958,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "readme": {
         "name": "readme",
@@ -1456,35 +1975,50 @@
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "remote-actions": {
         "name": "remote-actions",
         "scope": "teambit.scope",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/remote-actions"
+        "rootDir": "scopes/scope/remote-actions",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "remotes": {
         "name": "remotes",
         "scope": "teambit.scope",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "components/scope/remotes"
+        "rootDir": "components/scope/remotes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "remove": {
         "name": "remove",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -1505,112 +2039,160 @@
         "scope": "teambit.cloud",
         "version": "0.0.162",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple"
+        "rootDir": "scopes/cloud/ripple",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "scope-api": {
         "name": "scope-api",
         "scope": "teambit.legacy",
         "version": "0.0.193",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope-api"
+        "rootDir": "components/legacy/scope-api",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "scripts": {
         "name": "scripts",
         "scope": "teambit.workspace",
         "version": "0.0.296",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "snap-distance": {
         "name": "snap-distance",
         "scope": "teambit.component",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snap-distance"
+        "rootDir": "scopes/component/snap-distance",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "snapping": {
         "name": "snapping",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "sources": {
         "name": "sources",
         "scope": "teambit.component",
         "version": "0.0.190",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/sources"
+        "rootDir": "scopes/component/sources",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "stash": {
         "name": "stash",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1101",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/capitalize"
+        "rootDir": "scopes/toolbox/string/capitalize",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "string/ellipsis": {
         "name": "string/ellipsis",
         "scope": "teambit.toolbox",
         "version": "0.0.202",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/ellipsis"
+        "rootDir": "scopes/toolbox/string/ellipsis",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "string/eol": {
         "name": "string/eol",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/eol"
+        "rootDir": "scopes/toolbox/string/eol",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "string/get-initials": {
         "name": "string/get-initials",
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/get-initials"
+        "rootDir": "scopes/toolbox/string/get-initials",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "string/random": {
         "name": "string/random",
         "scope": "teambit.toolbox",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/random"
+        "rootDir": "scopes/toolbox/string/random",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "string/strip-trailing-char": {
         "name": "string/strip-trailing-char",
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/strip-trailing-char"
+        "rootDir": "scopes/toolbox/string/strip-trailing-char",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "tagged-exports": {
         "name": "tagged-exports",
@@ -1624,98 +2206,140 @@
         "scope": "teambit.harmony",
         "version": "0.0.1448",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
         "scope": "teambit.legacy",
         "version": "0.0.50",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/logger"
+        "rootDir": "components/legacy/logger",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "teambit.legacy/scope": {
         "name": "scope",
         "scope": "teambit.legacy",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope"
+        "rootDir": "components/legacy/scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "teambit.scope/scope": {
         "name": "scope",
         "scope": "teambit.scope",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
         "scope": "teambit.harmony",
         "version": "0.0.404",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/testing/load-aspect"
+        "rootDir": "scopes/harmony/testing/load-aspect",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "testing/mock-components": {
         "name": "testing/mock-components",
         "scope": "teambit.component",
         "version": "0.0.409",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/testing/mock-components"
+        "rootDir": "scopes/component/testing/mock-components",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "testing/mock-workspace": {
         "name": "testing/mock-workspace",
         "scope": "teambit.workspace",
         "version": "0.0.215",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/testing/mock-workspace"
+        "rootDir": "scopes/workspace/testing/mock-workspace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "time/timer": {
         "name": "time/timer",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/time/timer"
+        "rootDir": "scopes/toolbox/time/timer",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "tracker": {
         "name": "tracker",
         "scope": "teambit.component",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
         "scope": "teambit.typescript",
         "version": "0.0.85",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/ts-server"
+        "rootDir": "scopes/typescript/ts-server",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "types/serializable": {
         "name": "types/serializable",
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/types/serializable"
+        "rootDir": "scopes/toolbox/types/serializable",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "typescript": {
         "name": "typescript",
         "scope": "teambit.typescript",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui"
+        "rootDir": "scopes/ui-foundation/ui",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "ui/aspect-box": {
         "name": "ui/aspect-box",
@@ -2114,98 +2738,140 @@
         "scope": "teambit.toolbox",
         "version": "0.0.515",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/url/add-avatar-query-params"
+        "rootDir": "scopes/toolbox/url/add-avatar-query-params",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "url/query-string": {
         "name": "url/query-string",
         "scope": "teambit.toolbox",
         "version": "0.0.511",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/url/query-string"
+        "rootDir": "scopes/toolbox/url/query-string",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.0": {}
+        }
     },
     "user-agent": {
         "name": "user-agent",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "utils": {
         "name": "utils",
         "scope": "teambit.legacy",
         "version": "0.0.43",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/utils"
+        "rootDir": "components/legacy/utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.0": {}
+        }
     },
     "validator": {
         "name": "validator",
         "scope": "teambit.defender",
         "version": "0.0.313",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator"
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1623",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.869",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history"
+        "rootDir": "scopes/scope/version-history",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.443",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue"
+        "rootDir": "scopes/vue/vue",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1659",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1077",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.0": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,8 +1001,8 @@ importers:
         specifier: ~0.0.2
         version: 0.0.2
       '@teambit/typescript.typescript-compiler':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.1.0)
       '@teambit/ui-foundation.ui.constants.z-indexes':
         specifier: ^0.0.504
         version: 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -2154,20 +2154,20 @@ importers:
         version: 3.24.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
         version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@teambit/node.node':
-        specifier: 2.0.4
-        version: 2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.0
+        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.4
         version: 1.1.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/node@22.10.5)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -2203,8 +2203,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2234,8 +2234,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2283,8 +2283,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -2311,8 +2311,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2351,8 +2351,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2385,8 +2385,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2600,8 +2600,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2628,8 +2628,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2674,8 +2674,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2744,8 +2744,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2793,8 +2793,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2857,8 +2857,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -2903,8 +2903,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2934,8 +2934,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2986,8 +2986,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3047,8 +3047,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3105,8 +3105,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3163,8 +3163,8 @@ importers:
         version: 2.1.6
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3205,8 +3205,8 @@ importers:
         specifier: ~0.0.312
         version: 0.0.312
       '@teambit/typescript.typescript-compiler':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.1.0)
       '@teambit/workspace.root-components':
         specifier: ^1.0.1
         version: 1.0.1
@@ -3263,8 +3263,8 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3312,8 +3312,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3352,8 +3352,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/pretty-time':
         specifier: ^1.1.5
         version: 1.1.5
@@ -3404,8 +3404,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3486,8 +3486,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3547,8 +3547,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3605,8 +3605,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3645,8 +3645,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3682,8 +3682,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -3713,8 +3713,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3747,8 +3747,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -3781,8 +3781,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3891,8 +3891,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -4065,8 +4065,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -4108,8 +4108,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -5899,7 +5899,7 @@ importers:
         version: 0.0.355(react-dom@19.1.0)(react@19.1.0)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -5969,7 +5969,7 @@ importers:
         version: 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query':
         specifier: ^0.0.505
         version: 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -6402,7 +6402,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -6579,7 +6579,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6615,13 +6615,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6669,7 +6669,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -6996,13 +6996,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7011,10 +7011,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7098,7 +7098,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -7194,7 +7194,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -7227,13 +7227,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -7304,7 +7304,7 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
 
-  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@1.0.2:
+  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.0:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -7356,7 +7356,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -7533,7 +7533,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7569,13 +7569,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7623,7 +7623,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -7685,8 +7685,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/cli-reference(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/harmony.modules.concurrency':
         specifier: workspace:*
         version: file:scopes/harmony/modules/concurrency
@@ -7956,13 +7956,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -7971,10 +7971,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8058,7 +8058,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -8154,7 +8154,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -8187,13 +8187,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -8364,7 +8364,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@18.3.1)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -8541,7 +8541,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@18.3.1)(react@18.3.1)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
@@ -8577,13 +8577,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
@@ -8634,7 +8634,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@18.3.1)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@18.3.1)
@@ -8874,10 +8874,10 @@ importers:
         version: file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.mdx-scope-context':
         specifier: 1.1.1
         version: 1.1.1(react@18.3.1)
@@ -8970,13 +8970,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
@@ -8985,10 +8985,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
@@ -9072,7 +9072,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -9168,7 +9168,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@18.3.1)(react@18.3.1)
@@ -9201,13 +9201,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@18.3.1)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@18.3.1)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -9279,10 +9279,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -9291,7 +9291,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -9320,7 +9320,7 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
 
-  node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@1.0.3:
+  node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@2.0.0:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -9372,7 +9372,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -9549,7 +9549,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9585,13 +9585,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9639,7 +9639,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -9905,8 +9905,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -9972,13 +9972,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -9987,10 +9987,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10074,7 +10074,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -10170,7 +10170,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -10203,13 +10203,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -10304,7 +10304,7 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
 
-  node_modules/.bit_roots/teambit.node_envs_node-typescript-mocha@1.0.1:
+  node_modules/.bit_roots/teambit.node_envs_node-typescript-mocha@2.0.0:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -10356,7 +10356,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -10533,7 +10533,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10569,13 +10569,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10623,7 +10623,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -10889,8 +10889,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -10956,13 +10956,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10971,10 +10971,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11058,7 +11058,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -11154,7 +11154,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -11187,13 +11187,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -11288,7 +11288,7 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
 
-  node_modules/.bit_roots/teambit.node_node@2.0.4:
+  node_modules/.bit_roots/teambit.node_node@4.0.0:
     dependencies:
       '@babel/core':
         specifier: 7.26.9
@@ -11343,7 +11343,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -11520,7 +11520,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11556,13 +11556,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11610,7 +11610,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -11876,8 +11876,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.node':
-        specifier: 2.0.4
-        version: 2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.0
+        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -11943,13 +11943,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11958,10 +11958,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12045,7 +12045,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -12141,7 +12141,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -12174,13 +12174,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -12258,10 +12258,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -12270,7 +12270,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -12345,7 +12345,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -12522,7 +12522,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12558,13 +12558,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12612,7 +12612,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -12939,7 +12939,7 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.4
         version: 1.1.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/node@22.10.5)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -12948,7 +12948,7 @@ importers:
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12957,10 +12957,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13044,7 +13044,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -13140,7 +13140,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -13173,13 +13173,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -13251,10 +13251,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -13263,7 +13263,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -13338,7 +13338,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -13515,7 +13515,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13551,13 +13551,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13605,7 +13605,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -13932,13 +13932,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13947,10 +13947,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14034,7 +14034,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -14130,7 +14130,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -14163,13 +14163,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -14283,8 +14283,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14353,8 +14353,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -14399,8 +14399,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14433,8 +14433,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14464,8 +14464,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14495,8 +14495,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14523,8 +14523,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14551,8 +14551,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14594,8 +14594,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -14751,8 +14751,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14764,7 +14764,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14783,7 +14783,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14801,7 +14801,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14820,7 +14820,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14838,7 +14838,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14857,7 +14857,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14899,8 +14899,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14945,8 +14945,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15012,8 +15012,8 @@ importers:
         specifier: 1.96.22
         version: 1.96.22(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15049,8 +15049,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/babel__core':
         specifier: 7.20.0
         version: 7.20.0
@@ -15092,8 +15092,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15105,7 +15105,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -15124,7 +15124,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -15154,7 +15154,7 @@ importers:
         version: 0.4.12
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.menu-widget-icon':
         specifier: ^0.0.502
         version: 0.0.502(react-dom@19.1.0)(react@19.1.0)
@@ -15181,8 +15181,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15236,8 +15236,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15288,8 +15288,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15436,8 +15436,8 @@ importers:
         specifier: ^1.96.10
         version: 1.96.10(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15512,8 +15512,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15555,8 +15555,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15613,8 +15613,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -15650,8 +15650,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -15696,8 +15696,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15727,8 +15727,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15761,8 +15761,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -15816,8 +15816,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15874,8 +15874,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15923,8 +15923,8 @@ importers:
         specifier: 1.96.6
         version: 1.96.6(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15981,8 +15981,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16087,8 +16087,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -16142,8 +16142,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16224,8 +16224,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16279,8 +16279,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -16328,8 +16328,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -16386,8 +16386,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16432,8 +16432,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16481,8 +16481,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16533,8 +16533,8 @@ importers:
         version: 2.2.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16582,8 +16582,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16646,8 +16646,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16713,8 +16713,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16756,8 +16756,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16844,8 +16844,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16920,8 +16920,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16975,8 +16975,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17030,8 +17030,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17067,8 +17067,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17137,8 +17137,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17156,7 +17156,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -17175,7 +17175,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -17252,6 +17252,9 @@ importers:
       '@teambit/base-ui.surfaces.split-pane.split-pane':
         specifier: 1.0.0
         version: 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/component-id':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@teambit/compositions.ui.composition-live-controls':
         specifier: ^0.0.6
         version: 0.0.6(react@19.1.0)
@@ -17305,7 +17308,7 @@ importers:
         version: 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.property-table':
         specifier: 4.1.11
-        version: 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/evangelist.elements.icon':
         specifier: 1.0.5
         version: 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -17314,7 +17317,7 @@ importers:
         version: 0.4.12
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.constants.z-indexes':
         specifier: ^0.0.504
         version: 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -17358,12 +17361,9 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
-      '@teambit/component-id':
-        specifier: ^1.2.4
-        version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -17439,8 +17439,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17543,8 +17543,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -17586,8 +17586,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -17641,8 +17641,8 @@ importers:
         specifier: 1.96.11
         version: 1.96.11(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17708,8 +17708,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17766,8 +17766,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17809,8 +17809,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17852,8 +17852,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17892,8 +17892,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17926,8 +17926,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18023,8 +18023,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18066,8 +18066,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
 
   scopes/dependencies/aspect-docs/dependency-resolver:
     dependencies:
@@ -18076,7 +18076,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -18095,7 +18095,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18113,7 +18113,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -18132,7 +18132,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18150,7 +18150,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -18169,7 +18169,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18295,8 +18295,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -18425,8 +18425,8 @@ importers:
         version: 0.3.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18462,8 +18462,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18598,8 +18598,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18689,8 +18689,8 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18706,6 +18706,9 @@ importers:
       '@teambit/base-ui.loaders.skeleton':
         specifier: 1.0.2
         version: 1.0.2(react@19.1.0)
+      '@teambit/component-id':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@teambit/component.ui.component-meta':
         specifier: ^0.0.368
         version: 0.0.368(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -18752,15 +18755,12 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
-      '@teambit/component-id':
-        specifier: ^1.2.4
-        version: 1.2.4
       '@teambit/docs.content.docs-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18815,7 +18815,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -18834,7 +18834,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18861,10 +18861,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 7.1.0
-        version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+        version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 7.1.0
-        version: 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+        version: 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint-mdx:
         specifier: 1.17.1
         version: 1.17.1(eslint@8.56.0)
@@ -18873,7 +18873,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -18897,8 +18897,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
 
   scopes/envs/envs:
     dependencies:
@@ -18949,8 +18949,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19050,8 +19050,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -19108,8 +19108,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19127,7 +19127,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -19146,7 +19146,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19218,8 +19218,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19282,8 +19282,8 @@ importers:
         version: 3.28.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19328,8 +19328,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19359,8 +19359,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -19393,8 +19393,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19463,8 +19463,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -19530,8 +19530,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19596,8 +19596,8 @@ importers:
         specifier: 0.4.12
         version: 0.4.12
       '@teambit/typescript.typescript-compiler':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.1.0)
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -19636,8 +19636,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19652,7 +19652,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -19671,7 +19671,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19689,7 +19689,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -19708,7 +19708,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19783,8 +19783,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -19821,9 +19821,6 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
-      '@teambit/design.ui.brand.logo':
-        specifier: 1.96.19
-        version: 1.96.19(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
@@ -19924,9 +19921,12 @@ importers:
       '@teambit/bit.content.what-is-bit':
         specifier: 1.96.13
         version: 1.96.13(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/design.ui.brand.logo':
+        specifier: 1.96.19
+        version: 1.96.19(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/eventsource':
         specifier: ^1.1.15
         version: 1.1.15
@@ -19971,8 +19971,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -20035,8 +20035,8 @@ importers:
         version: 17.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/didyoumean':
         specifier: 1.2.0
         version: 1.2.0
@@ -20073,7 +20073,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -20127,8 +20127,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20167,8 +20167,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20237,8 +20237,8 @@ importers:
         version: 2.2.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20283,8 +20283,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -20338,8 +20338,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -20450,8 +20450,8 @@ importers:
         version: 7.5.10(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -20514,8 +20514,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20554,8 +20554,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20597,8 +20597,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20625,8 +20625,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20653,8 +20653,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -20687,8 +20687,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20718,8 +20718,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20746,8 +20746,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -20777,8 +20777,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20805,8 +20805,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20833,8 +20833,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20929,6 +20929,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
+      '@teambit/ui-foundation.ui.is-browser':
+        specifier: ^0.0.500
+        version: 0.0.500(react-dom@19.1.0)(react@19.1.0)
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -20955,11 +20958,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
-      '@teambit/ui-foundation.ui.is-browser':
-        specifier: ^0.0.500
-        version: 0.0.500(react-dom@19.1.0)(react@19.1.0)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20986,8 +20986,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21081,8 +21081,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21094,7 +21094,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21113,7 +21113,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21143,8 +21143,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21171,8 +21171,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21214,8 +21214,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21248,8 +21248,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21354,8 +21354,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21421,8 +21421,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21467,8 +21467,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21534,8 +21534,8 @@ importers:
         version: 3.24.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21556,7 +21556,7 @@ importers:
         version: 1.0.6(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21578,7 +21578,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21608,8 +21608,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21731,7 +21731,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21750,7 +21750,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21837,8 +21837,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/archiver':
         specifier: 5.3.1
         version: 5.3.1
@@ -21880,8 +21880,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21914,8 +21914,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21933,7 +21933,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21952,7 +21952,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21988,8 +21988,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -22073,8 +22073,8 @@ importers:
         version: 10.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.96.9
         version: 1.96.9(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -22101,7 +22101,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -22120,7 +22120,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22150,8 +22150,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -22203,6 +22203,9 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      cross-fetch:
+        specifier: 3.1.5
+        version: 3.1.5
       filenamify:
         specifier: 4.2.0
         version: 4.2.0
@@ -22221,6 +22224,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lru-cache:
+        specifier: 10.4.3
+        version: 10.4.3
       mime:
         specifier: 2.5.2
         version: 2.5.2
@@ -22256,8 +22262,8 @@ importers:
         version: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22279,12 +22285,6 @@ importers:
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
-      cross-fetch:
-        specifier: 3.1.5
-        version: 3.1.5
-      lru-cache:
-        specifier: 10.4.3
-        version: 10.4.3
 
   scopes/preview/ui/component-preview:
     dependencies:
@@ -22391,7 +22391,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -22410,7 +22410,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22461,8 +22461,8 @@ importers:
         specifier: 7.22.3
         version: 7.22.3
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.19.6)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.19.6)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -22489,10 +22489,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 7.1.0
-        version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+        version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 7.1.0
-        version: 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+        version: 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint:
         specifier: '> 8.0.0'
         version: 8.56.0
@@ -22501,7 +22501,7 @@ importers:
         version: 8.5.0(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-mdx:
         specifier: 1.17.1
         version: 1.17.1(eslint@8.56.0)
@@ -22519,8 +22519,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -22609,8 +22609,8 @@ importers:
         specifier: 0.0.45
         version: 0.0.45(react-dom@19.1.0)(react@19.1.0)
       '@teambit/typescript.typescript-compiler':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.1.0)
       '@typescript-eslint/eslint-plugin':
         specifier: 7.1.0
         version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.9.2)
@@ -22987,7 +22987,7 @@ importers:
         version: 4.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -23039,7 +23039,7 @@ importers:
         version: 4.1.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.property-table':
         specifier: 4.1.11
-        version: 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+        version: 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.7
         version: 4.1.7(react@19.1.0)
@@ -23259,8 +23259,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23326,8 +23326,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23357,8 +23357,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23427,8 +23427,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/http-proxy-agent':
         specifier: 2.0.2
         version: 2.0.2
@@ -23521,8 +23521,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23564,8 +23564,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -23706,8 +23706,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/scope.content.scope-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -23767,8 +23767,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23822,8 +23822,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/chai-subset':
         specifier: 1.3.5
         version: 1.3.5
@@ -23859,8 +23859,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -23893,8 +23893,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23933,8 +23933,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -23970,8 +23970,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24007,8 +24007,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24053,8 +24053,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24090,8 +24090,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24130,8 +24130,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24164,8 +24164,8 @@ importers:
         version: 1.20.0
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24192,8 +24192,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24223,8 +24223,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24254,8 +24254,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24291,8 +24291,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24322,8 +24322,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24353,8 +24353,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24387,8 +24387,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24418,8 +24418,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24452,8 +24452,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24480,8 +24480,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24511,8 +24511,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24539,8 +24539,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24573,8 +24573,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -24601,8 +24601,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24632,8 +24632,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24660,8 +24660,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24688,8 +24688,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 1.0.1
-        version: 1.0.1(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24707,7 +24707,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -24726,7 +24726,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -24762,8 +24762,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24817,8 +24817,8 @@ importers:
         version: 3.16.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24832,8 +24832,8 @@ importers:
         specifier: 0.4.12
         version: 0.4.12
       '@teambit/typescript.typescript-compiler':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.1.0)
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.1.0)
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -24878,8 +24878,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24918,8 +24918,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24961,8 +24961,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25001,8 +25001,8 @@ importers:
         version: 3.2.0(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -25044,8 +25044,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25087,8 +25087,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -25220,7 +25220,7 @@ importers:
         version: 19.1.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+        version: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
@@ -25250,8 +25250,8 @@ importers:
         version: 7.1.0(@types/babel__core@7.20.0)(webpack@5.97.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -25302,8 +25302,8 @@ importers:
         version: 0.7.40
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25351,11 +25351,11 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       vue-component-meta:
         specifier: ^2.2.10
-        version: 2.2.10(typescript@6.0.3)
+        version: 2.2.10(typescript@7.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
 
   scopes/webpack/config-mutator:
     dependencies:
@@ -25391,8 +25391,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/node.node':
-        specifier: 2.0.4
-        version: 2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.0
+        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -25428,8 +25428,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25459,8 +25459,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25490,8 +25490,8 @@ importers:
         version: 19.2.0(react@19.2.0)
     devDependencies:
       '@teambit/node.node':
-        specifier: 2.0.4
-        version: 2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.0
+        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25524,8 +25524,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25552,8 +25552,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25652,7 +25652,7 @@ importers:
         version: 19.1.0
       react-dev-utils:
         specifier: 12.0.1
-        version: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+        version: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
@@ -25697,8 +25697,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -25719,7 +25719,7 @@ importers:
         version: 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -25738,7 +25738,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -25777,8 +25777,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25835,8 +25835,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25878,8 +25878,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25966,8 +25966,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26012,8 +26012,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -26055,8 +26055,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -26107,8 +26107,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26144,8 +26144,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26190,8 +26190,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -26221,8 +26221,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 1.0.3
-        version: 1.0.3(@babel/core@7.28.3)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26267,8 +26267,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/workspace.content.variants':
         specifier: 1.96.7
         version: 1.96.7(react@19.1.0)
@@ -26331,8 +26331,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26515,8 +26515,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/workspace.content.workspace-overview':
         specifier: 1.96.7
         version: 1.96.7(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -26603,8 +26603,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 1.0.2
-        version: 1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.0
+        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -34356,8 +34356,8 @@ packages:
     peerDependencies:
       react: 19.1.0
 
-  '@teambit/harmony.envs.core-aspect-env@1.0.2':
-    resolution: {integrity: sha512-99NEBkaSYKbaCTlQ/rnRrZqL2N8+93TMmNKVLfXg+l/WJIVjgQy7+yrvAZkBAE0N4/3ge31A44t2E9gBPpYjDg==}
+  '@teambit/harmony.envs.core-aspect-env@2.0.0':
+    resolution: {integrity: sha512-s8t6AZwR2k3sdj6EhvMdV3CmayCVv37ygPjM9x2ECoUc7joG45TcvHAA8KMttFL+rg0FH/9BtMUtR7xUopWw6w==}
 
   '@teambit/harmony.modules.concurrency@0.0.12':
     resolution: {integrity: sha512-j8u/QH0wyXpoEvpATqspcBcf1wbJ70PR82c7Na/ZbOu8+9w2tQIHl+ME7kozcDMX2wSG3cM9TjhJcWS+goRxMg==}
@@ -34988,11 +34988,11 @@ packages:
   '@teambit/node.deps-detectors.parser-helper@0.0.6':
     resolution: {integrity: sha512-dSHRaKL9ScGkWx2+NE/smUqBrhC+knh9u5aCREKohkBCejt0siZDsu7toQP5/mtwBOrlU97KjJBxbKXr32rIDQ==}
 
-  '@teambit/node.envs.node-babel-mocha@1.0.3':
-    resolution: {integrity: sha512-ysJ65jofT5nxI4we+mNzsKg7hnuNBL0j0RzNG/VoPMusiXV01osAARqG2HUtzE2CIXp4IDlgyGW0RLHvqdY9fA==}
+  '@teambit/node.envs.node-babel-mocha@2.0.0':
+    resolution: {integrity: sha512-tGFASnZS2+tUeQOd3dcbLcgPAv0MH2eprkNKdb5c/XIfVbkoIo7l+OtLzwir7FVzKYVtHBJLG09C7tP7yi3Rqg==}
 
-  '@teambit/node.envs.node-typescript-mocha@1.0.1':
-    resolution: {integrity: sha512-zrhUK1y0DaF0AkOQttgbG7M1Bos5H23hYfA8nAh2FIw18JhV1PvoXWB4+XZbfaKAfkphnoAZmlBrleYc3KXz9A==}
+  '@teambit/node.envs.node-typescript-mocha@2.0.0':
+    resolution: {integrity: sha512-FbeQqfU5GVA/6szQsPgI/6J6UDKqBYte4OAYnkm/4P0zMR0ZnheEsrE5PraVT14+bjtHliqgurYaa2shA1io9w==}
 
   '@teambit/node.generator.node-starters@1.0.0':
     resolution: {integrity: sha512-EkEt8XJVx/+JAiC9eMQR7CH3tgYKGuZ7bu9raFDUi4EpWvdEkjR7Q6enXj/Ifqu3ekXtl2XecN/Nr1VxMBcGsQ==}
@@ -35000,8 +35000,8 @@ packages:
   '@teambit/node.generator.node-templates@1.0.22':
     resolution: {integrity: sha512-NwqgNWeAiw3rqqayPoQF2dY3fEdhjQS3Kf0xeEPuqIEkaq4rV73qp7bJZl7Bph0fGQ/l+kqBE7+9tTrz/nRxoQ==}
 
-  '@teambit/node.node@2.0.4':
-    resolution: {integrity: sha512-WNeySE2+FM6S4wMEGFG1/RYA0vzMht2RCuFQLG8LlgpJhFa7yLP5PVnCmm2Hli1jsXVmM8VSEJunDI3EB2nWDQ==}
+  '@teambit/node.node@4.0.0':
+    resolution: {integrity: sha512-zSOjuwAOgkbFxvaWbGRQpgJWaqjRU7PdgQkWRkAkyz0BnzC6Vigu5w+4Jwbtdjz4HFKjlyQxhPH+9WIhXZiotw==}
 
   '@teambit/node.utils.esm-loader@0.0.7':
     resolution: {integrity: sha512-DlihQpBgfMTI+onyqGgsDrcV3TfV/aCEVgjidc4JvyYeaOY2vCk0bLwwkkBSHJbvALrltK5p2/Z5lVpnlZ+01w==}
@@ -35941,8 +35941,8 @@ packages:
     peerDependencies:
       react: 19.1.0
 
-  '@teambit/typescript.typescript-compiler@4.0.0':
-    resolution: {integrity: sha512-EA10uUxQmTdE9v/8rI7HK1iUgkgnlhpqKziqUTsClE9LlmdpIlOUlay20NjwZbhvYM6EtlNO6oBfL/SKP42qkg==}
+  '@teambit/typescript.typescript-compiler@5.0.0':
+    resolution: {integrity: sha512-fPXpWjoyq+Tkl1K+wmZEZQ6MS//AX1T/y7wOfXfhdcUhz26L+nvUnJ/s307wLTqPTfOkNUUhPn9/Q1LwJMC9Vw==}
     peerDependencies:
       react: 19.1.0
 
@@ -37496,6 +37496,126 @@ packages:
   '@typescript-eslint/visitor-keys@8.39.0':
     resolution: {integrity: sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
@@ -47146,6 +47266,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   typical@5.2.0:
     resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
     engines: {node: '>=8'}
@@ -56107,12 +56232,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.1.0(typescript@6.0.3)':
+  '@svgr/core@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.28.3
       '@svgr/babel-preset': 8.1.0(@babel/core@7.28.3)
       camelcase: 6.2.0
-      cosmiconfig: 8.3.6(typescript@6.0.3)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -56151,10 +56276,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.9.2)
-      cosmiconfig: 8.3.6(typescript@6.0.3)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -56188,16 +56313,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@6.0.3)':
+  '@svgr/webpack@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-constant-elements': 7.25.9(@babel/core@7.28.3)
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -58937,7 +59062,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -58988,7 +59113,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -59039,7 +59164,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -61070,7 +61195,6 @@ snapshots:
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version
       '@teambit/clear-cache': file:scopes/workspace/clear-cache(graphql@15.8.0)(react@19.1.0)
       '@teambit/component-id': 1.2.4
-      '@teambit/design.ui.brand.logo': 1.96.19(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/harmony.content.cli-reference': file:scopes/harmony/cli-reference(react@19.1.0)
       '@teambit/legacy-bit-id': 1.1.3
@@ -61137,7 +61261,6 @@ snapshots:
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version
       '@teambit/clear-cache': file:scopes/workspace/clear-cache(graphql@15.8.0)(react@19.1.0)
       '@teambit/component-id': 1.2.4
-      '@teambit/design.ui.brand.logo': 1.96.19(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/harmony.content.cli-reference': file:scopes/harmony/cli-reference(react@19.1.0)
       '@teambit/legacy-bit-id': 1.1.3
@@ -61384,7 +61507,7 @@ snapshots:
       lodash: 4.17.21
       p-limit: 2.3.0
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61392,7 +61515,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61411,7 +61534,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
@@ -61419,7 +61542,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@18.3.1)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61438,7 +61561,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61446,7 +61569,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -63425,7 +63548,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.babel@file:scopes/compilation/aspect-docs/babel(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -63435,7 +63558,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.babel@file:scopes/compilation/aspect-docs/babel(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63445,7 +63568,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.compiler@file:scopes/compilation/aspect-docs/compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -63455,7 +63578,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.compiler@file:scopes/compilation/aspect-docs/compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63465,7 +63588,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.multi-compiler@file:scopes/compilation/aspect-docs/multi-compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -63475,7 +63598,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.multi-compiler@file:scopes/compilation/aspect-docs/multi-compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64115,7 +64238,7 @@ snapshots:
   '@teambit/component.aspect-docs.component@file:scopes/component/aspect-docs/component(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -64125,7 +64248,7 @@ snapshots:
   '@teambit/component.aspect-docs.component@file:scopes/component/aspect-docs/component(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64155,7 +64278,7 @@ snapshots:
       '@teambit/components.blocks.component-card-display': 0.0.40(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/docs.ui.zoomable-image': 1.97.9(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       react: 19.1.0
     transitivePeerDependencies:
       - '@apollo/client'
@@ -64439,7 +64562,7 @@ snapshots:
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.logger': 0.0.19
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
-      '@teambit/pkg.modules.component-package-name': 0.0.56(graphql@15.8.0)
+      '@teambit/pkg.modules.component-package-name': 0.0.56
       '@teambit/toolbox.fs.link-or-symlink': 0.0.20
       '@teambit/toolbox.fs.remove-empty-dir': 0.0.5
       '@teambit/toolbox.path.path': 0.0.8
@@ -67414,7 +67537,7 @@ snapshots:
   '@teambit/compositions.aspect-docs.compositions@file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -67424,7 +67547,7 @@ snapshots:
   '@teambit/compositions.aspect-docs.compositions@file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -67702,13 +67825,14 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(react-dom@19.1.0)(react@19.1.0)
@@ -67733,11 +67857,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -67768,13 +67892,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(react-dom@18.3.1)(react@18.3.1)
@@ -67799,11 +67924,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@18.3.1)(react@18.3.1)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@18.3.1)(react@18.3.1)
@@ -67834,13 +67959,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(react-dom@19.1.0)(react@19.1.0)
@@ -67865,11 +67991,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -68408,18 +68534,18 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68435,18 +68561,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@18.3.1)(react@18.3.1)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 18.3.1
@@ -68462,18 +68588,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@18.3.1)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@18.3.1)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 18.3.1
@@ -68489,18 +68615,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68540,7 +68666,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -68552,7 +68678,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68569,7 +68695,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@18.3.1)(react@18.3.1)
@@ -68581,7 +68707,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@18.3.1)(react@18.3.1)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68598,7 +68724,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@18.3.1)
@@ -68610,7 +68736,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@18.3.1)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68627,7 +68753,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -68639,7 +68765,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68716,7 +68842,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.dependency-resolver@file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -68726,7 +68852,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.dependency-resolver@file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68736,7 +68862,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.pnpm@file:scopes/dependencies/aspect-docs/pnpm(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -68746,7 +68872,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.pnpm@file:scopes/dependencies/aspect-docs/pnpm(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68756,7 +68882,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.yarn@file:scopes/dependencies/aspect-docs/yarn(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -68766,7 +68892,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.yarn@file:scopes/dependencies/aspect-docs/yarn(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68800,7 +68926,7 @@ snapshots:
     dependencies:
       '@pnpm/dependency-path': 1001.1.10
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -68830,7 +68956,7 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@6.0.3)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
@@ -68868,7 +68994,7 @@ snapshots:
       - typanion
       - typescript
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -68898,7 +69024,7 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@6.0.3)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
@@ -72933,6 +73059,7 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/component.ui.component-meta': 0.0.368(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
@@ -72963,6 +73090,7 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@18.3.1)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/component.ui.component-meta': 0.0.368(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(react-dom@18.3.1)(react@18.3.1)
@@ -72993,6 +73121,7 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/component.ui.component-meta': 0.0.368(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
@@ -73078,7 +73207,7 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@18.3.1)(react@18.3.1)
@@ -73088,13 +73217,13 @@ snapshots:
       prism-react-renderer: 1.3.5(react@18.3.1)
       react: 18.3.1
       react-live: 4.1.8(react-dom@18.3.1)(react@18.3.1)
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2)
       use-debounce: 9.0.4(react@18.3.1)
     transitivePeerDependencies:
       - react-dom
       - typescript
 
-  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@18.3.1)
@@ -73104,7 +73233,7 @@ snapshots:
       prism-react-renderer: 1.3.5(react@18.3.1)
       react: 18.3.1
       react-live: 4.1.8(react-dom@19.1.0)(react@18.3.1)
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2)
       use-debounce: 9.0.4(react@18.3.1)
     transitivePeerDependencies:
       - react-dom
@@ -73126,7 +73255,7 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@19.1.0)
@@ -73136,7 +73265,7 @@ snapshots:
       prism-react-renderer: 1.3.5(react@19.1.0)
       react: 19.1.0
       react-live: 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@6.0.3)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@7.0.2)
       use-debounce: 9.0.4(react@19.1.0)
     transitivePeerDependencies:
       - react-dom
@@ -73191,9 +73320,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73217,9 +73346,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73243,9 +73372,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73256,9 +73385,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73282,9 +73411,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73411,11 +73540,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
       '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
@@ -73469,11 +73598,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -73498,11 +73627,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
       '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
@@ -73527,11 +73656,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
       '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
@@ -73556,11 +73685,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -74094,13 +74223,13 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.table-row': 4.1.14(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       react: 18.3.1
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2)
       use-debounce: 3.4.3(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -74120,13 +74249,13 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.table-row': 4.1.14(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       react: 19.1.0
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@6.0.3)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@7.0.2)
       use-debounce: 3.4.3(react@19.1.0)
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -74469,17 +74598,17 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/harmony': 0.4.12
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -74498,7 +74627,7 @@ snapshots:
   '@teambit/envs.aspect-docs.envs@file:scopes/envs/aspect-docs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -74508,7 +74637,7 @@ snapshots:
   '@teambit/envs.aspect-docs.envs@file:scopes/envs/aspect-docs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -75629,7 +75758,7 @@ snapshots:
   '@teambit/generator.aspect-docs.generator@file:scopes/generator/aspect-docs/generator(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -75639,7 +75768,7 @@ snapshots:
   '@teambit/generator.aspect-docs.generator@file:scopes/generator/aspect-docs/generator(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76107,7 +76236,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.logger@file:scopes/harmony/aspect-docs/logger(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -76117,7 +76246,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.logger@file:scopes/harmony/aspect-docs/logger(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76127,7 +76256,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.node@file:scopes/harmony/aspect-docs/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -76137,7 +76266,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.node@file:scopes/harmony/aspect-docs/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76160,7 +76289,7 @@ snapshots:
       react-dom: 18.3.1(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@19.1.0)
 
-  '@teambit/harmony.envs.core-aspect-env@1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76177,9 +76306,9 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76201,7 +76330,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       sass: 1.72.0
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -76235,7 +76364,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/harmony.envs.core-aspect-env@1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76252,9 +76381,9 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76276,7 +76405,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       sass: 1.72.0
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -76310,7 +76439,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/harmony.envs.core-aspect-env@1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76327,9 +76456,9 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@19.1.0)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76351,7 +76480,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       sass: 1.72.0
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -76385,7 +76514,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/harmony.envs.core-aspect-env@1.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76402,9 +76531,9 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76426,7 +76555,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       sass: 1.72.0
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -76686,7 +76815,7 @@ snapshots:
   '@teambit/html.aspect-docs.html@file:scopes/html/aspect-docs/html(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -76696,7 +76825,7 @@ snapshots:
   '@teambit/html.aspect-docs.html@file:scopes/html/aspect-docs/html(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -79190,7 +79319,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@teambit/workspace.root-components': 1.0.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -79235,7 +79364,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@18.3.1)
       '@teambit/workspace.root-components': 1.0.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -79280,7 +79409,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@teambit/workspace.root-components': 1.0.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -79690,7 +79819,7 @@ snapshots:
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79702,7 +79831,7 @@ snapshots:
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79821,7 +79950,7 @@ snapshots:
 
   '@teambit/mdx.generator.mdx-templates@1.0.14': {}
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -79833,21 +79962,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -79989,7 +80118,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80001,21 +80130,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80073,7 +80202,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80085,21 +80214,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80157,7 +80286,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80169,21 +80298,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80350,9 +80479,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 18.3.1
@@ -80378,9 +80507,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -80406,9 +80535,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
       react: 18.3.1
@@ -80420,9 +80549,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
       react: 18.3.1
@@ -80448,9 +80577,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -80526,11 +80655,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       react: 18.3.1
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80558,11 +80687,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80574,11 +80703,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       react: 18.3.1
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80590,11 +80719,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
       react: 18.3.1
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80606,11 +80735,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80964,7 +81093,7 @@ snapshots:
 
   '@teambit/node.deps-detectors.parser-helper@0.0.6': {}
 
-  '@teambit/node.envs.node-babel-mocha@1.0.3(@babel/core@7.19.6)':
+  '@teambit/node.envs.node-babel-mocha@2.0.0(@babel/core@7.19.6)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.19.6)
       '@babel/preset-env': 7.28.3(@babel/core@7.19.6)
@@ -80979,7 +81108,7 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/mocha': 10.0.10
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80991,12 +81120,12 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@teambit/node.envs.node-babel-mocha@1.0.3(@babel/core@7.28.3)':
+  '@teambit/node.envs.node-babel-mocha@2.0.0(@babel/core@7.28.3)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
@@ -81011,7 +81140,7 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/mocha': 10.0.10
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -81023,12 +81152,12 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@teambit/node.envs.node-typescript-mocha@1.0.1(@babel/core@7.28.3)':
+  '@teambit/node.envs.node-typescript-mocha@2.0.0(@babel/core@7.28.3)':
     dependencies:
       '@babel/preset-env': 7.22.15(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.22.15(@babel/core@7.28.3)
@@ -81038,7 +81167,7 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/typescript.typescript-compiler': 3.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/mocha': 10.0.10
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -81050,7 +81179,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -81063,7 +81192,7 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  '@teambit/node.node@2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -81080,21 +81209,21 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
-      '@teambit/typescript.typescript-compiler': 2.0.68(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/jest': 29.5.14
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -81102,6 +81231,7 @@ snapshots:
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@module-federation/runtime-tools'
@@ -81136,7 +81266,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -81146,7 +81275,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/node.node@2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -81163,21 +81292,21 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
-      '@teambit/typescript.typescript-compiler': 2.0.68(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/jest': 29.5.14
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.9.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -81185,6 +81314,7 @@ snapshots:
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@module-federation/runtime-tools'
@@ -81219,7 +81349,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -81229,7 +81358,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/node.node@2.0.4(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -81246,21 +81375,21 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
-      '@teambit/typescript.typescript-compiler': 2.0.68(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/jest': 29.5.14
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -81268,6 +81397,7 @@ snapshots:
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@module-federation/runtime-tools'
@@ -81302,7 +81432,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -81541,7 +81670,7 @@ snapshots:
   '@teambit/pipelines.aspect-docs.builder@file:scopes/pipelines/aspect-docs/builder(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -81551,7 +81680,7 @@ snapshots:
   '@teambit/pipelines.aspect-docs.builder@file:scopes/pipelines/aspect-docs/builder(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -81574,7 +81703,7 @@ snapshots:
   '@teambit/pkg.aspect-docs.pkg@file:scopes/pkg/aspect-docs/pkg(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -81584,7 +81713,7 @@ snapshots:
   '@teambit/pkg.aspect-docs.pkg@file:scopes/pkg/aspect-docs/pkg(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -81638,7 +81767,7 @@ snapshots:
 
   '@teambit/pkg.entities.registry@0.0.4': {}
 
-  '@teambit/pkg.modules.component-package-name@0.0.56(graphql@15.8.0)':
+  '@teambit/pkg.modules.component-package-name@0.0.56':
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/legacy.constants': 0.0.11
@@ -81647,10 +81776,7 @@ snapshots:
       '@teambit/legacy.utils': 0.0.21
       '@teambit/toolbox.path.path': 0.0.8
     transitivePeerDependencies:
-      - domexception
       - encoding
-      - graphql
-      - supports-color
 
   '@teambit/pkg.modules.component-package-name@file:components/modules/component-package-name(graphql@15.8.0)':
     dependencies:
@@ -82093,7 +82219,7 @@ snapshots:
   '@teambit/preview.aspect-docs.preview@file:scopes/preview/aspect-docs/preview(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -82103,7 +82229,7 @@ snapshots:
   '@teambit/preview.aspect-docs.preview@file:scopes/preview/aspect-docs/preview(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82122,13 +82248,13 @@ snapshots:
 
   '@teambit/preview.modules.preview-modules@1.0.3': {}
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -82169,13 +82295,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -82216,13 +82342,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -82263,13 +82389,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82357,13 +82483,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82404,13 +82530,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82451,13 +82577,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -82545,13 +82671,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -82592,13 +82718,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
@@ -82744,12 +82870,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -82804,12 +82932,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -82864,12 +82994,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -82924,12 +83056,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -82959,6 +83093,7 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(react@18.3.1)':
     dependencies:
       '@teambit/harmony': 0.4.12
+      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.1.0)(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -82971,6 +83106,7 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(react@19.1.0)':
     dependencies:
       '@teambit/harmony': 0.4.12
+      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -83399,7 +83535,7 @@ snapshots:
   '@teambit/react.aspect-docs.react@file:scopes/react/aspect-docs/react(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -83409,7 +83545,7 @@ snapshots:
   '@teambit/react.aspect-docs.react@file:scopes/react/aspect-docs/react(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -83534,13 +83670,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/react.eslint-config-bit-react@2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
+  '@teambit/react.eslint-config-bit-react@2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
     transitivePeerDependencies:
@@ -83567,15 +83703,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
+  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
     dependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
       react: 19.1.0
@@ -84865,13 +85001,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -84887,13 +85023,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 18.3.1
@@ -84909,13 +85045,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85057,10 +85193,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85076,10 +85212,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85095,10 +85231,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85130,11 +85266,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/documenter.ui.section': 4.1.7(react@18.3.1)
       core-js: 3.13.0
       react: 18.3.1
@@ -85162,11 +85298,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -86128,7 +86264,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
       '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
@@ -86137,7 +86273,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86145,7 +86281,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86160,7 +86296,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86199,7 +86335,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
       '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
@@ -86208,7 +86344,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@5.9.2)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86216,7 +86352,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86231,7 +86367,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.9.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86270,7 +86406,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
       '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
@@ -86279,7 +86415,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86287,7 +86423,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86302,7 +86438,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86341,7 +86477,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86350,7 +86486,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86358,7 +86494,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86373,7 +86509,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86483,7 +86619,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86492,7 +86628,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86500,7 +86636,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86515,7 +86651,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86554,7 +86690,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86563,7 +86699,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86571,7 +86707,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86586,7 +86722,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86625,7 +86761,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86634,7 +86770,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86642,7 +86778,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.49(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86657,7 +86793,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86767,7 +86903,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86776,7 +86912,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86784,7 +86920,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.49(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86799,7 +86935,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86838,7 +86974,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86847,7 +86983,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86855,7 +86991,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.49(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86870,7 +87006,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86950,7 +87086,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -87088,7 +87224,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -87226,7 +87362,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@18.3.1)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -87364,7 +87500,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -89407,16 +89543,16 @@ snapshots:
       - '@apollo/client'
       - '@teambit/base-react.navigation.link'
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -89451,16 +89587,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
       '@teambit/design.ui.pill-label': 0.0.360(react@18.3.1)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@18.3.1)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@18.3.1)
@@ -89495,16 +89631,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -89939,7 +90075,7 @@ snapshots:
   '@teambit/typescript.aspect-docs.typescript@file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -89949,7 +90085,7 @@ snapshots:
   '@teambit/typescript.aspect-docs.typescript@file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -89974,12 +90110,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@teambit/typescript.deps-detectors.detective-typescript@0.0.10(typescript@6.0.3)':
+  '@teambit/typescript.deps-detectors.detective-typescript@0.0.10(typescript@7.0.2)':
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.6
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@7.0.2)
       node-source-walk: 6.0.2
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -90115,21 +90251,7 @@ snapshots:
       react: 18.3.1
       typescript: 6.0.3
 
-  '@teambit/typescript.typescript-compiler@3.0.0(react@19.1.0)':
-    dependencies:
-      '@teambit/bit-error': 0.0.404
-      '@teambit/compilation.compiler-task': 1.0.12
-      comment-json: 4.2.3
-      fs-extra: 11.3.4
-      get-tsconfig: 4.2.0
-      glob: 10.4.5
-      globby: 11.1.0
-      lodash: 4.17.21
-      normalize-path: 3.0.0
-      react: 19.1.0
-      typescript: 6.0.3
-
-  '@teambit/typescript.typescript-compiler@4.0.0(react@18.3.1)':
+  '@teambit/typescript.typescript-compiler@5.0.0(react@18.3.1)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/compilation.compiler-task': 1.0.12
@@ -90143,7 +90265,7 @@ snapshots:
       react: 18.3.1
       typescript: 6.0.3
 
-  '@teambit/typescript.typescript-compiler@4.0.0(react@19.1.0)':
+  '@teambit/typescript.typescript-compiler@5.0.0(react@19.1.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/compilation.compiler-task': 1.0.12
@@ -90167,7 +90289,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -90197,7 +90319,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator
-      '@teambit/typescript.typescript-compiler': 4.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -92046,7 +92168,7 @@ snapshots:
     dependencies:
       url-parse: 1.5.3
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92099,7 +92221,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92130,7 +92252,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92183,7 +92305,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
       resolve-url-loader: 5.0.0
@@ -92214,7 +92336,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92267,7 +92389,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92405,7 +92527,7 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@18.3.1)(typescript@6.0.3)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
@@ -92420,11 +92542,11 @@ snapshots:
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@18.3.1)
-      vue-component-meta: 2.2.10(typescript@6.0.3)
+      vue-component-meta: 2.2.10(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@6.0.3)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -92439,7 +92561,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      vue-component-meta: 2.2.10(typescript@6.0.3)
+      vue-component-meta: 2.2.10(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
@@ -93083,7 +93205,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
@@ -93091,7 +93213,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.7.5)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93114,7 +93236,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@19.1.0)
@@ -93122,7 +93244,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.7.5)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93176,7 +93298,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
@@ -93184,7 +93306,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.7.8)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93238,7 +93360,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@19.1.0)
@@ -93246,7 +93368,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.7.8)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93269,7 +93391,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
@@ -93277,7 +93399,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@2.1.4)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93300,7 +93422,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/harmony': 0.4.12
@@ -93336,7 +93458,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@18.3.1)
       stream-browserify: 3.0.0
@@ -93364,7 +93486,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/harmony': 0.4.12
@@ -93400,7 +93522,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       stream-browserify: 3.0.0
@@ -93478,7 +93600,7 @@ snapshots:
   '@teambit/workspace.aspect-docs.variants@file:scopes/workspace/aspect-docs/variants(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -93488,7 +93610,7 @@ snapshots:
   '@teambit/workspace.aspect-docs.variants@file:scopes/workspace/aspect-docs/variants(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@6.0.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -95193,13 +95315,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/scope-manager': 6.19.1
-      '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
@@ -95207,9 +95329,9 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95253,13 +95375,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/scope-manager': 7.1.0
-      '@typescript-eslint/type-utils': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/utils': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 7.1.0
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
@@ -95267,9 +95389,9 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95331,16 +95453,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1
       '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95370,16 +95492,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.1.0(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@7.1.0(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.1.0
       '@typescript-eslint/types': 7.1.0
-      '@typescript-eslint/typescript-estree': 7.1.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 7.1.0(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 7.1.0
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95413,12 +95535,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.39.0(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.39.0
       debug: 4.3.4(supports-color@9.4.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95455,9 +95577,9 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@7.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
@@ -95483,15 +95605,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@7.0.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95519,15 +95641,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.1.0(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@7.1.0(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.1.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 7.1.0(typescript@7.0.2)
+      '@typescript-eslint/utils': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95584,7 +95706,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -95592,9 +95714,9 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
-      tsutils: 3.21.0(typescript@6.0.3)
+      tsutils: 3.21.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95628,7 +95750,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.19.1(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@6.19.1(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/types': 6.19.1
       '@typescript-eslint/visitor-keys': 6.19.1
@@ -95637,9 +95759,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95673,7 +95795,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.1.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@7.1.0(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/types': 7.1.0
       '@typescript-eslint/visitor-keys': 7.1.0
@@ -95682,9 +95804,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@6.0.3)
+      ts-api-utils: 1.4.3(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95720,10 +95842,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.39.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.39.0(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.3.4(supports-color@9.4.0)
@@ -95731,8 +95853,8 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.1.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -95766,14 +95888,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@7.0.2)
       eslint: 8.56.0
       eslint-scope: 5.1.1
       semver: 7.7.1
@@ -95809,14 +95931,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.19.1(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@6.19.1(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.19.1
       '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@7.0.2)
       eslint: 8.56.0
       semver: 7.7.1
     transitivePeerDependencies:
@@ -95851,14 +95973,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.1.0(eslint@8.56.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@7.1.0(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 7.1.0
       '@typescript-eslint/types': 7.1.0
-      '@typescript-eslint/typescript-estree': 7.1.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 7.1.0(typescript@7.0.2)
       eslint: 8.56.0
       semver: 7.7.1
     transitivePeerDependencies:
@@ -95889,6 +96011,66 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.2.1': {}
 
@@ -96092,7 +96274,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@vue/language-core@2.2.10(typescript@6.0.3)':
+  '@vue/language-core@2.2.10(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.14
       '@vue/compiler-dom': 3.5.17
@@ -96103,7 +96285,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   '@vue/shared@3.5.17': {}
 
@@ -98581,14 +98763,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  cosmiconfig@8.3.6(typescript@6.0.3):
+  cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   crc-32@1.2.2: {}
 
@@ -99784,7 +99966,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -99794,7 +99976,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -99831,7 +100013,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -99858,7 +100040,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -99913,12 +100095,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3):
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -99935,12 +100117,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3):
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -100674,7 +100856,7 @@ snapshots:
     optionalDependencies:
       eslint: 8.56.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@types/json-schema': 7.0.15
@@ -100689,7 +100871,7 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.7.1
       tapable: 1.1.3
-      typescript: 6.0.3
+      typescript: 7.0.2
       webpack: 5.97.1(esbuild@0.14.29)
     optionalDependencies:
       eslint: 8.56.0
@@ -106157,7 +106339,7 @@ snapshots:
       - supports-color
       - vue-template-compiler
 
-  react-dev-utils@12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1):
+  react-dev-utils@12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       address: 1.2.2
@@ -106168,7 +106350,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -106185,7 +106367,7 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.97.1(esbuild@0.14.29)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -106473,11 +106655,11 @@ snapshots:
       react: 18.3.1
       typescript: 5.9.2
 
-  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3):
+  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2):
     dependencies:
       '@types/react': 19.2.14
       react: 18.3.1
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.9.2):
     dependencies:
@@ -106485,11 +106667,11 @@ snapshots:
       react: 19.1.0
       typescript: 5.9.2
 
-  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@6.0.3):
+  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@7.0.2):
     dependencies:
       '@types/react': 19.2.14
       react: 19.1.0
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   react-use@17.6.0(react-dom@19.1.0)(react@19.1.0):
     dependencies:
@@ -108527,9 +108709,9 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  ts-api-utils@1.4.3(typescript@6.0.3):
+  ts-api-utils@1.4.3(typescript@7.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   ts-api-utils@2.1.0(typescript@5.5.3):
     dependencies:
@@ -108539,9 +108721,9 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  ts-api-utils@2.1.0(typescript@6.0.3):
+  ts-api-utils@2.1.0(typescript@7.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   ts-easing@0.2.0: {}
 
@@ -108587,10 +108769,10 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.9.2
 
-  tsutils@3.21.0(typescript@6.0.3):
+  tsutils@3.21.0(typescript@7.0.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tty-browserify@0.0.1: {}
 
@@ -108703,6 +108885,29 @@ snapshots:
   typescript@5.9.2: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   typical@5.2.0: {}
 
@@ -109311,14 +109516,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  vue-component-meta@2.2.10(typescript@6.0.3):
+  vue-component-meta@2.2.10(typescript@7.0.2):
     dependencies:
       '@volar/typescript': 2.4.14
-      '@vue/language-core': 2.2.10(typescript@6.0.3)
+      '@vue/language-core': 2.2.10(typescript@7.0.2)
       path-browserify: 1.0.1
       vue-component-type-helpers: 2.2.10
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   vue-component-type-helpers@2.2.10: {}
 

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -339,7 +339,7 @@
         "@teambit/toolbox.time.time-format": "^0.0.502",
         "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.10",
         "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.2",
-        "@teambit/typescript.typescript-compiler": "^4.0.0",
+        "@teambit/typescript.typescript-compiler": "^5.0.0",
         "@teambit/ui-foundation.ui.constants.z-indexes": "^0.0.504",
         "@teambit/ui-foundation.ui.corner": "^0.0.520",
         "@teambit/ui-foundation.ui.empty-component-gallery": "^0.0.512",


### PR DESCRIPTION
Rolls the workspace onto the TypeScript 7 releases of the core envs (CR: https://bit.cloud/teambit/typescript/~change-requests/ts7-native-tsc):

- `envs update`: core-aspect-env 2.0.0, node-babel-mocha 2.0.0, node-typescript-mocha 2.0.0, node 4.0.0
- `@teambit/typescript.typescript-compiler` ^4.0.0 → ^5.0.0

These majors compile with TypeScript 7 by spawning the native tsc binary (TS7 ships no in-process JS compiler API). Verified locally: component builds are green and dist output is byte-identical to the TS6 compiler.