### PR TITLE
test: skip yarn e2e-tests

### DIFF
--- a/e2e/harmony/dependencies/never-built-dependencies.e2e.ts
+++ b/e2e/harmony/dependencies/never-built-dependencies.e2e.ts
@@ -42,7 +42,8 @@ chai.use(chaiFs);
       ).not.to.be.a.path();
     });
   });
-  describe('using yarn', () => {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using yarn', () => {
     let npmCiRegistry: NpmCiRegistry;
     before(async () => {
       helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -223,7 +223,8 @@ describe('dependency-resolver extension', function () {
     //   ├─┬ once 1.4.0
     //   │ └── wrappy 1.0.2
     //   └── path-is-absolute 1.0.1
-    describe('using Yarn as a package manager', () => {
+    // skipped: yarn support is deprecated and planned for removal
+    describe.skip('using Yarn as a package manager', () => {
       before(() => {
         helper.scopeHelper.reInitWorkspace();
         helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('packageManager', 'teambit.dependencies/yarn');

--- a/e2e/harmony/deps-in-capsules.e2e.ts
+++ b/e2e/harmony/deps-in-capsules.e2e.ts
@@ -20,7 +20,7 @@ chai.use(chaiString);
   before(async () => {
     helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
     helper.scopeHelper.setWorkspaceWithRemoteScope();
-    helper.workspaceJsonc.setPackageManager('teambit.dependencies/yarn');
+    helper.workspaceJsonc.setPackageManager('teambit.dependencies/pnpm');
     npmCiRegistry = new NpmCiRegistry(helper);
     await npmCiRegistry.init();
     npmCiRegistry.configureCiInPackageJsonHarmony();
@@ -75,7 +75,8 @@ chai.use(chaiString);
       expect(path.join(nodeEnv2CapsuleDir, 'node_modules', comp2PkgJson.name)).to.be.a.path();
     });
   });
-  describe('using Yarn', () => {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using Yarn', () => {
     let nodeEnv1CapsuleDir: string;
     let nodeEnv2CapsuleDir: string;
     before(() => {
@@ -113,7 +114,8 @@ chai.use(chaiString);
       expect(path.join(nodeEnv2CapsuleDir, 'node_modules', comp2PkgJson.name)).to.be.a.path();
     });
   });
-  describe('using Yarn with isolatedCapsules set to false', () => {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using Yarn with isolatedCapsules set to false', () => {
     before(() => {
       helper.scopeHelper.reInitWorkspace();
       helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('packageManager', `teambit.dependencies/yarn`);

--- a/e2e/harmony/dev-files.e2e.ts
+++ b/e2e/harmony/dev-files.e2e.ts
@@ -23,7 +23,7 @@ describe('dev files', function () {
     const COMP_NAME = 'custom-dev-files';
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();
-      helper.workspaceJsonc.setPackageManager('teambit.dependencies/yarn');
+      helper.workspaceJsonc.setPackageManager('teambit.dependencies/pnpm');
       envName = helper.env.setCustomEnv(ENV_NAME);
       envId = `${helper.scopes.remote}/${envName}`;
       // helper.fixtures.createComponentBarFoo();

--- a/e2e/harmony/install-and-compile.e2e.ts
+++ b/e2e/harmony/install-and-compile.e2e.ts
@@ -81,7 +81,8 @@ export function comp() {
       expect(path.join(helper.fixtures.scopes.localPath, 'node_modules', 'is-odd')).to.be.a.path();
     });
   });
-  describe('using yarn', function () {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using yarn', function () {
     this.timeout(0);
     before(prepare);
     it('should use the compiled custom env to build the component', () => {

--- a/e2e/harmony/install.e2e.ts
+++ b/e2e/harmony/install.e2e.ts
@@ -228,7 +228,8 @@ describe('install new dependencies', function () {
       );
     });
   });
-  describe('using yarn', () => {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using yarn', () => {
     before(() => {
       helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
       helper.scopeHelper.setWorkspaceWithRemoteScope();

--- a/e2e/harmony/node-linker.e2e.ts
+++ b/e2e/harmony/node-linker.e2e.ts
@@ -36,7 +36,8 @@ describe('installing with non-default nodeLinker', function () {
       });
     });
   });
-  describe('using Yarn as a package manager', () => {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using Yarn as a package manager', () => {
     describe(`setting nodeLinker to "hoisted"`, () => {
       before(() => {
         helper.scopeHelper.reInitWorkspace();

--- a/e2e/harmony/pkg-manager-config.e2e.ts
+++ b/e2e/harmony/pkg-manager-config.e2e.ts
@@ -19,7 +19,7 @@ chai.use(chaiString);
     before(async () => {
       helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
       helper.scopeHelper.setWorkspaceWithRemoteScope();
-      helper.workspaceJsonc.setPackageManager('teambit.dependencies/yarn');
+      helper.workspaceJsonc.setPackageManager('teambit.dependencies/pnpm');
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
       npmCiRegistry.configureCiInPackageJsonHarmony();
@@ -34,7 +34,8 @@ chai.use(chaiString);
       helper.scopeHelper.addRemoteScope();
       helper.workspaceJsonc.setupDefault();
     });
-    describe('using Yarn', () => {
+    // skipped: yarn support is deprecated and planned for removal
+    describe.skip('using Yarn', () => {
       before(() => {
         helper.scopeHelper.reInitWorkspace({
           yarnRCConfig: {

--- a/e2e/harmony/publish.e2e.ts
+++ b/e2e/harmony/publish.e2e.ts
@@ -20,7 +20,7 @@ describe('publish functionality', function () {
     let scopeWithoutOwner: string;
     before(() => {
       helper.scopeHelper.setWorkspaceWithRemoteScope();
-      helper.workspaceJsonc.setPackageManager('teambit.dependencies/yarn');
+      helper.workspaceJsonc.setPackageManager('teambit.dependencies/pnpm');
       scopeWithoutOwner = helper.scopes.remoteWithoutOwner;
       appOutput = helper.fixtures.populateComponentsTS(3);
       npmCiRegistry = new NpmCiRegistry(helper);

--- a/e2e/harmony/root-components.e2e.ts
+++ b/e2e/harmony/root-components.e2e.ts
@@ -828,7 +828,8 @@ module.exports.default = {
     });
   });
 
-  describe('yarn hoisted linker', function () {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('yarn hoisted linker', function () {
     before(() => {
       helper = new Helper();
       helper.scopeHelper.setWorkspaceWithRemoteScope();
@@ -1434,7 +1435,8 @@ module.exports.default = {
     helper.scopeHelper.addRemoteScope();
     helper.workspaceJsonc.setupDefault();
   });
-  describe('using Yarn', () => {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('using Yarn', () => {
     let scopeAspectsCapsulesRootDir!: string;
     before(() => {
       helper.extensions.workspaceJsonc.setPackageManager(`teambit.dependencies/yarn`);
@@ -1595,7 +1597,8 @@ describe('env peer dependencies hoisting when the env is in the workspace', func
     });
   });
 
-  describe('yarn hoisted linker', function () {
+  // skipped: yarn support is deprecated and planned for removal
+  describe.skip('yarn hoisted linker', function () {
     before(() => prepare('yarn'));
     after(() => {
       helper.scopeHelper.destroy();

--- a/e2e/harmony/yarn-env-as-package.e2e.ts
+++ b/e2e/harmony/yarn-env-as-package.e2e.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiFs from 'chai-fs';
-import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/legacy.e2e-helper';
+import { Helper, NpmCiRegistry } from '@teambit/legacy.e2e-helper';
 
 chai.use(chaiFs);
 
@@ -11,58 +11,56 @@ chai.use(chaiFs);
  * doesn't survive yarn's locator stringify/parse round-trip - failing the resolution of the
  * project's file: dependencies with "isn't supported by any available fetcher".
  */
-(supportNpmCiRegistryTesting ? describe : describe.skip)(
-  'yarn install with an env installed as a package',
-  function () {
-    this.timeout(0);
-    let helper: Helper;
-    let envId: string;
-    let envName: string;
-    let npmCiRegistry: NpmCiRegistry;
-    before(async () => {
-      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
-      helper.scopeHelper.setWorkspaceWithRemoteScope();
-      npmCiRegistry = new NpmCiRegistry(helper);
-      await npmCiRegistry.init();
-      npmCiRegistry.configureCiInPackageJsonHarmony();
-      helper.workspaceJsonc.setupDefault();
-      envName = helper.env.setCustomNewEnv('node-based-env', ['@teambit/node.node'], {
-        policy: {
-          runtime: [
-            {
-              name: 'is-negative',
-              version: '1.0.0',
-              force: true,
-            },
-          ],
-        },
-      });
-      envId = `${helper.scopes.remote}/${envName}`;
-      helper.command.tagAllComponents();
-      helper.command.export();
+// skipped: yarn support is deprecated and planned for removal
+describe.skip('yarn install with an env installed as a package', function () {
+  this.timeout(0);
+  let helper: Helper;
+  let envId: string;
+  let envName: string;
+  let npmCiRegistry: NpmCiRegistry;
+  before(async () => {
+    helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+    helper.scopeHelper.setWorkspaceWithRemoteScope();
+    npmCiRegistry = new NpmCiRegistry(helper);
+    await npmCiRegistry.init();
+    npmCiRegistry.configureCiInPackageJsonHarmony();
+    helper.workspaceJsonc.setupDefault();
+    envName = helper.env.setCustomNewEnv('node-based-env', ['@teambit/node.node'], {
+      policy: {
+        runtime: [
+          {
+            name: 'is-negative',
+            version: '1.0.0',
+            force: true,
+          },
+        ],
+      },
+    });
+    envId = `${helper.scopes.remote}/${envName}`;
+    helper.command.tagAllComponents();
+    helper.command.export();
 
-      helper.scopeHelper.reInitWorkspace({
-        yarnRCConfig: {
-          unsafeHttpWhitelist: ['localhost'],
-        },
-      });
-      helper.scopeHelper.addRemoteScope();
-      helper.workspaceJsonc.setPackageManager('teambit.dependencies/yarn');
-      helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
-      helper.extensions.workspaceJsonc.addKeyValToWorkspace('resolveEnvsFromRoots', true);
-      helper.fixtures.populateComponents(1);
-      helper.command.setEnv('comp1', envId);
+    helper.scopeHelper.reInitWorkspace({
+      yarnRCConfig: {
+        unsafeHttpWhitelist: ['localhost'],
+      },
     });
-    after(() => {
-      npmCiRegistry.destroy();
-      helper.scopeHelper.destroy();
-    });
-    it('should create a versioned root dir for the env and install successfully', () => {
-      // without the workspace-ident sanitization in the yarn package-manager, this fails with
-      // 'the "file:." reference ... isn't supported by any available fetcher'
-      helper.command.install();
-      const envRootDir = helper.env.rootCompDir(`${envId}@0.0.1`);
-      expect(envRootDir).to.be.a.path();
-    });
-  }
-);
+    helper.scopeHelper.addRemoteScope();
+    helper.workspaceJsonc.setPackageManager('teambit.dependencies/yarn');
+    helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('rootComponents', true);
+    helper.extensions.workspaceJsonc.addKeyValToWorkspace('resolveEnvsFromRoots', true);
+    helper.fixtures.populateComponents(1);
+    helper.command.setEnv('comp1', envId);
+  });
+  after(() => {
+    npmCiRegistry.destroy();
+    helper.scopeHelper.destroy();
+  });
+  it('should create a versioned root dir for the env and install successfully', () => {
+    // without the workspace-ident sanitization in the yarn package-manager, this fails with
+    // 'the "file:." reference ... isn't supported by any available fetcher'
+    helper.command.install();
+    const envRootDir = helper.env.rootCompDir(`${envId}@0.0.1`);
+    expect(envRootDir).to.be.a.path();
+  });
+});


### PR DESCRIPTION
Yarn e2e-tests started failing on master (e.g. `yarn install with an env installed as a package`), and yarn support is planned for removal in the next major.

- Skip all yarn-specific `describe` blocks across the e2e suite.
- Tests that used yarn only incidentally as the workspace package manager (publish, dev-files, deps-in-capsules and pkg-manager-config setups) were switched to pnpm so their coverage keeps running.