### PR TITLE
chore: update mdx-env to 3.1.0

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -74,140 +74,200 @@
         "scope": "teambit.compilation",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/babel"
+        "rootDir": "scopes/compilation/aspect-docs/babel",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/builder": {
         "name": "aspect-docs/builder",
         "scope": "teambit.pipelines",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/aspect-docs/builder"
+        "rootDir": "scopes/pipelines/aspect-docs/builder",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/compiler": {
         "name": "aspect-docs/compiler",
         "scope": "teambit.compilation",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/compiler"
+        "rootDir": "scopes/compilation/aspect-docs/compiler",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/component": {
         "name": "aspect-docs/component",
         "scope": "teambit.component",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/aspect-docs/component"
+        "rootDir": "scopes/component/aspect-docs/component",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/compositions": {
         "name": "aspect-docs/compositions",
         "scope": "teambit.compositions",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/aspect-docs/compositions"
+        "rootDir": "scopes/compositions/aspect-docs/compositions",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/dependency-resolver": {
         "name": "aspect-docs/dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "0.0.188",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver"
+        "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/envs": {
         "name": "aspect-docs/envs",
         "scope": "teambit.envs",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/aspect-docs/envs"
+        "rootDir": "scopes/envs/aspect-docs/envs",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/generator": {
         "name": "aspect-docs/generator",
         "scope": "teambit.generator",
         "version": "0.0.181",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/aspect-docs/generator"
+        "rootDir": "scopes/generator/aspect-docs/generator",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/html": {
         "name": "aspect-docs/html",
         "scope": "teambit.html",
         "version": "0.0.134",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/aspect-docs/html"
+        "rootDir": "scopes/html/aspect-docs/html",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/logger": {
         "name": "aspect-docs/logger",
         "scope": "teambit.harmony",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-docs/logger"
+        "rootDir": "scopes/harmony/aspect-docs/logger",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/mdx": {
         "name": "aspect-docs/mdx",
         "scope": "teambit.mdx",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/aspect-docs/mdx"
+        "rootDir": "scopes/mdx/aspect-docs/mdx",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/multi-compiler": {
         "name": "aspect-docs/multi-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/multi-compiler"
+        "rootDir": "scopes/compilation/aspect-docs/multi-compiler",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/node": {
         "name": "aspect-docs/node",
         "scope": "teambit.harmony",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-docs/node"
+        "rootDir": "scopes/harmony/aspect-docs/node",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/pkg": {
         "name": "aspect-docs/pkg",
         "scope": "teambit.pkg",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/aspect-docs/pkg"
+        "rootDir": "scopes/pkg/aspect-docs/pkg",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/pnpm": {
         "name": "aspect-docs/pnpm",
         "scope": "teambit.dependencies",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/pnpm"
+        "rootDir": "scopes/dependencies/aspect-docs/pnpm",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/preview": {
         "name": "aspect-docs/preview",
         "scope": "teambit.preview",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/aspect-docs/preview"
+        "rootDir": "scopes/preview/aspect-docs/preview",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/react": {
         "name": "aspect-docs/react",
         "scope": "teambit.react",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/aspect-docs/react"
+        "rootDir": "scopes/react/aspect-docs/react",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/typescript": {
         "name": "aspect-docs/typescript",
         "scope": "teambit.typescript",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/aspect-docs/typescript"
+        "rootDir": "scopes/typescript/aspect-docs/typescript",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/variants": {
         "name": "aspect-docs/variants",
         "scope": "teambit.workspace",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/aspect-docs/variants"
+        "rootDir": "scopes/workspace/aspect-docs/variants",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-docs/yarn": {
         "name": "aspect-docs/yarn",
         "scope": "teambit.dependencies",
         "version": "0.0.177",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/yarn"
+        "rootDir": "scopes/dependencies/aspect-docs/yarn",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "aspect-loader": {
         "name": "aspect-loader",
@@ -641,7 +701,10 @@
         "scope": "teambit.harmony",
         "version": "2.0.1153",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli-reference"
+        "rootDir": "scopes/harmony/cli-reference",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.0": {}
+        }
     },
     "crypto/sha1": {
         "name": "crypto/sha1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2157,8 +2157,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.0
         version: 2.0.0(@babel/core@7.28.3)
@@ -6402,7 +6402,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -6579,7 +6579,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6615,13 +6615,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6669,7 +6669,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -6996,13 +6996,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7011,10 +7011,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7098,7 +7098,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -7194,7 +7194,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -7227,13 +7227,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -7356,7 +7356,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -7533,7 +7533,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7569,13 +7569,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7623,7 +7623,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -7956,13 +7956,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -7971,10 +7971,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8058,7 +8058,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -8154,7 +8154,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -8187,13 +8187,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -8312,7 +8312,7 @@ importers:
         specifier: 1.72.0
         version: 1.72.0
 
-  node_modules/.bit_roots/teambit.mdx_mdx-env@3.0.5:
+  node_modules/.bit_roots/teambit.mdx_mdx-env@3.1.0:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -8364,7 +8364,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@18.3.1)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@6.0.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -8541,7 +8541,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@18.3.1)(react@18.3.1)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
@@ -8577,13 +8577,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
@@ -8634,7 +8634,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@18.3.1)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@18.3.1)
@@ -8873,11 +8873,11 @@ importers:
         specifier: workspace:*
         version: file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
-        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+        version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context':
         specifier: 1.1.1
         version: 1.1.1(react@18.3.1)
@@ -8970,13 +8970,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
@@ -8985,10 +8985,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
@@ -9072,7 +9072,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -9168,7 +9168,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@18.3.1)(react@18.3.1)
@@ -9201,13 +9201,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@18.3.1)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@18.3.1)(typescript@6.0.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -9279,10 +9279,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -9291,7 +9291,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -9319,6 +9319,9 @@ importers:
       react-router-dom:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@2.0.0:
     dependencies:
@@ -9372,7 +9375,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -9549,7 +9552,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9585,13 +9588,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9639,7 +9642,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -9972,13 +9975,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -9987,10 +9990,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10074,7 +10077,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -10170,7 +10173,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -10203,13 +10206,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -10356,7 +10359,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -10533,7 +10536,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10569,13 +10572,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10623,7 +10626,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -10956,13 +10959,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10971,10 +10974,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11058,7 +11061,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -11154,7 +11157,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -11187,13 +11190,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -11343,7 +11346,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -11520,7 +11523,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11556,13 +11559,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11610,7 +11613,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -11943,13 +11946,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11958,10 +11961,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12045,7 +12048,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -12141,7 +12144,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -12174,13 +12177,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -12258,10 +12261,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -12270,7 +12273,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -12345,7 +12348,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -12522,7 +12525,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12558,13 +12561,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12612,7 +12615,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -12939,7 +12942,7 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.4
         version: 1.1.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/node@22.10.5)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -12948,7 +12951,7 @@ importers:
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12957,10 +12960,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13044,7 +13047,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -13140,7 +13143,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -13173,13 +13176,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -13251,10 +13254,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -13263,7 +13266,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -13338,7 +13341,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -13515,7 +13518,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13551,13 +13554,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13605,7 +13608,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -13932,13 +13935,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13947,10 +13950,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14034,7 +14037,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -14130,7 +14133,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -14163,13 +14166,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -14782,8 +14785,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14819,8 +14822,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14856,8 +14859,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -15123,8 +15126,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -17174,8 +17177,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -17252,9 +17255,6 @@ importers:
       '@teambit/base-ui.surfaces.split-pane.split-pane':
         specifier: 1.0.0
         version: 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/component-id':
-        specifier: ^1.2.4
-        version: 1.2.4
       '@teambit/compositions.ui.composition-live-controls':
         specifier: ^0.0.6
         version: 0.0.6(react@19.1.0)
@@ -17361,6 +17361,9 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
+      '@teambit/component-id':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
         specifier: 2.0.0
         version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -18094,8 +18097,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18131,8 +18134,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18168,8 +18171,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18706,9 +18709,6 @@ importers:
       '@teambit/base-ui.loaders.skeleton':
         specifier: 1.0.2
         version: 1.0.2(react@19.1.0)
-      '@teambit/component-id':
-        specifier: ^1.2.4
-        version: 1.2.4
       '@teambit/component.ui.component-meta':
         specifier: ^0.0.368
         version: 0.0.368(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -18755,6 +18755,9 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
+      '@teambit/component-id':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@teambit/docs.content.docs-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -18833,8 +18836,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19145,8 +19148,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19670,8 +19673,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19707,8 +19710,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19821,6 +19824,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@teambit/design.ui.brand.logo':
+        specifier: 1.96.19
+        version: 1.96.19(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
@@ -19921,9 +19927,6 @@ importers:
       '@teambit/bit.content.what-is-bit':
         specifier: 1.96.13
         version: 1.96.13(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/design.ui.brand.logo':
-        specifier: 1.96.19
-        version: 1.96.19(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
         specifier: 2.0.0
         version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -20072,8 +20075,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -20929,9 +20932,6 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
-      '@teambit/ui-foundation.ui.is-browser':
-        specifier: ^0.0.500
-        version: 0.0.500(react-dom@19.1.0)(react@19.1.0)
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -20960,6 +20960,9 @@ importers:
       '@teambit/harmony.envs.core-aspect-env':
         specifier: 2.0.0
         version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+      '@teambit/ui-foundation.ui.is-browser':
+        specifier: ^0.0.500
+        version: 0.0.500(react-dom@19.1.0)(react@19.1.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21112,8 +21115,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21577,8 +21580,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21749,8 +21752,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21951,8 +21954,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22119,8 +22122,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22203,9 +22206,6 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
-      cross-fetch:
-        specifier: 3.1.5
-        version: 3.1.5
       filenamify:
         specifier: 4.2.0
         version: 4.2.0
@@ -22224,9 +22224,6 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
-      lru-cache:
-        specifier: 10.4.3
-        version: 10.4.3
       mime:
         specifier: 2.5.2
         version: 2.5.2
@@ -22285,6 +22282,12 @@ importers:
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
+      cross-fetch:
+        specifier: 3.1.5
+        version: 3.1.5
+      lru-cache:
+        specifier: 10.4.3
+        version: 10.4.3
 
   scopes/preview/ui/component-preview:
     dependencies:
@@ -22409,8 +22412,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -24725,8 +24728,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -25737,8 +25740,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.0.5
-        version: 3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.0
+        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -34885,8 +34888,8 @@ packages:
   '@teambit/mdx.generator.mdx-templates@1.0.14':
     resolution: {integrity: sha512-ZHWlZISw0TyMgOwIKCGi0HNIuPxKCVikOg5eZLKedZIx5ZoS79Tu4YvUBx0CKAzeQ9PxJN6r9tiLF5FXZ/FnJg==}
 
-  '@teambit/mdx.mdx-env@3.0.5':
-    resolution: {integrity: sha512-rPan84c+JSJO9MQDo94muP2W4lEew8B1WjtpLe48mxkACTlXTC2wWWcDwKGjfhN7uY+1T1sltDW7wvpUKfbvNw==}
+  '@teambit/mdx.mdx-env@3.1.0':
+    resolution: {integrity: sha512-rm6Wllwmzxw6VQDHLnKgDDNvFdYc0DA2ukiKWXODair7BUD8qH1A3pO1jSS0Pq+QKomNgICqmOPC52DZc8GMVA==}
 
   '@teambit/mdx.modules.mdx-admonitions-adapter@0.0.1':
     resolution: {integrity: sha512-uRGaZaAS+h1junyIjrZagWeUO32uWLwyizA5XhpbwW6tY3aI70S1+K78Pe4zFIhAd9kHyg+TzfCIUb6hZ25c4w==}
@@ -56232,6 +56235,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@svgr/core@8.1.0(typescript@6.0.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.3)
+      camelcase: 6.2.0
+      cosmiconfig: 8.3.6(typescript@6.0.3)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@svgr/core@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.28.3
@@ -56276,6 +56290,15 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)':
+    dependencies:
+      '@svgr/core': 8.1.0(typescript@5.9.2)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
+      deepmerge: 4.3.1
+      svgo: 3.3.2
+    transitivePeerDependencies:
+      - typescript
+
   '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.9.2)
@@ -56309,6 +56332,20 @@ snapshots:
       '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@svgr/webpack@8.1.0(typescript@6.0.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/plugin-transform-react-constant-elements': 7.25.9(@babel/core@7.28.3)
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -56589,7 +56626,7 @@ snapshots:
 
   '@teambit/api-reference.models.api-node-renderer@0.0.53(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
       react: 18.3.1
@@ -56649,7 +56686,7 @@ snapshots:
   '@teambit/api-reference.overview.api-reference-table-of-contents@0.0.41(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53
+      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -58797,10 +58834,6 @@ snapshots:
   '@teambit/api-reference.utils.schema-node-signature-transform@0.0.47':
     dependencies:
       '@teambit/semantics.entities.semantic-schema': 0.0.92
-
-  '@teambit/api-reference.utils.sort-api-nodes@0.0.53':
-    dependencies:
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
 
   '@teambit/api-reference.utils.sort-api-nodes@0.0.53(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
@@ -61195,6 +61228,7 @@ snapshots:
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version
       '@teambit/clear-cache': file:scopes/workspace/clear-cache(graphql@15.8.0)(react@19.1.0)
       '@teambit/component-id': 1.2.4
+      '@teambit/design.ui.brand.logo': 1.96.19(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/harmony.content.cli-reference': file:scopes/harmony/cli-reference(react@19.1.0)
       '@teambit/legacy-bit-id': 1.1.3
@@ -61261,6 +61295,7 @@ snapshots:
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version
       '@teambit/clear-cache': file:scopes/workspace/clear-cache(graphql@15.8.0)(react@19.1.0)
       '@teambit/component-id': 1.2.4
+      '@teambit/design.ui.brand.logo': 1.96.19(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/harmony.content.cli-reference': file:scopes/harmony/cli-reference(react@19.1.0)
       '@teambit/legacy-bit-id': 1.1.3
@@ -61507,7 +61542,7 @@ snapshots:
       lodash: 4.17.21
       p-limit: 2.3.0
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61515,7 +61550,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61534,7 +61569,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
@@ -61542,7 +61577,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@18.3.1)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61561,7 +61596,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61569,7 +61604,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -63548,7 +63583,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.babel@file:scopes/compilation/aspect-docs/babel(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -63558,7 +63593,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.babel@file:scopes/compilation/aspect-docs/babel(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63568,7 +63603,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.compiler@file:scopes/compilation/aspect-docs/compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -63578,7 +63613,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.compiler@file:scopes/compilation/aspect-docs/compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63588,7 +63623,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.multi-compiler@file:scopes/compilation/aspect-docs/multi-compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -63598,7 +63633,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.multi-compiler@file:scopes/compilation/aspect-docs/multi-compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64238,7 +64273,7 @@ snapshots:
   '@teambit/component.aspect-docs.component@file:scopes/component/aspect-docs/component(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -64248,7 +64283,7 @@ snapshots:
   '@teambit/component.aspect-docs.component@file:scopes/component/aspect-docs/component(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -67537,7 +67572,7 @@ snapshots:
   '@teambit/compositions.aspect-docs.compositions@file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -67547,7 +67582,7 @@ snapshots:
   '@teambit/compositions.aspect-docs.compositions@file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -67825,14 +67860,13 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(react-dom@19.1.0)(react@19.1.0)
@@ -67857,11 +67891,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -67892,14 +67926,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(react-dom@18.3.1)(react@18.3.1)
@@ -67924,11 +67957,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@18.3.1)(react@18.3.1)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@18.3.1)(react@18.3.1)
@@ -67959,14 +67992,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(react-dom@19.1.0)(react@19.1.0)
@@ -67991,11 +68023,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -68534,18 +68566,18 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68561,18 +68593,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@18.3.1)(react@18.3.1)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 18.3.1
@@ -68588,18 +68620,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@18.3.1)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@18.3.1)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 18.3.1
@@ -68615,18 +68647,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68666,7 +68698,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -68678,7 +68710,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68695,7 +68727,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@18.3.1)(react@18.3.1)
@@ -68707,7 +68739,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@18.3.1)(react@18.3.1)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68724,7 +68756,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@18.3.1)
@@ -68736,7 +68768,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@18.3.1)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@18.3.1)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68753,7 +68785,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -68765,7 +68797,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68842,7 +68874,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.dependency-resolver@file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -68852,7 +68884,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.dependency-resolver@file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68862,7 +68894,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.pnpm@file:scopes/dependencies/aspect-docs/pnpm(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -68872,7 +68904,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.pnpm@file:scopes/dependencies/aspect-docs/pnpm(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68882,7 +68914,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.yarn@file:scopes/dependencies/aspect-docs/yarn(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -68892,7 +68924,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.yarn@file:scopes/dependencies/aspect-docs/yarn(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68926,7 +68958,7 @@ snapshots:
     dependencies:
       '@pnpm/dependency-path': 1001.1.10
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -68956,7 +68988,7 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
@@ -68994,7 +69026,7 @@ snapshots:
       - typanion
       - typescript
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -69024,7 +69056,75 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
+      '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      archy: 1.0.0
+      chai: 5.2.1
+      chalk: 4.1.2
+      cli-table: 0.3.6
+      debug: 4.3.4(supports-color@9.4.0)
+      detective-amd: 3.0.1
+      detective-stylus: 1.0.0
+      fs-extra: 10.0.0
+      lodash: 4.17.21
+      module-definition: 3.3.1
+      moment: 2.29.4
+      node-source-walk: 4.2.0
+      p-map-series: 2.1.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+      read-pkg-up: 7.0.1
+      resolve-dependency-path: 2.0.0
+      semver: 7.7.1
+      stylus-lookup: 3.0.2
+      table: 6.7.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@pnpm/logger'
+      - domexception
+      - encoding
+      - graphql
+      - postcss
+      - supports-color
+      - typanion
+      - typescript
+
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/component-id': 1.2.4
+      '@teambit/component-issues': file:components/component-issues
+      '@teambit/component-package-version': file:scopes/component/component-package-version
+      '@teambit/component-version': 1.0.4
+      '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
+      '@teambit/component.testing.mock-components': file:scopes/component/testing/mock-components(graphql@15.8.0)
+      '@teambit/harmony': 0.4.12
+      '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
+      '@teambit/legacy.bit-map': file:components/legacy/bit-map(graphql@15.8.0)
+      '@teambit/legacy.constants': file:components/legacy/constants
+      '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
+      '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
+      '@teambit/legacy.dependency-graph': file:components/legacy/dependency-graph(graphql@15.8.0)
+      '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
+      '@teambit/legacy.logger': file:components/legacy/logger
+      '@teambit/legacy.utils': file:components/legacy/utils
+      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
+      '@teambit/node.deps-detectors.detective-es6': 0.0.6
+      '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-sass': 0.0.9(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-scss': 0.0.9(postcss@8.4.45)
+      '@teambit/styling.deps-lookups.lookup-styling': 0.0.4
+      '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
+      '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
+      '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@6.0.3)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
@@ -73059,7 +73159,6 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
-      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/component.ui.component-meta': 0.0.368(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
@@ -73090,7 +73189,6 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@18.3.1)
-      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/component.ui.component-meta': 0.0.368(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(react-dom@18.3.1)(react@18.3.1)
@@ -73121,7 +73219,6 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.1.0)
-      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/component.ui.component-meta': 0.0.368(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
@@ -73207,6 +73304,22 @@ snapshots:
       - react-dom
       - typescript
 
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/base-ui.input.error': 1.0.3(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      prism-react-renderer: 1.3.5(react@18.3.1)
+      react: 18.3.1
+      react-live: 4.1.8(react-dom@18.3.1)(react@18.3.1)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3)
+      use-debounce: 9.0.4(react@18.3.1)
+    transitivePeerDependencies:
+      - react-dom
+      - typescript
+
   '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@18.3.1)(react@18.3.1)
@@ -73223,7 +73336,7 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@18.3.1)
@@ -73233,8 +73346,24 @@ snapshots:
       prism-react-renderer: 1.3.5(react@18.3.1)
       react: 18.3.1
       react-live: 4.1.8(react-dom@19.1.0)(react@18.3.1)
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3)
       use-debounce: 9.0.4(react@18.3.1)
+    transitivePeerDependencies:
+      - react-dom
+      - typescript
+
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      prism-react-renderer: 1.3.5(react@19.1.0)
+      react: 19.1.0
+      react-live: 4.1.8(react-dom@19.1.0)(react@19.1.0)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
+      use-debounce: 9.0.4(react@19.1.0)
     transitivePeerDependencies:
       - react-dom
       - typescript
@@ -73307,9 +73436,9 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73320,22 +73449,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
-      '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
-    dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73346,9 +73462,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73372,6 +73488,19 @@ snapshots:
       - react-dom
       - typescript
 
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
   '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
@@ -73385,13 +73514,26 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-syntax-highlighter'
@@ -73511,11 +73653,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
       '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
@@ -73540,28 +73682,28 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
-      '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
-      '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
-      '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
-      '@teambit/documenter.ui.image': 4.0.4(react@18.3.1)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
-      '@teambit/documenter.ui.italic': 4.0.9(react@18.3.1)
-      '@teambit/documenter.ui.ol': 4.1.7(react@18.3.1)
-      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.ui.separator': 4.1.7(react@18.3.1)
-      '@teambit/documenter.ui.sup': 4.0.9(react@18.3.1)
-      '@teambit/documenter.ui.table.base-table': 4.1.7(react@18.3.1)
-      '@teambit/documenter.ui.table.td': 4.1.7(react@18.3.1)
-      '@teambit/documenter.ui.table.tr': 4.1.7(react@18.3.1)
-      '@teambit/documenter.ui.ul': 4.1.7(react@18.3.1)
+      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
+      '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.image': 4.0.4(react@19.1.0)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
+      '@teambit/documenter.ui.italic': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.ol': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.separator': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.sup': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.table.base-table': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.table.td': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.table.tr': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.ul': 4.1.7(react@19.1.0)
       '@types/react': 19.2.14
       classnames: 2.5.1
-      react: 18.3.1
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-dom'
@@ -73598,28 +73740,28 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
-      '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.image': 4.0.4(react@19.1.0)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
-      '@teambit/documenter.ui.italic': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.ol': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.separator': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.sup': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.table.base-table': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.table.td': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.table.tr': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.ul': 4.1.7(react@19.1.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
+      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
+      '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
+      '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
+      '@teambit/documenter.ui.image': 4.0.4(react@18.3.1)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
+      '@teambit/documenter.ui.italic': 4.0.9(react@18.3.1)
+      '@teambit/documenter.ui.ol': 4.1.7(react@18.3.1)
+      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/documenter.ui.separator': 4.1.7(react@18.3.1)
+      '@teambit/documenter.ui.sup': 4.0.9(react@18.3.1)
+      '@teambit/documenter.ui.table.base-table': 4.1.7(react@18.3.1)
+      '@teambit/documenter.ui.table.td': 4.1.7(react@18.3.1)
+      '@teambit/documenter.ui.table.tr': 4.1.7(react@18.3.1)
+      '@teambit/documenter.ui.ul': 4.1.7(react@18.3.1)
       '@types/react': 19.2.14
       classnames: 2.5.1
-      react: 19.1.0
+      react: 18.3.1
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-dom'
@@ -73656,11 +73798,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.routing.external-link': 4.1.4(react@18.3.1)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@18.3.1)
       '@teambit/documenter.ui.bold': 4.0.9(react@18.3.1)
@@ -73678,6 +73820,35 @@ snapshots:
       '@types/react': 19.2.14
       classnames: 2.5.1
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
+      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
+      '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.image': 4.0.4(react@19.1.0)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
+      '@teambit/documenter.ui.italic': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.ol': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.separator': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.sup': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.table.base-table': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.table.td': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.table.tr': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.ul': 4.1.7(react@19.1.0)
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-dom'
@@ -74223,14 +74394,27 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.table-row': 4.1.14(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       react: 18.3.1
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3)
       use-debounce: 3.4.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - react-dom
+      - typescript
+
+  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.table-row': 4.1.14(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      react: 19.1.0
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
+      use-debounce: 3.4.3(react@19.1.0)
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
@@ -74598,17 +74782,43 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
     dependencies:
       '@teambit/harmony': 0.4.12
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
+      eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
+      eslint-plugin-react: 7.33.2(eslint@8.56.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+    transitivePeerDependencies:
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+      - typescript
+
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/harmony': 0.4.12
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      eslint-mdx: 1.17.1(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -74627,7 +74837,7 @@ snapshots:
   '@teambit/envs.aspect-docs.envs@file:scopes/envs/aspect-docs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -74637,7 +74847,7 @@ snapshots:
   '@teambit/envs.aspect-docs.envs@file:scopes/envs/aspect-docs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -75758,7 +75968,7 @@ snapshots:
   '@teambit/generator.aspect-docs.generator@file:scopes/generator/aspect-docs/generator(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -75768,7 +75978,7 @@ snapshots:
   '@teambit/generator.aspect-docs.generator@file:scopes/generator/aspect-docs/generator(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76236,7 +76446,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.logger@file:scopes/harmony/aspect-docs/logger(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -76246,7 +76456,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.logger@file:scopes/harmony/aspect-docs/logger(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76256,7 +76466,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.node@file:scopes/harmony/aspect-docs/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -76266,7 +76476,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.node@file:scopes/harmony/aspect-docs/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76815,7 +77025,7 @@ snapshots:
   '@teambit/html.aspect-docs.html@file:scopes/html/aspect-docs/html(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -76825,7 +77035,7 @@ snapshots:
   '@teambit/html.aspect-docs.html@file:scopes/html/aspect-docs/html(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -79070,7 +79280,7 @@ snapshots:
       '@teambit/legacy.cli.error': 0.0.19
       '@teambit/legacy.constants': 0.0.11
       '@teambit/legacy.consumer': 0.0.49(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': 0.0.49
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.loader': 0.0.7
       '@teambit/legacy.logger': 0.0.19
@@ -79137,7 +79347,7 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/legacy.consumer-config@0.0.49(graphql@15.8.0)':
+  '@teambit/legacy.consumer-config@0.0.49':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -79154,9 +79364,7 @@ snapshots:
       lodash: 4.17.21
       p-map-series: 2.1.0
     transitivePeerDependencies:
-      - domexception
       - encoding
-      - graphql
       - supports-color
 
   '@teambit/legacy.consumer-config@file:components/legacy/consumer-config(graphql@15.8.0)':
@@ -79197,7 +79405,7 @@ snapshots:
       '@teambit/legacy.bit-map': 0.0.106(graphql@15.8.0)
       '@teambit/legacy.constants': 0.0.11
       '@teambit/legacy.consumer-component': 0.0.50(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': 0.0.49
       '@teambit/legacy.logger': 0.0.19
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.utils': 0.0.21
@@ -79586,7 +79794,7 @@ snapshots:
       '@teambit/legacy.constants': 0.0.11
       '@teambit/legacy.consumer': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.consumer-component': 0.0.50(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': 0.0.49
       '@teambit/legacy.dependency-graph': 0.0.52(graphql@15.8.0)
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.loader': 0.0.7
@@ -79819,7 +80027,7 @@ snapshots:
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79831,7 +80039,7 @@ snapshots:
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79950,7 +80158,7 @@ snapshots:
 
   '@teambit/mdx.generator.mdx-templates@1.0.14': {}
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -79962,21 +80170,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -79986,6 +80194,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -80024,7 +80233,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -80034,7 +80242,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80046,21 +80254,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.9.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80070,6 +80278,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -80108,7 +80317,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -80118,7 +80326,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80130,21 +80338,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80154,6 +80362,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -80192,7 +80401,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -80202,7 +80410,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80214,21 +80422,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80238,6 +80446,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -80276,7 +80485,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -80286,7 +80494,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80298,21 +80506,21 @@ snapshots:
       '@teambit/mdx.compilers.mdx-multi-compiler': 2.0.46(@babel/core@7.28.3)(react@18.3.1)(rollup@4.53.3)
       '@teambit/mdx.generator.mdx-starters': 1.0.10
       '@teambit/mdx.generator.mdx-templates': 1.0.14
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       core-js: 3.13.0
       eslint: 8.56.0
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -80322,6 +80530,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -80360,7 +80569,6 @@ snapshots:
       - supports-color
       - ts-node
       - type-fest
-      - typescript
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
@@ -80465,9 +80673,9 @@ snapshots:
       - '@types/react'
       - react-dom
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 18.3.1
@@ -80479,23 +80687,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
-      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
-    dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -80507,9 +80701,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -80535,6 +80729,20 @@ snapshots:
       - react-dom
       - typescript
 
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
+    dependencies:
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
+      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
   '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
@@ -80549,12 +80757,26 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
+      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
@@ -80639,11 +80861,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       react: 18.3.1
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80655,12 +80877,12 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
-      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
-      react: 18.3.1
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
       - '@teambit/mdx.ui.mdx-scope-context'
@@ -80687,12 +80909,12 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      react: 19.1.0
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      react: 18.3.1
     transitivePeerDependencies:
       - '@mdx-js/react'
       - '@teambit/mdx.ui.mdx-scope-context'
@@ -80719,12 +80941,28 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@mdx-js/react'
+      - '@teambit/mdx.ui.mdx-scope-context'
+      - '@testing-library/react'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
       - '@teambit/mdx.ui.mdx-scope-context'
@@ -81670,7 +81908,7 @@ snapshots:
   '@teambit/pipelines.aspect-docs.builder@file:scopes/pipelines/aspect-docs/builder(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -81680,7 +81918,7 @@ snapshots:
   '@teambit/pipelines.aspect-docs.builder@file:scopes/pipelines/aspect-docs/builder(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -81703,7 +81941,7 @@ snapshots:
   '@teambit/pkg.aspect-docs.pkg@file:scopes/pkg/aspect-docs/pkg(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -81713,7 +81951,7 @@ snapshots:
   '@teambit/pkg.aspect-docs.pkg@file:scopes/pkg/aspect-docs/pkg(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -81771,7 +82009,7 @@ snapshots:
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/legacy.constants': 0.0.11
-      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': 0.0.49
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.utils': 0.0.21
       '@teambit/toolbox.path.path': 0.0.8
@@ -82219,7 +82457,7 @@ snapshots:
   '@teambit/preview.aspect-docs.preview@file:scopes/preview/aspect-docs/preview(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -82229,7 +82467,7 @@ snapshots:
   '@teambit/preview.aspect-docs.preview@file:scopes/preview/aspect-docs/preview(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82389,13 +82627,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82436,13 +82674,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82483,13 +82721,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82530,13 +82768,13 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 18.3.1
@@ -82870,14 +83108,12 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
-      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
-      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -82932,14 +83168,12 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
-      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
-      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -82994,14 +83228,12 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
-      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
-      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -83056,14 +83288,12 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
-      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
-      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -83093,7 +83323,6 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(react@18.3.1)':
     dependencies:
       '@teambit/harmony': 0.4.12
-      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.1.0)(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -83106,7 +83335,6 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(react@19.1.0)':
     dependencies:
       '@teambit/harmony': 0.4.12
-      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -83535,7 +83763,7 @@ snapshots:
   '@teambit/react.aspect-docs.react@file:scopes/react/aspect-docs/react(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -83545,7 +83773,7 @@ snapshots:
   '@teambit/react.aspect-docs.react@file:scopes/react/aspect-docs/react(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -83656,13 +83884,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/react.eslint-config-bit-react@2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)':
+  '@teambit/react.eslint-config-bit-react@2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.9.2)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
     transitivePeerDependencies:
@@ -83670,15 +83898,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/react.eslint-config-bit-react@2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
+  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - jest
       - supports-color
@@ -83703,15 +83936,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
+  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
     dependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
       react: 19.1.0
@@ -85001,13 +85234,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85023,13 +85256,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@18.3.1)(react@18.3.1)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 18.3.1
@@ -85045,13 +85278,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85193,10 +85426,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85212,10 +85445,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85231,10 +85464,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85266,15 +85499,31 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/documenter.ui.section': 4.1.7(react@18.3.1)
       core-js: 3.13.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - graphql
+      - typescript
+
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
+      core-js: 3.13.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -85287,22 +85536,6 @@ snapshots:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
-      '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      core-js: 3.13.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - encoding
-      - graphql
-      - typescript
-
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
-    dependencies:
-      '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -86477,7 +86710,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86486,7 +86719,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86494,7 +86727,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86509,7 +86742,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86548,7 +86781,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86557,7 +86790,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@5.9.2)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86565,7 +86798,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86580,7 +86813,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.9.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86619,7 +86852,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86628,7 +86861,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86636,7 +86869,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86651,7 +86884,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -86690,7 +86923,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -86699,7 +86932,7 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
@@ -86707,7 +86940,7 @@ snapshots:
       '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
       css-loader: 6.7.2(webpack@5.97.1)
       css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
@@ -86722,7 +86955,7 @@ snapshots:
       postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
       postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
       postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
@@ -89543,16 +89776,16 @@ snapshots:
       - '@apollo/client'
       - '@teambit/base-react.navigation.link'
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -89587,16 +89820,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@18.3.1)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@18.3.1)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@18.3.1)
@@ -89631,16 +89864,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -90075,7 +90308,7 @@ snapshots:
   '@teambit/typescript.aspect-docs.typescript@file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -90085,7 +90318,7 @@ snapshots:
   '@teambit/typescript.aspect-docs.typescript@file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -90110,12 +90343,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@teambit/typescript.deps-detectors.detective-typescript@0.0.10(typescript@7.0.2)':
+  '@teambit/typescript.deps-detectors.detective-typescript@0.0.10(typescript@6.0.3)':
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.6
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@6.0.3)
       node-source-walk: 6.0.2
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -92168,7 +92401,7 @@ snapshots:
     dependencies:
       url-parse: 1.5.3
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92221,7 +92454,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92252,7 +92485,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@18.3.1)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@18.3.1)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92305,7 +92538,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
       resolve-url-loader: 5.0.0
@@ -92336,7 +92569,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92389,7 +92622,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92527,7 +92760,7 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@18.3.1)(typescript@7.0.2)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
@@ -92542,11 +92775,11 @@ snapshots:
       react: 18.3.1
       react-dom: 19.1.0(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@18.3.1)
-      vue-component-meta: 2.2.10(typescript@7.0.2)
+      vue-component-meta: 2.2.10(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -92561,7 +92794,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      vue-component-meta: 2.2.10(typescript@7.0.2)
+      vue-component-meta: 2.2.10(typescript@5.5.3)
     transitivePeerDependencies:
       - typescript
 
@@ -93205,7 +93438,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
@@ -93213,7 +93446,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.7.5)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93267,7 +93500,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
@@ -93275,38 +93508,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.7.8)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.9.2)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - lightningcss
-      - react
-      - supports-color
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
-    dependencies:
-      '@teambit/toolbox.path.path': 0.0.8
-      '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      find-root: 1.1.0
-      html-webpack-plugin: 5.6.3(@rspack/core@1.7.8)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93391,7 +93593,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/webpack.webpack-dev-server@1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@teambit/toolbox.path.path': 0.0.8
       '@teambit/webpack.modules.config-mutator': 0.0.177(esbuild@0.14.29)(react@18.3.1)
@@ -93399,7 +93601,7 @@ snapshots:
       find-root: 1.1.0
       html-webpack-plugin: 5.6.3(@rspack/core@2.1.4)(webpack@5.97.1)
       object-hash: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -93422,7 +93624,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/harmony': 0.4.12
@@ -93458,7 +93660,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@18.3.1)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@18.3.1)
       stream-browserify: 3.0.0
@@ -93486,7 +93688,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/harmony': 0.4.12
@@ -93522,7 +93724,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       stream-browserify: 3.0.0
@@ -93600,7 +93802,7 @@ snapshots:
   '@teambit/workspace.aspect-docs.variants@file:scopes/workspace/aspect-docs/variants(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -93610,7 +93812,7 @@ snapshots:
   '@teambit/workspace.aspect-docs.variants@file:scopes/workspace/aspect-docs/variants(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -95295,32 +95497,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 6.19.1
-      '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@5.9.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 6.19.1
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.56.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/scope-manager': 6.19.1
-      '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.3.4(supports-color@9.4.0)
@@ -95329,7 +95511,27 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@7.0.2)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 6.19.1
+      '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/visitor-keys': 6.19.1
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.56.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      semver: 7.7.1
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -95372,6 +95574,26 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 7.1.0
+      '@typescript-eslint/type-utils': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 7.1.0
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.56.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.4.3(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95453,11 +95675,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.19.1
+      '@typescript-eslint/types': 6.19.1
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 6.19.1
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.56.0
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1
       '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
@@ -95489,6 +95724,19 @@ snapshots:
       eslint: 8.56.0
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.1.0(eslint@8.56.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.1.0
+      '@typescript-eslint/types': 7.1.0
+      '@typescript-eslint/typescript-estree': 7.1.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 7.1.0
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.56.0
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95535,12 +95783,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.0(typescript@7.0.2)':
+  '@typescript-eslint/project-service@8.39.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.39.0
       debug: 4.3.4(supports-color@9.4.0)
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95577,9 +95825,9 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@7.0.2)':
+  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@6.0.3)':
     dependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
 
   '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
@@ -95593,27 +95841,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.9.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@5.9.2)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.56.0
-      ts-api-utils: 1.4.3(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@7.0.2)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
       '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 8.56.0
-      ts-api-utils: 1.4.3(typescript@7.0.2)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95638,6 +95874,18 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@7.1.0(eslint@8.56.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.1.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.56.0
+      ts-api-utils: 1.4.3(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95706,6 +95954,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.4(supports-color@9.4.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.1
+      tsutils: 3.21.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@5.62.0(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -95750,7 +96012,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@6.19.1(typescript@7.0.2)':
+  '@typescript-eslint/typescript-estree@6.19.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 6.19.1
       '@typescript-eslint/visitor-keys': 6.19.1
@@ -95759,9 +96021,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.4.3(typescript@7.0.2)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95792,6 +96054,21 @@ snapshots:
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.1.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 7.1.0
+      '@typescript-eslint/visitor-keys': 7.1.0
+      debug: 4.3.4(supports-color@9.4.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.1
+      ts-api-utils: 1.4.3(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95842,10 +96119,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.39.0(typescript@7.0.2)':
+  '@typescript-eslint/typescript-estree@8.39.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.0(typescript@7.0.2)
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/project-service': 8.39.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.3.4(supports-color@9.4.0)
@@ -95853,8 +96130,8 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@7.0.2)
-      typescript: 7.0.2
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -95881,6 +96158,21 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
+      eslint: 8.56.0
+      eslint-scope: 5.1.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
       eslint: 8.56.0
       eslint-scope: 5.1.1
       semver: 7.7.1
@@ -95917,20 +96209,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.19.1(eslint@8.56.0)(typescript@5.9.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 6.19.1
-      '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.9.2)
-      eslint: 8.56.0
-      semver: 7.7.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/utils@6.19.1(eslint@8.56.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
@@ -95938,7 +96216,7 @@ snapshots:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.19.1
       '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@6.0.3)
       eslint: 8.56.0
       semver: 7.7.1
     transitivePeerDependencies:
@@ -95967,6 +96245,20 @@ snapshots:
       '@typescript-eslint/scope-manager': 7.1.0
       '@typescript-eslint/types': 7.1.0
       '@typescript-eslint/typescript-estree': 7.1.0(typescript@5.9.2)
+      eslint: 8.56.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@7.1.0(eslint@8.56.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.56.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.1.0
+      '@typescript-eslint/types': 7.1.0
+      '@typescript-eslint/typescript-estree': 7.1.0(typescript@6.0.3)
       eslint: 8.56.0
       semver: 7.7.1
     transitivePeerDependencies:
@@ -96261,6 +96553,19 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
+  '@vue/language-core@2.2.10(typescript@5.5.3)':
+    dependencies:
+      '@volar/language-core': 2.4.14
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.17
+      alien-signals: 1.0.13
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.5.3
+
   '@vue/language-core@2.2.10(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.14
@@ -96273,6 +96578,19 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.9.2
+
+  '@vue/language-core@2.2.10(typescript@6.0.3)':
+    dependencies:
+      '@volar/language-core': 2.4.14
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.17
+      alien-signals: 1.0.13
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@vue/language-core@2.2.10(typescript@7.0.2)':
     dependencies:
@@ -98763,6 +99081,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
+  cosmiconfig@8.3.6(typescript@6.0.3):
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 6.0.3
+
   cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
       import-fresh: 3.3.0
@@ -99966,7 +100293,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -100013,7 +100340,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -100084,12 +100411,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2):
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@6.0.3)
       eslint: 8.56.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@6.0.3)
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -100106,12 +100433,34 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.5.3)
+      eslint: 8.56.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
+      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@8.39.0)(eslint@8.56.0)(typescript@5.9.2)
+      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@6.0.3)
+      eslint: 8.56.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -100852,6 +101201,26 @@ snapshots:
       semver: 7.7.1
       tapable: 1.1.3
       typescript: 5.9.2
+      webpack: 5.97.1(esbuild@0.14.29)
+    optionalDependencies:
+      eslint: 8.56.0
+
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1):
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@types/json-schema': 7.0.15
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      cosmiconfig: 6.0.0
+      deepmerge: 4.3.1
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      memfs: 3.5.3
+      minimatch: 3.0.5
+      schema-utils: 2.7.0
+      semver: 7.7.1
+      tapable: 1.1.3
+      typescript: 6.0.3
       webpack: 5.97.1(esbuild@0.14.29)
     optionalDependencies:
       eslint: 8.56.0
@@ -106339,6 +106708,40 @@ snapshots:
       - supports-color
       - vue-template-compiler
 
+  react-dev-utils@12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1):
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      address: 1.2.2
+      browserslist: 4.23.3
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      detect-port-alt: 1.1.6
+      escape-string-regexp: 4.0.0
+      filesize: 8.0.7
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      global-modules: 2.0.0
+      globby: 11.1.0
+      gzip-size: 6.0.0
+      immer: 9.0.21
+      is-root: 2.1.0
+      loader-utils: 3.3.1
+      open: 8.4.2
+      pkg-up: 3.1.0
+      prompts: 2.4.2
+      react-error-overlay: 6.0.11
+      recursive-readdir: 2.2.3
+      shell-quote: 1.8.2
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+      webpack: 5.97.1(esbuild@0.14.29)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - vue-template-compiler
+
   react-dev-utils@12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -106655,11 +107058,23 @@ snapshots:
       react: 18.3.1
       typescript: 5.9.2
 
+  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@6.0.3):
+    dependencies:
+      '@types/react': 19.2.14
+      react: 18.3.1
+      typescript: 6.0.3
+
   react-use-dimensions@1.2.1(@types/react@19.2.14)(react@18.3.1)(typescript@7.0.2):
     dependencies:
       '@types/react': 19.2.14
       react: 18.3.1
       typescript: 7.0.2
+
+  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3):
+    dependencies:
+      '@types/react': 19.2.14
+      react: 19.1.0
+      typescript: 5.5.3
 
   react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.9.2):
     dependencies:
@@ -108709,6 +109124,10 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
+  ts-api-utils@1.4.3(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   ts-api-utils@1.4.3(typescript@7.0.2):
     dependencies:
       typescript: 7.0.2
@@ -108721,9 +109140,9 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  ts-api-utils@2.1.0(typescript@7.0.2):
+  ts-api-utils@2.1.0(typescript@6.0.3):
     dependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
 
   ts-easing@0.2.0: {}
 
@@ -108768,6 +109187,11 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.9.2
+
+  tsutils@3.21.0(typescript@6.0.3):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 6.0.3
 
   tsutils@3.21.0(typescript@7.0.2):
     dependencies:
@@ -109507,6 +109931,15 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  vue-component-meta@2.2.10(typescript@5.5.3):
+    dependencies:
+      '@volar/typescript': 2.4.14
+      '@vue/language-core': 2.2.10(typescript@5.5.3)
+      path-browserify: 1.0.1
+      vue-component-type-helpers: 2.2.10
+    optionalDependencies:
+      typescript: 5.5.3
+
   vue-component-meta@2.2.10(typescript@5.9.2):
     dependencies:
       '@volar/typescript': 2.4.14
@@ -109515,6 +109948,15 @@ snapshots:
       vue-component-type-helpers: 2.2.10
     optionalDependencies:
       typescript: 5.9.2
+
+  vue-component-meta@2.2.10(typescript@6.0.3):
+    dependencies:
+      '@volar/typescript': 2.4.14
+      '@vue/language-core': 2.2.10(typescript@6.0.3)
+      path-browserify: 1.0.1
+      vue-component-type-helpers: 2.2.10
+    optionalDependencies:
+      typescript: 6.0.3
 
   vue-component-meta@2.2.10(typescript@7.0.2):
     dependencies:


### PR DESCRIPTION
Updates the 23 aspect-docs components to mdx-env 3.1.0, which pins a `typescript` peer (6.0.3) in the env.

This fixes the `bit_merge` CI failure on master: with typescript@7 in the workspace graph (from the TS7-based envs), the mdx-env root's unpinned typescript peers auto-bound to 7.0.2 — which ships no JS compiler API — crashing the `EslintLint` build task at plugin load (`ts-api-utils` reads the API at require-time). With 3.1.0 the env root pins typescript 6.0.3 and the ESLint toolchain binds to it.

Verified locally: `bit build` of an mdx-env component passes all tasks including `EslintLint`.