### PR TITLE
chore: update envs with the fixed typescript-compiler

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -14,420 +14,600 @@
         "scope": "teambit.legacy",
         "version": "0.0.100",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/analytics"
+        "rootDir": "components/legacy/analytics",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "api-reference": {
         "name": "api-reference",
         "scope": "teambit.api-reference",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1109",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
         "scope": "teambit.toolbox",
         "version": "0.0.9",
         "mainFile": "find-duplications.ts",
-        "rootDir": "scopes/toolbox/array/duplications-finder"
+        "rootDir": "scopes/toolbox/array/duplications-finder",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "aspect": {
         "name": "aspect",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
         "scope": "teambit.compilation",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/babel"
+        "rootDir": "scopes/compilation/aspect-docs/babel",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/builder": {
         "name": "aspect-docs/builder",
         "scope": "teambit.pipelines",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/aspect-docs/builder"
+        "rootDir": "scopes/pipelines/aspect-docs/builder",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/compiler": {
         "name": "aspect-docs/compiler",
         "scope": "teambit.compilation",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/compiler"
+        "rootDir": "scopes/compilation/aspect-docs/compiler",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/component": {
         "name": "aspect-docs/component",
         "scope": "teambit.component",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/aspect-docs/component"
+        "rootDir": "scopes/component/aspect-docs/component",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/compositions": {
         "name": "aspect-docs/compositions",
         "scope": "teambit.compositions",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/aspect-docs/compositions"
+        "rootDir": "scopes/compositions/aspect-docs/compositions",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/dependency-resolver": {
         "name": "aspect-docs/dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "0.0.189",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver"
+        "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/envs": {
         "name": "aspect-docs/envs",
         "scope": "teambit.envs",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/aspect-docs/envs"
+        "rootDir": "scopes/envs/aspect-docs/envs",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/generator": {
         "name": "aspect-docs/generator",
         "scope": "teambit.generator",
         "version": "0.0.182",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/aspect-docs/generator"
+        "rootDir": "scopes/generator/aspect-docs/generator",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/html": {
         "name": "aspect-docs/html",
         "scope": "teambit.html",
         "version": "0.0.135",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/aspect-docs/html"
+        "rootDir": "scopes/html/aspect-docs/html",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/logger": {
         "name": "aspect-docs/logger",
         "scope": "teambit.harmony",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-docs/logger"
+        "rootDir": "scopes/harmony/aspect-docs/logger",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/mdx": {
         "name": "aspect-docs/mdx",
         "scope": "teambit.mdx",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/aspect-docs/mdx"
+        "rootDir": "scopes/mdx/aspect-docs/mdx",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/multi-compiler": {
         "name": "aspect-docs/multi-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/aspect-docs/multi-compiler"
+        "rootDir": "scopes/compilation/aspect-docs/multi-compiler",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/node": {
         "name": "aspect-docs/node",
         "scope": "teambit.harmony",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-docs/node"
+        "rootDir": "scopes/harmony/aspect-docs/node",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/pkg": {
         "name": "aspect-docs/pkg",
         "scope": "teambit.pkg",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/aspect-docs/pkg"
+        "rootDir": "scopes/pkg/aspect-docs/pkg",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/pnpm": {
         "name": "aspect-docs/pnpm",
         "scope": "teambit.dependencies",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/pnpm"
+        "rootDir": "scopes/dependencies/aspect-docs/pnpm",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/preview": {
         "name": "aspect-docs/preview",
         "scope": "teambit.preview",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/aspect-docs/preview"
+        "rootDir": "scopes/preview/aspect-docs/preview",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/react": {
         "name": "aspect-docs/react",
         "scope": "teambit.react",
         "version": "0.0.181",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/aspect-docs/react"
+        "rootDir": "scopes/react/aspect-docs/react",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/typescript": {
         "name": "aspect-docs/typescript",
         "scope": "teambit.typescript",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/aspect-docs/typescript"
+        "rootDir": "scopes/typescript/aspect-docs/typescript",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/variants": {
         "name": "aspect-docs/variants",
         "scope": "teambit.workspace",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/aspect-docs/variants"
+        "rootDir": "scopes/workspace/aspect-docs/variants",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-docs/yarn": {
         "name": "aspect-docs/yarn",
         "scope": "teambit.dependencies",
         "version": "0.0.178",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/aspect-docs/yarn"
+        "rootDir": "scopes/dependencies/aspect-docs/yarn",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "aspect-loader": {
         "name": "aspect-loader",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
         "scope": "teambit.react",
         "version": "1.0.58",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/bit-react-transformer"
+        "rootDir": "scopes/react/bit-react-transformer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "bit": {
         "name": "bit",
         "scope": "teambit.harmony",
         "version": "2.0.46",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "bit-map": {
         "name": "bit-map",
         "scope": "teambit.legacy",
         "version": "0.0.196",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/bit-map"
+        "rootDir": "components/legacy/bit-map",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "builder": {
         "name": "builder",
         "scope": "teambit.pipelines",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
         "scope": "teambit.pipelines",
         "version": "0.0.412",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/builder-data"
+        "rootDir": "scopes/pipelines/modules/builder-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "bundler": {
         "name": "bundler",
         "scope": "teambit.compilation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1449",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.468",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci"
+        "rootDir": "scopes/git/ci",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.573",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1356",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.217",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server"
+        "rootDir": "scopes/mcp/cli-mcp-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
         "scope": "teambit.toolbox",
         "version": "0.0.56",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/tables/cli-table"
+        "rootDir": "scopes/toolbox/tables/cli-table",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "cli/error": {
         "name": "cli/error",
         "scope": "teambit.legacy",
         "version": "0.0.51",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/cli/error"
+        "rootDir": "components/legacy/cli/error",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "cli/webpack-events-listener": {
         "name": "cli/webpack-events-listener",
         "scope": "teambit.preview",
         "version": "0.0.184",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/cli/webpack-events-listener"
+        "rootDir": "scopes/preview/cli/webpack-events-listener",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "cloud": {
         "name": "cloud",
         "scope": "teambit.cloud",
         "version": "0.0.1376",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.784",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.457",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor"
+        "rootDir": "scopes/component/component-descriptor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component-diff": {
         "name": "component-diff",
         "scope": "teambit.legacy",
         "version": "0.0.195",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-diff"
+        "rootDir": "components/legacy/component-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "component-issues": {
         "name": "component-issues",
         "scope": "teambit.component",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "components/component-issues"
+        "rootDir": "components/component-issues",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "component-list": {
         "name": "component-list",
         "scope": "teambit.legacy",
         "version": "0.0.193",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-list"
+        "rootDir": "components/legacy/component-list",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "component-log": {
         "name": "component-log",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
         "scope": "teambit.component",
         "version": "0.0.456",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-package-version"
+        "rootDir": "scopes/component/component-package-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "component-sizer": {
         "name": "component-sizer",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -441,357 +621,510 @@
         "scope": "teambit.compositions",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1531",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.945",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.237",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store"
+        "rootDir": "components/config-store",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "constants": {
         "name": "constants",
         "scope": "teambit.legacy",
         "version": "0.0.36",
         "mainFile": "constants.ts",
-        "rootDir": "components/legacy/constants"
+        "rootDir": "components/legacy/constants",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "consumer": {
         "name": "consumer",
         "scope": "teambit.legacy",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer"
+        "rootDir": "components/legacy/consumer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "consumer-component": {
         "name": "consumer-component",
         "scope": "teambit.legacy",
         "version": "0.0.140",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-component"
+        "rootDir": "components/legacy/consumer-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "consumer-config": {
         "name": "consumer-config",
         "scope": "teambit.legacy",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-config"
+        "rootDir": "components/legacy/consumer-config",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "content/cli-reference": {
         "name": "content/cli-reference",
         "scope": "teambit.harmony",
         "version": "2.0.1154",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli-reference"
+        "rootDir": "scopes/harmony/cli-reference",
+        "config": {
+            "teambit.mdx/mdx-env@3.1.1": {}
+        }
     },
     "crypto/sha1": {
         "name": "crypto/sha1",
         "scope": "teambit.toolbox",
         "version": "0.0.19",
         "mainFile": "index.ts",
-        "rootDir": "components/crypto/sha1"
+        "rootDir": "components/crypto/sha1",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "dependencies": {
         "name": "dependencies",
         "scope": "teambit.dependencies",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "dependency-graph": {
         "name": "dependency-graph",
         "scope": "teambit.legacy",
         "version": "0.0.142",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/dependency-graph"
+        "rootDir": "components/legacy/dependency-graph",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "dependency-resolver": {
         "name": "dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "deps-detectors/detective-mdx": {
         "name": "deps-detectors/detective-mdx",
         "scope": "teambit.mdx",
         "version": "0.0.2",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/deps-detectors/detective-mdx"
+        "rootDir": "scopes/mdx/deps-detectors/detective-mdx",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "dev-files": {
         "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "doc-parser": {
         "name": "doc-parser",
         "scope": "teambit.semantics",
         "version": "0.0.147",
         "mainFile": "index.ts",
-        "rootDir": "components/semantics/doc-parser"
+        "rootDir": "components/semantics/doc-parser",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "docs": {
         "name": "docs",
         "scope": "teambit.docs",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.763",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor"
+        "rootDir": "scopes/harmony/doctor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "e2e-helper": {
         "name": "e2e-helper",
         "scope": "teambit.legacy",
         "version": "0.0.189",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/e2e-helper"
+        "rootDir": "components/legacy/e2e-helper",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "eject": {
         "name": "eject",
         "scope": "teambit.workspace",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
         "scope": "teambit.lanes",
         "version": "0.0.195",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/entities/lane-diff"
+        "rootDir": "scopes/lanes/entities/lane-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "entities/semantic-schema": {
         "name": "entities/semantic-schema",
         "scope": "teambit.semantics",
         "version": "0.0.109",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema"
+        "rootDir": "components/entities/semantic-schema",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "entities/semantic-schema-diff": {
         "name": "entities/semantic-schema-diff",
         "scope": "teambit.semantics",
         "version": "0.0.9",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema-diff"
+        "rootDir": "components/entities/semantic-schema-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "env": {
         "name": "env",
         "scope": "teambit.envs",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint"
+        "rootDir": "scopes/defender/eslint",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
         "scope": "teambit.react",
         "version": "2.0.17",
         "mainFile": "index.js",
-        "rootDir": "scopes/react/eslint-config-bit-react"
+        "rootDir": "scopes/react/eslint-config-bit-react",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "eslint/config-mutator": {
         "name": "eslint/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.129",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint-config-mutator"
+        "rootDir": "scopes/defender/eslint-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "export": {
         "name": "export",
         "scope": "teambit.scope",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1455",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "extension-data": {
         "name": "extension-data",
         "scope": "teambit.legacy",
         "version": "0.0.141",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/extension-data"
+        "rootDir": "components/legacy/extension-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "forking": {
         "name": "forking",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/extension-getter"
+        "rootDir": "scopes/toolbox/fs/extension-getter",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "fs/hard-link-directory": {
         "name": "fs/hard-link-directory",
         "scope": "teambit.toolbox",
         "version": "0.0.33",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/hard-link-directory"
+        "rootDir": "scopes/toolbox/fs/hard-link-directory",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "fs/is-dir-empty": {
         "name": "fs/is-dir-empty",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/is-dir-empty"
+        "rootDir": "scopes/toolbox/fs/is-dir-empty",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "fs/last-modified": {
         "name": "fs/last-modified",
         "scope": "teambit.toolbox",
         "version": "0.0.18",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/last-modified"
+        "rootDir": "scopes/toolbox/fs/last-modified",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "fs/link-or-symlink": {
         "name": "fs/link-or-symlink",
         "scope": "teambit.toolbox",
         "version": "0.0.58",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/link-or-symlink"
+        "rootDir": "scopes/toolbox/fs/link-or-symlink",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "fs/linked-dependencies": {
         "name": "fs/linked-dependencies",
         "scope": "teambit.dependencies",
         "version": "0.0.66",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/fs/linked-dependencies"
+        "rootDir": "scopes/dependencies/fs/linked-dependencies",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "fs/remove-empty-dir": {
         "name": "fs/remove-empty-dir",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/fs/remove-empty-dir"
+        "rootDir": "scopes/toolbox/fs/remove-empty-dir",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "generator": {
         "name": "generator",
         "scope": "teambit.generator",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "get-bit-version": {
         "name": "get-bit-version",
         "scope": "teambit.bit",
         "version": "0.0.22",
         "mainFile": "index.ts",
-        "rootDir": "components/bit/get-bit-version"
+        "rootDir": "components/bit/get-bit-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "git": {
         "name": "git",
         "scope": "teambit.git",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1360",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
         "scope": "teambit.cloud",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-cloud-scopes"
+        "rootDir": "scopes/cloud/hooks/use-cloud-scopes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "hooks/use-current-user": {
         "name": "hooks/use-current-user",
         "scope": "teambit.cloud",
         "version": "0.0.32",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-current-user"
+        "rootDir": "scopes/cloud/hooks/use-current-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "hooks/use-lane-components": {
         "name": "hooks/use-lane-components",
@@ -812,7 +1145,10 @@
         "scope": "teambit.cloud",
         "version": "0.0.25",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-logout"
+        "rootDir": "scopes/cloud/hooks/use-logout",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "hooks/use-navigation-message-listener": {
         "name": "hooks/use-navigation-message-listener",
@@ -833,119 +1169,170 @@
         "scope": "teambit.lanes",
         "version": "0.0.262",
         "mainFile": "index.ts",
-        "rootDir": "components/hooks/use-viewed-lane-from-url_1"
+        "rootDir": "components/hooks/use-viewed-lane-from-url_1",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "host-initializer": {
         "name": "host-initializer",
         "scope": "teambit.harmony",
         "version": "0.0.791",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer"
+        "rootDir": "scopes/harmony/host-initializer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.77",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize"
+        "rootDir": "scopes/component/internalize",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
         "scope": "teambit.toolbox",
         "version": "0.0.8",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/json/jsonc-utils"
+        "rootDir": "scopes/toolbox/json/jsonc-utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "lanes": {
         "name": "lanes",
         "scope": "teambit.lanes",
         "version": "1.0.1098",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
         "scope": "teambit.component",
         "version": "0.0.424",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy-component-log"
+        "rootDir": "components/legacy-component-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "linter": {
         "name": "linter",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "loader": {
         "name": "loader",
         "scope": "teambit.legacy",
         "version": "0.0.25",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/loader"
+        "rootDir": "components/legacy/loader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "mcp-config-writer": {
         "name": "mcp-config-writer",
         "scope": "teambit.mcp",
         "version": "0.0.15",
         "mainFile": "index.ts",
-        "rootDir": "components/mcp/mcp-config-writer"
+        "rootDir": "components/mcp/mcp-config-writer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -959,21 +1346,30 @@
         "scope": "teambit.lanes",
         "version": "1.0.1098",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1081",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.874",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -987,315 +1383,450 @@
         "scope": "teambit.compositions",
         "version": "0.0.527",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/model/composition-type"
+        "rootDir": "scopes/compositions/model/composition-type",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "models/cloud-scope": {
         "name": "models/cloud-scope",
         "scope": "teambit.cloud",
         "version": "0.0.26",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-scope"
+        "rootDir": "scopes/cloud/models/cloud-scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "models/cloud-user": {
         "name": "models/cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.26",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-user"
+        "rootDir": "scopes/cloud/models/cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "models/scope-model": {
         "name": "models/scope-model",
         "scope": "teambit.scope",
         "version": "0.0.558",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/models/scope-model"
+        "rootDir": "scopes/scope/models/scope-model",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/babel-compiler": {
         "name": "modules/babel-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.148",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/modules/babel-compiler"
+        "rootDir": "scopes/compilation/modules/babel-compiler",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/component-package-name": {
         "name": "modules/component-package-name",
         "scope": "teambit.pkg",
         "version": "0.0.146",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/component-package-name"
+        "rootDir": "components/modules/component-package-name",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/component-url": {
         "name": "modules/component-url",
         "scope": "teambit.component",
         "version": "0.0.197",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-url"
+        "rootDir": "scopes/component/component-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/concurrency": {
         "name": "modules/concurrency",
         "scope": "teambit.harmony",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/concurrency"
+        "rootDir": "scopes/harmony/modules/concurrency",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/config-mutator": {
         "name": "modules/config-mutator",
         "scope": "teambit.webpack",
         "version": "0.0.180",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/config-mutator"
+        "rootDir": "scopes/webpack/config-mutator",
+        "config": {
+            "teambit.node/node@4.0.1": {}
+        }
     },
     "modules/create-element-from-string": {
         "name": "modules/create-element-from-string",
         "scope": "teambit.html",
         "version": "0.0.131",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/create-element-from-string"
+        "rootDir": "scopes/html/modules/create-element-from-string",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/create-lane": {
         "name": "modules/create-lane",
         "scope": "teambit.lanes",
         "version": "0.0.174",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/modules/create-lane"
+        "rootDir": "scopes/lanes/modules/create-lane",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/diff": {
         "name": "modules/diff",
         "scope": "teambit.lanes",
         "version": "0.0.644",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/diff"
+        "rootDir": "scopes/lanes/diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/feature-toggle": {
         "name": "modules/feature-toggle",
         "scope": "teambit.harmony",
         "version": "0.0.48",
         "mainFile": "feature-toggle.ts",
-        "rootDir": "scopes/harmony/modules/feature-toggle"
+        "rootDir": "scopes/harmony/modules/feature-toggle",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/fetch-html-from-url": {
         "name": "modules/fetch-html-from-url",
         "scope": "teambit.html",
         "version": "0.0.131",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/fetch-html-from-url"
+        "rootDir": "scopes/html/modules/fetch-html-from-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/find-scope-path": {
         "name": "modules/find-scope-path",
         "scope": "teambit.scope",
         "version": "0.0.38",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/find-scope-path"
+        "rootDir": "components/modules/find-scope-path",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/fs-cache": {
         "name": "modules/fs-cache",
         "scope": "teambit.workspace",
         "version": "0.0.66",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/fs-cache"
+        "rootDir": "scopes/workspace/modules/fs-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/generate-asset-manifest": {
         "name": "modules/generate-asset-manifest",
         "scope": "teambit.rspack",
         "version": "0.0.8",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/generate-asset-manifest"
+        "rootDir": "components/modules/generate-asset-manifest",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "modules/generate-expose-loaders": {
         "name": "modules/generate-expose-loaders",
         "scope": "teambit.webpack",
         "version": "0.0.38",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-expose-loaders"
+        "rootDir": "scopes/webpack/modules/generate-expose-loaders",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/generate-externals": {
         "name": "modules/generate-externals",
         "scope": "teambit.webpack",
         "version": "0.0.39",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-externals"
+        "rootDir": "scopes/webpack/modules/generate-externals",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/generate-style-loaders": {
         "name": "modules/generate-style-loaders",
         "scope": "teambit.webpack",
         "version": "1.0.29",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-style-loaders"
+        "rootDir": "scopes/webpack/modules/generate-style-loaders",
+        "config": {
+            "teambit.node/node@4.0.1": {}
+        }
     },
     "modules/get-basic-log": {
         "name": "modules/get-basic-log",
         "scope": "teambit.harmony",
         "version": "0.0.140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/get-basic-log"
+        "rootDir": "scopes/harmony/modules/get-basic-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/get-cloud-user": {
         "name": "modules/get-cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/modules/get-cloud-user"
+        "rootDir": "scopes/cloud/modules/get-cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/git-executable": {
         "name": "modules/git-executable",
         "scope": "teambit.git",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/git-executable"
+        "rootDir": "scopes/git/modules/git-executable",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/harmony-root-generator": {
         "name": "modules/harmony-root-generator",
         "scope": "teambit.harmony",
         "version": "0.0.39",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/harmony-root-generator"
+        "rootDir": "components/modules/harmony-root-generator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/ignore-file-reader": {
         "name": "modules/ignore-file-reader",
         "scope": "teambit.git",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/ignore-file-reader"
+        "rootDir": "scopes/git/modules/ignore-file-reader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/in-memory-cache": {
         "name": "modules/in-memory-cache",
         "scope": "teambit.harmony",
         "version": "0.0.40",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/in-memory-cache"
+        "rootDir": "scopes/harmony/modules/in-memory-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/load-trace": {
         "name": "modules/load-trace",
         "scope": "teambit.harmony",
         "version": "0.0.8",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/load-trace"
+        "rootDir": "scopes/harmony/modules/load-trace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/match-pattern": {
         "name": "modules/match-pattern",
         "scope": "teambit.workspace",
         "version": "0.0.528",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/match-pattern"
+        "rootDir": "scopes/workspace/modules/match-pattern",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/merge-component-results": {
         "name": "modules/merge-component-results",
         "scope": "teambit.pipelines",
         "version": "0.0.519",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/merge-component-results"
+        "rootDir": "scopes/pipelines/modules/merge-component-results",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/merge-helper": {
         "name": "modules/merge-helper",
         "scope": "teambit.component",
         "version": "0.0.82",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/modules/merge-helper"
+        "rootDir": "scopes/component/modules/merge-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/module-resolver": {
         "name": "modules/module-resolver",
         "scope": "teambit.toolbox",
         "version": "0.0.23",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/modules/module-resolver"
+        "rootDir": "scopes/toolbox/modules/module-resolver",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "modules/node-modules-linker": {
         "name": "modules/node-modules-linker",
         "scope": "teambit.workspace",
         "version": "0.0.370",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/node-modules-linker"
+        "rootDir": "scopes/workspace/modules/node-modules-linker",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/requireable-component": {
         "name": "modules/requireable-component",
         "scope": "teambit.harmony",
         "version": "0.0.520",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/requireable-component"
+        "rootDir": "scopes/harmony/modules/requireable-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/resolved-component": {
         "name": "modules/resolved-component",
         "scope": "teambit.harmony",
         "version": "0.0.520",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/resolved-component"
+        "rootDir": "scopes/harmony/modules/resolved-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/semver-helper": {
         "name": "modules/semver-helper",
         "scope": "teambit.pkg",
         "version": "0.0.29",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/modules/semver-helper"
+        "rootDir": "scopes/pkg/modules/semver-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/send-server-sent-events": {
         "name": "modules/send-server-sent-events",
         "scope": "teambit.harmony",
         "version": "0.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/send-server-sent-events"
+        "rootDir": "scopes/harmony/modules/send-server-sent-events",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/style-regexps": {
         "name": "modules/style-regexps",
         "scope": "teambit.webpack",
         "version": "1.0.27",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/style-regexps"
+        "rootDir": "scopes/webpack/style-regexps",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/ts-config-mutator": {
         "name": "modules/ts-config-mutator",
         "scope": "teambit.typescript",
         "version": "0.0.93",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/modules/ts-config-mutator"
+        "rootDir": "scopes/typescript/modules/ts-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "modules/workspace-locator": {
         "name": "modules/workspace-locator",
         "scope": "teambit.workspace",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/workspace-locator"
+        "rootDir": "scopes/workspace/modules/workspace-locator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "mover": {
         "name": "mover",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "network": {
         "name": "network",
         "scope": "teambit.scope",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/network"
+        "rootDir": "scopes/scope/network",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "network/get-port": {
         "name": "network/get-port",
         "scope": "teambit.toolbox",
         "version": "1.0.24",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/network/get-port"
+        "rootDir": "scopes/toolbox/network/get-port",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "new-component-helper": {
         "name": "new-component-helper",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "node": {
         "name": "node",
@@ -1309,14 +1840,20 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.585",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects"
+        "rootDir": "scopes/scope/objects",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
@@ -1330,7 +1867,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.1359",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1344,91 +1884,130 @@
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/is-path-inside"
+        "rootDir": "scopes/toolbox/path/is-path-inside",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "path/match-patterns": {
         "name": "path/match-patterns",
         "scope": "teambit.toolbox",
         "version": "0.0.31",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/match-patterns"
+        "rootDir": "scopes/toolbox/path/match-patterns",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "path/path": {
         "name": "path/path",
         "scope": "teambit.toolbox",
         "version": "0.0.20",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/path"
+        "rootDir": "scopes/toolbox/path/path",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "path/to-windows-compatible-path": {
         "name": "path/to-windows-compatible-path",
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/path/to-windows-compatible-path"
+        "rootDir": "scopes/toolbox/path/to-windows-compatible-path",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "pkg": {
         "name": "pkg",
         "scope": "teambit.pkg",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
         "scope": "teambit.webpack",
         "version": "0.0.31",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin"
+        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "plugins/manifest-plugin": {
         "name": "plugins/manifest-plugin",
         "scope": "teambit.rspack",
         "version": "0.0.7",
         "mainFile": "index.ts",
-        "rootDir": "components/plugins/manifest-plugin"
+        "rootDir": "components/plugins/manifest-plugin",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "pnpm": {
         "name": "pnpm",
         "scope": "teambit.dependencies",
         "version": "1.0.1115",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.123",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier-config-mutator"
+        "rootDir": "scopes/defender/prettier-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "preview": {
         "name": "preview",
         "scope": "teambit.preview",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
         "scope": "teambit.toolbox",
         "version": "0.0.18",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/promise/map-pool"
+        "rootDir": "scopes/toolbox/promise/map-pool",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "pubsub": {
         "name": "pubsub",
         "scope": "teambit.harmony",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "react": {
         "name": "react",
@@ -1442,7 +2021,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "readme": {
         "name": "readme",
@@ -1456,35 +2038,50 @@
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "remote-actions": {
         "name": "remote-actions",
         "scope": "teambit.scope",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/remote-actions"
+        "rootDir": "scopes/scope/remote-actions",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "remotes": {
         "name": "remotes",
         "scope": "teambit.scope",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "components/scope/remotes"
+        "rootDir": "components/scope/remotes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "remove": {
         "name": "remove",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -1505,112 +2102,160 @@
         "scope": "teambit.cloud",
         "version": "0.0.163",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple"
+        "rootDir": "scopes/cloud/ripple",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "scope-api": {
         "name": "scope-api",
         "scope": "teambit.legacy",
         "version": "0.0.194",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope-api"
+        "rootDir": "components/legacy/scope-api",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "scripts": {
         "name": "scripts",
         "scope": "teambit.workspace",
         "version": "0.0.297",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "snap-distance": {
         "name": "snap-distance",
         "scope": "teambit.component",
         "version": "0.0.140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snap-distance"
+        "rootDir": "scopes/component/snap-distance",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "snapping": {
         "name": "snapping",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "sources": {
         "name": "sources",
         "scope": "teambit.component",
         "version": "0.0.191",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/sources"
+        "rootDir": "scopes/component/sources",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "stash": {
         "name": "stash",
         "scope": "teambit.component",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1102",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/capitalize"
+        "rootDir": "scopes/toolbox/string/capitalize",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "string/ellipsis": {
         "name": "string/ellipsis",
         "scope": "teambit.toolbox",
         "version": "0.0.203",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/ellipsis"
+        "rootDir": "scopes/toolbox/string/ellipsis",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "string/eol": {
         "name": "string/eol",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/eol"
+        "rootDir": "scopes/toolbox/string/eol",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "string/get-initials": {
         "name": "string/get-initials",
         "scope": "teambit.toolbox",
         "version": "0.0.513",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/get-initials"
+        "rootDir": "scopes/toolbox/string/get-initials",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "string/random": {
         "name": "string/random",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/random"
+        "rootDir": "scopes/toolbox/string/random",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "string/strip-trailing-char": {
         "name": "string/strip-trailing-char",
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/string/strip-trailing-char"
+        "rootDir": "scopes/toolbox/string/strip-trailing-char",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "tagged-exports": {
         "name": "tagged-exports",
@@ -1624,98 +2269,140 @@
         "scope": "teambit.harmony",
         "version": "0.0.1449",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
         "scope": "teambit.legacy",
         "version": "0.0.51",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/logger"
+        "rootDir": "components/legacy/logger",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "teambit.legacy/scope": {
         "name": "scope",
         "scope": "teambit.legacy",
         "version": "0.0.139",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope"
+        "rootDir": "components/legacy/scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "teambit.scope/scope": {
         "name": "scope",
         "scope": "teambit.scope",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
         "scope": "teambit.harmony",
         "version": "0.0.405",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/testing/load-aspect"
+        "rootDir": "scopes/harmony/testing/load-aspect",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "testing/mock-components": {
         "name": "testing/mock-components",
         "scope": "teambit.component",
         "version": "0.0.410",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/testing/mock-components"
+        "rootDir": "scopes/component/testing/mock-components",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "testing/mock-workspace": {
         "name": "testing/mock-workspace",
         "scope": "teambit.workspace",
         "version": "0.0.216",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/testing/mock-workspace"
+        "rootDir": "scopes/workspace/testing/mock-workspace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "time/timer": {
         "name": "time/timer",
         "scope": "teambit.toolbox",
         "version": "0.0.18",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/time/timer"
+        "rootDir": "scopes/toolbox/time/timer",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "tracker": {
         "name": "tracker",
         "scope": "teambit.component",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
         "scope": "teambit.typescript",
         "version": "0.0.86",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/ts-server"
+        "rootDir": "scopes/typescript/ts-server",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "types/serializable": {
         "name": "types/serializable",
         "scope": "teambit.toolbox",
         "version": "0.0.513",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/types/serializable"
+        "rootDir": "scopes/toolbox/types/serializable",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "typescript": {
         "name": "typescript",
         "scope": "teambit.typescript",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui"
+        "rootDir": "scopes/ui-foundation/ui",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "ui/aspect-box": {
         "name": "ui/aspect-box",
@@ -2114,98 +2801,140 @@
         "scope": "teambit.toolbox",
         "version": "0.0.516",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/url/add-avatar-query-params"
+        "rootDir": "scopes/toolbox/url/add-avatar-query-params",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "url/query-string": {
         "name": "url/query-string",
         "scope": "teambit.toolbox",
         "version": "0.0.512",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/url/query-string"
+        "rootDir": "scopes/toolbox/url/query-string",
+        "config": {
+            "teambit.node/envs/node-typescript-mocha@2.0.2": {}
+        }
     },
     "user-agent": {
         "name": "user-agent",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "utils": {
         "name": "utils",
         "scope": "teambit.legacy",
         "version": "0.0.44",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/utils"
+        "rootDir": "components/legacy/utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@2.0.3": {}
+        }
     },
     "validator": {
         "name": "validator",
         "scope": "teambit.defender",
         "version": "0.0.314",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator"
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1624",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.870",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history"
+        "rootDir": "scopes/scope/version-history",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.444",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue"
+        "rootDir": "scopes/vue/vue",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1660",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1078",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1079",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.4": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,31 +767,43 @@ jobs:
           when: always
           no_output_timeout: '15m'
           command: |
-            set -x
-            TSC=$(ls -d ~/bit/bit/node_modules/.pnpm/typescript@7*/node_modules/typescript/lib/tsc.js 2>/dev/null | head -1)
+            set +e
+            set +o pipefail
+            TSC=$(find ~/bit/bit/node_modules/.pnpm -maxdepth 4 -path '*typescript@7*/node_modules/typescript/lib/tsc.js' 2>/dev/null | head -1)
             echo "TSC=$TSC"
             for N in ~/Library/Caches/Bit/capsules/*/; do
               [ -f "$N/tsconfig.json" ] || continue
               echo "==== network: $N ===="
-              head -80 "$N/tsconfig.json"
+              head -100 "$N/tsconfig.json"
               echo "-- tsbuildinfo files --"
-              find "$N/dist" -name '*tsbuildinfo*' 2>/dev/null | head -5
-              echo "-- root dist: entry-level d.ts (maxdepth 2) --"
-              find "$N/dist" -maxdepth 2 -name '*.d.ts' 2>/dev/null | head -40
-              echo "-- sample capsule dists --"
-              ls -d "$N"teambit.* 2>/dev/null | head -6 | while read C; do
-                echo "--- $(basename $C)"; ls "$C/dist" 2>/dev/null | head -15
-              done
+              find "$N/dist" -name '*tsbuildinfo*' 2>/dev/null > /tmp/tbi.txt; cat /tmp/tbi.txt
+              echo "-- capsules missing entry d.ts vs having it --"
+              for C in "$N"teambit.*/; do
+                [ -d "$C/dist" ] || continue
+                base=$(basename "$C")
+                dts=$(find "$C/dist" -maxdepth 1 -name '*.d.ts' 2>/dev/null | wc -l)
+                if [ -f "$C/dist/index.d.ts" ]; then
+                  echo "OK      $base (top-level d.ts: $dts)"
+                else
+                  echo "MISSING $base (top-level d.ts: $dts)"
+                fi
+              done > /tmp/caps.txt
+              grep -c '^OK' /tmp/caps.txt; grep -c '^MISSING' /tmp/caps.txt
+              echo "--- MISSING list (first 30):"; grep '^MISSING' /tmp/caps.txt > /tmp/miss.txt; head -30 /tmp/miss.txt
+              echo "--- OK list (first 10):"; grep '^OK' /tmp/caps.txt > /tmp/ok.txt; head -10 /tmp/ok.txt
+              echo "-- root dist entry d.ts count --"
+              find "$N/dist" -maxdepth 2 -name 'index.d.ts' 2>/dev/null > /tmp/rootidx.txt; wc -l < /tmp/rootidx.txt; head -15 /tmp/rootidx.txt
               if [ -n "$TSC" ]; then
                 echo "-- re-running native tsc with --listEmittedFiles --"
-                cd "$N"
+                cd "$N" || continue
                 node "$TSC" -p tsconfig.json --listEmittedFiles > /tmp/emit.log 2>&1
                 echo "tsc-exit=$?"
-                echo "emitted total: $(grep -c '^TSFILE' /tmp/emit.log)"
-                echo "-- emitted entry d.ts (dist/<capsule>/index.d.ts, depth-2 only) --"
-                grep '^TSFILE' /tmp/emit.log | grep -E "dist/[^/]+/index\.d\.ts$" | head -30
-                echo "-- non-TSFILE output (errors etc.) --"
-                grep -v '^TSFILE' /tmp/emit.log | head -40
+                grep -c '^TSFILE' /tmp/emit.log
+                echo "-- emitted entry d.ts (depth-2 index.d.ts) --"
+                grep '^TSFILE' /tmp/emit.log > /tmp/tsfiles.txt
+                grep -E "dist/[^/]+/index\.d\.ts$" /tmp/tsfiles.txt > /tmp/entries.txt; wc -l < /tmp/entries.txt; head -15 /tmp/entries.txt
+                echo "-- non-TSFILE output (errors etc., first 40) --"
+                grep -v '^TSFILE' /tmp/emit.log > /tmp/rest.txt; head -40 /tmp/rest.txt
                 cd - > /dev/null
               fi
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,6 +758,44 @@ jobs:
             # NOTE: parallel builds (BIT_BUILD_CONCURRENCY>1) were measured here and did NOT help —
             # this build is CPU-bound and dominated by one env, so concurrency only added contention.
             # See tasks-parallel-scheduler.ts header for the numbers. Left serial on purpose.
+      # TEMPORARY diagnostic for the missing dist/{main}.d.ts in packages built on CI
+      # (entry d.ts absent from the declaration artifacts of every component snapped on
+      # the TS7 lane, while local builds emit it). Dumps the capsule-network state and
+      # re-runs the exact native tsc with --listEmittedFiles to see what gets emitted here.
+      - run:
+          name: 'dts emit diagnostics'
+          when: always
+          no_output_timeout: '15m'
+          command: |
+            set -x
+            TSC=$(ls -d ~/bit/bit/node_modules/.pnpm/typescript@7*/node_modules/typescript/lib/tsc.js 2>/dev/null | head -1)
+            echo "TSC=$TSC"
+            for N in ~/Library/Caches/Bit/capsules/*/; do
+              [ -f "$N/tsconfig.json" ] || continue
+              echo "==== network: $N ===="
+              head -80 "$N/tsconfig.json"
+              echo "-- tsbuildinfo files --"
+              find "$N/dist" -name '*tsbuildinfo*' 2>/dev/null | head -5
+              echo "-- root dist: entry-level d.ts (maxdepth 2) --"
+              find "$N/dist" -maxdepth 2 -name '*.d.ts' 2>/dev/null | head -40
+              echo "-- sample capsule dists --"
+              ls -d "$N"teambit.* 2>/dev/null | head -6 | while read C; do
+                echo "--- $(basename $C)"; ls "$C/dist" 2>/dev/null | head -15
+              done
+              if [ -n "$TSC" ]; then
+                echo "-- re-running native tsc with --listEmittedFiles --"
+                cd "$N"
+                node "$TSC" -p tsconfig.json --listEmittedFiles > /tmp/emit.log 2>&1
+                echo "tsc-exit=$?"
+                echo "emitted total: $(grep -c '^TSFILE' /tmp/emit.log)"
+                echo "-- emitted entry d.ts (dist/<capsule>/index.d.ts, depth-2 only) --"
+                grep '^TSFILE' /tmp/emit.log | grep -E "dist/[^/]+/index\.d\.ts$" | head -30
+                echo "-- non-TSFILE output (errors etc.) --"
+                grep -v '^TSFILE' /tmp/emit.log | head -40
+                cd - > /dev/null
+              fi
+            done
+            true
       - store_artifacts:
           path: ~/Library/Caches/Bit/logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,56 +758,6 @@ jobs:
             # NOTE: parallel builds (BIT_BUILD_CONCURRENCY>1) were measured here and did NOT help —
             # this build is CPU-bound and dominated by one env, so concurrency only added contention.
             # See tasks-parallel-scheduler.ts header for the numbers. Left serial on purpose.
-      # TEMPORARY diagnostic for the missing dist/{main}.d.ts in packages built on CI
-      # (entry d.ts absent from the declaration artifacts of every component snapped on
-      # the TS7 lane, while local builds emit it). Dumps the capsule-network state and
-      # re-runs the exact native tsc with --listEmittedFiles to see what gets emitted here.
-      - run:
-          name: 'dts emit diagnostics'
-          when: always
-          no_output_timeout: '15m'
-          command: |
-            set +e
-            set +o pipefail
-            TSC=$(find ~/bit/bit/node_modules/.pnpm -maxdepth 4 -path '*typescript@7*/node_modules/typescript/lib/tsc.js' 2>/dev/null | head -1)
-            echo "TSC=$TSC"
-            for N in ~/Library/Caches/Bit/capsules/*/; do
-              [ -f "$N/tsconfig.json" ] || continue
-              echo "==== network: $N ===="
-              head -100 "$N/tsconfig.json"
-              echo "-- tsbuildinfo files --"
-              find "$N/dist" -name '*tsbuildinfo*' 2>/dev/null > /tmp/tbi.txt; cat /tmp/tbi.txt
-              echo "-- capsules missing entry d.ts vs having it --"
-              for C in "$N"teambit.*/; do
-                [ -d "$C/dist" ] || continue
-                base=$(basename "$C")
-                dts=$(find "$C/dist" -maxdepth 1 -name '*.d.ts' 2>/dev/null | wc -l)
-                if [ -f "$C/dist/index.d.ts" ]; then
-                  echo "OK      $base (top-level d.ts: $dts)"
-                else
-                  echo "MISSING $base (top-level d.ts: $dts)"
-                fi
-              done > /tmp/caps.txt
-              grep -c '^OK' /tmp/caps.txt; grep -c '^MISSING' /tmp/caps.txt
-              echo "--- MISSING list (first 30):"; grep '^MISSING' /tmp/caps.txt > /tmp/miss.txt; head -30 /tmp/miss.txt
-              echo "--- OK list (first 10):"; grep '^OK' /tmp/caps.txt > /tmp/ok.txt; head -10 /tmp/ok.txt
-              echo "-- root dist entry d.ts count --"
-              find "$N/dist" -maxdepth 2 -name 'index.d.ts' 2>/dev/null > /tmp/rootidx.txt; wc -l < /tmp/rootidx.txt; head -15 /tmp/rootidx.txt
-              if [ -n "$TSC" ]; then
-                echo "-- re-running native tsc with --listEmittedFiles --"
-                cd "$N" || continue
-                node "$TSC" -p tsconfig.json --listEmittedFiles > /tmp/emit.log 2>&1
-                echo "tsc-exit=$?"
-                grep -c '^TSFILE' /tmp/emit.log
-                echo "-- emitted entry d.ts (depth-2 index.d.ts) --"
-                grep '^TSFILE' /tmp/emit.log > /tmp/tsfiles.txt
-                grep -E "dist/[^/]+/index\.d\.ts$" /tmp/tsfiles.txt > /tmp/entries.txt; wc -l < /tmp/entries.txt; head -15 /tmp/entries.txt
-                echo "-- non-TSFILE output (errors etc., first 40) --"
-                grep -v '^TSFILE' /tmp/emit.log > /tmp/rest.txt; head -40 /tmp/rest.txt
-                cd - > /dev/null
-              fi
-            done
-            true
       - store_artifacts:
           path: ~/Library/Caches/Bit/logs
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2154,20 +2154,20 @@ importers:
         version: 3.24.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@teambit/node.node':
-        specifier: 4.0.0
-        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.1
+        version: 4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.4
         version: 1.1.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/node@22.10.5)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -2186,6 +2186,9 @@ importers:
 
   components/bit/get-bit-version:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2203,8 +2206,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2214,6 +2217,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2234,8 +2240,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2283,8 +2289,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -2311,8 +2317,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2325,6 +2331,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2351,8 +2360,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2368,6 +2377,9 @@ importers:
 
   components/entities/semantic-schema-diff:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2385,8 +2397,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2583,6 +2595,9 @@ importers:
       '@teambit/ui-foundation.ui.react-router.use-query':
         specifier: ^0.0.505
         version: 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2600,8 +2615,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2611,6 +2626,9 @@ importers:
 
   components/legacy-component-log:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2628,14 +2646,17 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
 
   components/legacy/analytics:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2674,8 +2695,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2706,6 +2727,9 @@ importers:
       '@teambit/toolbox.object.sorter':
         specifier: ~0.0.2
         version: 0.0.2
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2744,8 +2768,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2767,6 +2791,9 @@ importers:
       '@teambit/bit-error':
         specifier: ~0.0.404
         version: 0.0.404
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2793,8 +2820,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2813,6 +2840,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2857,8 +2887,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -2880,6 +2910,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2903,8 +2936,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2917,6 +2950,9 @@ importers:
 
   components/legacy/constants:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2934,8 +2970,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -2957,6 +2993,9 @@ importers:
       '@teambit/toolbox.object.sorter':
         specifier: ~0.0.2
         version: 0.0.2
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -2986,8 +3025,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3015,6 +3054,9 @@ importers:
       '@teambit/legacy-bit-id':
         specifier: ^1.1.3
         version: 1.1.3
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3047,8 +3089,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3076,6 +3118,9 @@ importers:
       '@teambit/legacy-bit-id':
         specifier: ^1.1.3
         version: 1.1.3
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3105,8 +3150,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3125,6 +3170,9 @@ importers:
       '@teambit/graph.cleargraph':
         specifier: 0.0.11
         version: 0.0.11
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3163,8 +3211,8 @@ importers:
         version: 2.1.6
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3263,8 +3311,8 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3292,6 +3340,9 @@ importers:
       '@teambit/toolbox.object.sorter':
         specifier: ~0.0.2
         version: 0.0.2
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3312,8 +3363,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3326,6 +3377,9 @@ importers:
 
   components/legacy/loader:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3352,8 +3406,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/pretty-time':
         specifier: ^1.1.5
         version: 1.1.5
@@ -3363,6 +3417,9 @@ importers:
 
   components/legacy/logger:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3404,8 +3461,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3433,6 +3490,9 @@ importers:
       '@teambit/pkg.package-json.validator':
         specifier: 0.0.1
         version: 0.0.1
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3486,8 +3546,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3521,6 +3581,9 @@ importers:
       '@teambit/lane-id':
         specifier: ~0.0.312
         version: 0.0.312
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3547,8 +3610,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3570,6 +3633,9 @@ importers:
       '@teambit/toolbox.fs.readdir-skip-system-files':
         specifier: ~0.0.2
         version: 0.0.2
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3605,8 +3671,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3625,6 +3691,9 @@ importers:
 
   components/mcp/mcp-config-writer:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3645,8 +3714,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3665,6 +3734,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3682,8 +3754,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -3693,6 +3765,9 @@ importers:
 
   components/modules/find-scope-path:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3713,8 +3788,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3747,8 +3822,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -3761,6 +3836,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -3781,8 +3859,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3891,8 +3969,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -4030,6 +4108,9 @@ importers:
       '@teambit/legacy-bit-id':
         specifier: ^1.1.3
         version: 1.1.3
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -4065,8 +4146,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -4082,6 +4163,9 @@ importers:
       '@teambit/bit-error':
         specifier: ~0.0.404
         version: 0.0.404
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -4108,8 +4192,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -6402,7 +6486,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -6579,7 +6663,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6615,13 +6699,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6669,7 +6753,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -6996,13 +7080,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7011,10 +7095,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7098,7 +7182,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -7194,7 +7278,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -7227,13 +7311,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -7304,7 +7388,7 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
 
-  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.0:
+  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.4:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -7356,7 +7440,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -7533,7 +7617,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7569,13 +7653,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7623,7 +7707,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -7685,8 +7769,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/cli-reference(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
       '@teambit/harmony.modules.concurrency':
         specifier: workspace:*
         version: file:scopes/harmony/modules/concurrency
@@ -7956,13 +8040,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -7971,10 +8055,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8058,7 +8142,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -8154,7 +8238,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -8187,13 +8271,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -8312,7 +8396,7 @@ importers:
         specifier: 1.72.0
         version: 1.72.0
 
-  node_modules/.bit_roots/teambit.mdx_mdx-env@3.1.0:
+  node_modules/.bit_roots/teambit.mdx_mdx-env@3.1.1:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -8873,8 +8957,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
         version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
@@ -9323,7 +9407,7 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
-  node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@2.0.0:
+  node_modules/.bit_roots/teambit.node_envs_node-babel-mocha@2.0.3:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -9375,7 +9459,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -9552,7 +9636,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9588,13 +9672,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9642,7 +9726,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -9908,8 +9992,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -9975,13 +10059,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -9990,10 +10074,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10077,7 +10161,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -10173,7 +10257,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -10206,13 +10290,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -10279,6 +10363,9 @@ importers:
       '@types/mocha':
         specifier: 10.0.10
         version: 10.0.10
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -10307,7 +10394,7 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
 
-  node_modules/.bit_roots/teambit.node_envs_node-typescript-mocha@2.0.0:
+  node_modules/.bit_roots/teambit.node_envs_node-typescript-mocha@2.0.2:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -10359,7 +10446,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -10536,7 +10623,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10572,13 +10659,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10626,7 +10713,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -10892,8 +10979,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -10959,13 +11046,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10974,10 +11061,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11061,7 +11148,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -11157,7 +11244,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -11190,13 +11277,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -11291,7 +11378,7 @@ importers:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
 
-  node_modules/.bit_roots/teambit.node_node@4.0.0:
+  node_modules/.bit_roots/teambit.node_node@4.0.1:
     dependencies:
       '@babel/core':
         specifier: 7.26.9
@@ -11346,7 +11433,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -11523,7 +11610,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11559,13 +11646,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11613,7 +11700,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -11879,8 +11966,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(eslint@8.56.0)(jest@29.3.1)
       '@teambit/node.node':
-        specifier: 4.0.0
-        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.1
+        version: 4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(@testing-library/react@16.3.2)(react-router-dom@6.30.1)(react@19.1.0)
@@ -11946,13 +12033,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11961,10 +12048,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12048,7 +12135,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -12144,7 +12231,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -12177,13 +12264,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -12261,10 +12348,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -12273,7 +12360,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -12348,7 +12435,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -12525,7 +12612,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12561,13 +12648,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12615,7 +12702,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -12942,7 +13029,7 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.4
         version: 1.1.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/node@22.10.5)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -12951,7 +13038,7 @@ importers:
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12960,10 +13047,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13047,7 +13134,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -13143,7 +13230,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -13176,13 +13263,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -13254,10 +13341,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
+        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -13266,7 +13353,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -13341,7 +13428,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -13518,7 +13605,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13554,13 +13641,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13608,7 +13695,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -13935,13 +14022,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13950,10 +14037,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14037,7 +14124,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -14133,7 +14220,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -14166,13 +14253,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -14286,8 +14373,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14356,8 +14443,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -14385,6 +14472,9 @@ importers:
       '@teambit/ui-foundation.ui.hooks.use-data-query':
         specifier: ^0.0.506
         version: 0.0.506(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14402,8 +14492,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14419,6 +14509,9 @@ importers:
       '@teambit/ui-foundation.ui.hooks.use-data-query':
         specifier: ^0.0.506
         version: 0.0.506(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14436,8 +14529,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14450,6 +14543,9 @@ importers:
       '@apollo/client':
         specifier: ^3.12.0
         version: 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14467,8 +14563,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14481,6 +14577,9 @@ importers:
       '@teambit/scopes.scope-descriptor':
         specifier: ^0.0.34
         version: 0.0.34(react@19.1.0)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14498,8 +14597,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14509,6 +14608,9 @@ importers:
 
   scopes/cloud/models/cloud-user:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14526,8 +14628,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14537,6 +14639,9 @@ importers:
 
   scopes/cloud/modules/get-cloud-user:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -14554,8 +14659,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14597,8 +14702,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -14754,8 +14859,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14785,8 +14890,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14822,8 +14927,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14859,8 +14964,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14902,8 +15007,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14948,8 +15053,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15015,8 +15120,8 @@ importers:
         specifier: 1.96.22
         version: 1.96.22(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15035,6 +15140,9 @@ importers:
       '@babel/core':
         specifier: 7.28.3
         version: 7.28.3
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -15052,8 +15160,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/babel__core':
         specifier: 7.20.0
         version: 7.20.0
@@ -15095,8 +15203,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15126,8 +15234,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -15184,8 +15292,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15239,8 +15347,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15291,8 +15399,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15439,8 +15547,8 @@ importers:
         specifier: ^1.96.10
         version: 1.96.10(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15515,8 +15623,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15558,8 +15666,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15616,8 +15724,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -15636,6 +15744,9 @@ importers:
       '@teambit/component-version':
         specifier: ^1.0.4
         version: 1.0.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -15653,8 +15764,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -15699,8 +15810,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15730,8 +15841,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15744,6 +15855,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -15764,8 +15878,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -15819,8 +15933,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15877,8 +15991,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15926,8 +16040,8 @@ importers:
         specifier: 1.96.6
         version: 1.96.6(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15984,8 +16098,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16090,8 +16204,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -16145,8 +16259,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16227,8 +16341,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16282,8 +16396,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -16331,8 +16445,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -16389,8 +16503,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16406,6 +16520,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -16435,8 +16552,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16484,8 +16601,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16536,8 +16653,8 @@ importers:
         version: 2.2.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16585,8 +16702,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16649,8 +16766,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16716,8 +16833,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16736,6 +16853,9 @@ importers:
       '@teambit/graph.cleargraph':
         specifier: 0.0.11
         version: 0.0.11
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -16759,8 +16879,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16847,8 +16967,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16876,6 +16996,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -16923,8 +17046,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16978,8 +17101,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17033,8 +17156,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17047,6 +17170,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -17070,8 +17196,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17140,8 +17266,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17177,8 +17303,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -17365,8 +17491,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -17425,6 +17551,9 @@ importers:
 
   scopes/compositions/model/composition-type:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -17442,8 +17571,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17546,8 +17675,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -17566,6 +17695,9 @@ importers:
       '@teambit/defender.eslint-linter':
         specifier: ^1.0.56
         version: 1.0.56(eslint@8.56.0)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -17589,8 +17721,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -17644,8 +17776,8 @@ importers:
         specifier: 1.96.11
         version: 1.96.11(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17711,8 +17843,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17769,8 +17901,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17812,8 +17944,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17855,8 +17987,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17895,8 +18027,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17906,6 +18038,9 @@ importers:
 
   scopes/defender/prettier-config-mutator:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -17929,8 +18064,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18026,8 +18161,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.23)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18069,8 +18204,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
 
   scopes/dependencies/aspect-docs/dependency-resolver:
     dependencies:
@@ -18097,8 +18232,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18134,8 +18269,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18171,8 +18306,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18298,8 +18433,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -18428,8 +18563,8 @@ importers:
         version: 0.3.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18448,6 +18583,9 @@ importers:
 
   scopes/dependencies/fs/linked-dependencies:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -18465,8 +18603,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18601,8 +18739,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18692,8 +18830,8 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18762,8 +18900,8 @@ importers:
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18836,8 +18974,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18900,8 +19038,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
 
   scopes/envs/envs:
     dependencies:
@@ -18952,8 +19090,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19053,8 +19191,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -19111,8 +19249,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19148,8 +19286,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19221,8 +19359,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19285,8 +19423,8 @@ importers:
         version: 3.28.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19331,8 +19469,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19345,6 +19483,9 @@ importers:
       '@teambit/bit-error':
         specifier: ~0.0.404
         version: 0.0.404
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -19362,8 +19503,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -19373,6 +19514,9 @@ importers:
 
   scopes/git/modules/ignore-file-reader:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -19396,8 +19540,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19466,8 +19610,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -19533,8 +19677,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19639,8 +19783,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19673,8 +19817,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19710,8 +19854,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19786,8 +19930,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -19928,8 +20072,8 @@ importers:
         specifier: 1.96.13
         version: 1.96.13(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/eventsource':
         specifier: ^1.1.15
         version: 1.1.15
@@ -19974,8 +20118,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -20038,8 +20182,8 @@ importers:
         version: 17.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/didyoumean':
         specifier: 1.2.0
         version: 1.2.0
@@ -20075,8 +20219,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -20130,8 +20274,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20170,8 +20314,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20240,8 +20384,8 @@ importers:
         version: 2.2.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20286,8 +20430,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -20341,8 +20485,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -20453,8 +20597,8 @@ importers:
         version: 7.5.10(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -20517,8 +20661,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20557,8 +20701,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20600,8 +20744,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20611,6 +20755,9 @@ importers:
 
   scopes/harmony/modules/concurrency:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20628,8 +20775,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20639,6 +20786,9 @@ importers:
 
   scopes/harmony/modules/feature-toggle:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20656,8 +20806,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -20673,6 +20823,9 @@ importers:
       '@teambit/lane-id':
         specifier: ~0.0.312
         version: 0.0.312
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20690,8 +20843,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20701,6 +20854,9 @@ importers:
 
   scopes/harmony/modules/in-memory-cache:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20721,8 +20877,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20732,6 +20888,9 @@ importers:
 
   scopes/harmony/modules/load-trace:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20749,8 +20908,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -20763,6 +20922,9 @@ importers:
 
   scopes/harmony/modules/requireable-component:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20780,8 +20942,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20791,6 +20953,9 @@ importers:
 
   scopes/harmony/modules/resolved-component:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20808,8 +20973,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20819,6 +20984,9 @@ importers:
 
   scopes/harmony/modules/send-server-sent-events:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20836,8 +21004,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20958,8 +21126,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@teambit/ui-foundation.ui.is-browser':
         specifier: ^0.0.500
         version: 0.0.500(react-dom@19.1.0)(react@19.1.0)
@@ -20972,6 +21140,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -20989,8 +21160,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21084,8 +21255,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21115,8 +21286,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21129,6 +21300,9 @@ importers:
 
   scopes/html/modules/create-element-from-string:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21146,8 +21320,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21157,6 +21331,9 @@ importers:
 
   scopes/html/modules/fetch-html-from-url:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21174,8 +21351,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21194,6 +21371,9 @@ importers:
       '@teambit/lane-id':
         specifier: ~0.0.312
         version: 0.0.312
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21217,8 +21397,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21234,6 +21414,9 @@ importers:
       '@teambit/lane-id':
         specifier: ~0.0.312
         version: 0.0.312
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21251,8 +21434,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21357,8 +21540,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21424,8 +21607,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21450,6 +21633,9 @@ importers:
       '@teambit/legacy-bit-id':
         specifier: ^1.1.3
         version: 1.1.3
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21470,8 +21656,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21537,8 +21723,8 @@ importers:
         version: 3.24.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21580,8 +21766,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21611,8 +21797,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21752,8 +21938,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21840,8 +22026,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/archiver':
         specifier: 5.3.1
         version: 5.3.1
@@ -21866,6 +22052,9 @@ importers:
 
   scopes/pipelines/modules/builder-data:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21883,8 +22072,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21897,6 +22086,9 @@ importers:
 
   scopes/pipelines/modules/merge-component-results:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21917,8 +22109,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21954,8 +22146,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21971,6 +22163,9 @@ importers:
       '@teambit/component-version':
         specifier: ^1.0.4
         version: 1.0.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -21991,8 +22186,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -22076,8 +22271,8 @@ importers:
         version: 10.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.96.9
         version: 1.96.9(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -22122,8 +22317,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22136,6 +22331,9 @@ importers:
 
   scopes/preview/cli/webpack-events-listener:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -22153,8 +22351,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -22259,8 +22457,8 @@ importers:
         version: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22412,8 +22610,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22432,6 +22630,9 @@ importers:
       '@teambit/react.ui.highlighter.component-metadata.bit-component-meta':
         specifier: 0.0.45
         version: 0.0.45(react-dom@19.1.0)(react@19.1.0)
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -22464,8 +22665,8 @@ importers:
         specifier: 7.22.3
         version: 7.22.3
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.19.6)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.19.6)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -22484,6 +22685,9 @@ importers:
 
   scopes/react/eslint-config-bit-react:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -22522,8 +22726,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -23262,8 +23466,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23329,8 +23533,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23343,6 +23547,9 @@ importers:
       '@teambit/component-id':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -23360,8 +23567,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23386,6 +23593,9 @@ importers:
       '@teambit/toolbox.network.agent':
         specifier: ~0.0.554
         version: 0.0.554
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -23430,8 +23640,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/http-proxy-agent':
         specifier: 2.0.2
         version: 2.0.2
@@ -23524,8 +23734,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23547,6 +23757,9 @@ importers:
       '@teambit/lane-id':
         specifier: ~0.0.312
         version: 0.0.312
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -23567,8 +23780,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       chai:
         specifier: 5.2.1
         version: 5.2.1
@@ -23709,8 +23922,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@teambit/scope.content.scope-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -23770,8 +23983,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23825,8 +24038,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/chai-subset':
         specifier: 1.3.5
         version: 1.3.5
@@ -23842,6 +24055,9 @@ importers:
 
   scopes/toolbox/array/duplications-finder:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -23862,8 +24078,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -23896,8 +24112,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23907,6 +24123,9 @@ importers:
 
   scopes/toolbox/fs/hard-link-directory:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -23936,8 +24155,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -23973,8 +24192,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24010,8 +24229,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24056,8 +24275,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24093,8 +24312,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24107,6 +24326,9 @@ importers:
 
   scopes/toolbox/json/jsonc-utils:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -24133,8 +24355,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24167,8 +24389,8 @@ importers:
         version: 1.20.0
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24195,8 +24417,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24226,8 +24448,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24257,8 +24479,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24294,8 +24516,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24325,8 +24547,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24356,8 +24578,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24390,8 +24612,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24421,8 +24643,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24455,8 +24677,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24483,8 +24705,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24514,8 +24736,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24542,8 +24764,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24553,6 +24775,9 @@ importers:
 
   scopes/toolbox/tables/cli-table:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -24576,8 +24801,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -24604,8 +24829,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24635,8 +24860,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24663,8 +24888,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24691,8 +24916,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-typescript-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24728,8 +24953,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -24742,6 +24967,9 @@ importers:
 
   scopes/typescript/modules/ts-config-mutator:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -24765,8 +24993,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24785,6 +25013,9 @@ importers:
 
   scopes/typescript/ts-server:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -24820,8 +25051,8 @@ importers:
         version: 3.16.0
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24881,8 +25112,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24921,8 +25152,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24964,8 +25195,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25004,8 +25235,8 @@ importers:
         version: 3.2.0(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -25047,8 +25278,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25090,8 +25321,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -25253,8 +25484,8 @@ importers:
         version: 7.1.0(@types/babel__core@7.20.0)(webpack@5.97.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -25305,8 +25536,8 @@ importers:
         version: 0.7.40
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25357,8 +25588,8 @@ importers:
         version: 2.2.10(typescript@7.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
 
   scopes/webpack/config-mutator:
     dependencies:
@@ -25394,8 +25625,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/node.node':
-        specifier: 4.0.0
-        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.1
+        version: 4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -25411,6 +25642,9 @@ importers:
 
   scopes/webpack/modules/generate-expose-loaders:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -25431,8 +25665,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25445,6 +25679,9 @@ importers:
 
   scopes/webpack/modules/generate-externals:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -25462,8 +25699,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25493,14 +25730,17 @@ importers:
         version: 19.2.0(react@19.2.0)
     devDependencies:
       '@teambit/node.node':
-        specifier: 4.0.0
-        version: 4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 4.0.1
+        version: 4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
 
   scopes/webpack/plugins/inject-head-webpack-plugin:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -25527,8 +25767,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25538,6 +25778,9 @@ importers:
 
   scopes/webpack/style-regexps:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -25555,8 +25798,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25700,8 +25943,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -25740,8 +25983,8 @@ importers:
         version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@teambit/mdx.mdx-env':
-        specifier: 3.1.0
-        version: 3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+        specifier: 3.1.1
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -25780,8 +26023,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25838,8 +26081,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25881,8 +26124,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25969,8 +26212,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25992,6 +26235,9 @@ importers:
 
   scopes/workspace/modules/fs-cache:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -26015,8 +26261,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -26035,6 +26281,9 @@ importers:
       '@teambit/bit-error':
         specifier: ~0.0.404
         version: 0.0.404
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -26058,8 +26307,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -26084,6 +26333,9 @@ importers:
       '@teambit/workspace.root-components':
         specifier: ^1.0.1
         version: 1.0.1
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -26110,8 +26362,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26127,6 +26379,9 @@ importers:
 
   scopes/workspace/modules/workspace-locator:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -26147,8 +26402,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26193,14 +26448,17 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
 
   scopes/workspace/testing/mock-workspace:
     dependencies:
+      '@types/node':
+        specifier: 22.10.5
+        version: 22.10.5
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -26224,8 +26482,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.3)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26270,8 +26528,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@teambit/workspace.content.variants':
         specifier: 1.96.7
         version: 1.96.7(react@19.1.0)
@@ -26334,8 +26592,8 @@ importers:
         version: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26518,8 +26776,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@teambit/workspace.content.workspace-overview':
         specifier: 1.96.7
         version: 1.96.7(@apollo/client@3.12.2)(@testing-library/react@16.3.2)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -26606,8 +26864,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.0
-        version: 2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
+        specifier: 2.0.4
+        version: 2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -27860,12 +28118,6 @@ packages:
   '@bitdev/react.preview.react-docs-app@0.0.11':
     resolution: {integrity: sha512-J7tcl32xfyqbaDD9ywZSl8PDFOZXfrLwaytL2FpZAYrYMxg0sKHNv+kh0H8k6PBouFhmMWovqA7GsMj6khMsmw==}
 
-  '@bitdev/react.preview.react-docs-template@1.0.10':
-    resolution: {integrity: sha512-RRy2HKxzxwfjlbha1faqcMzTl9yz+tD8peWxoIXSe6THUZJYiZBeQDC65GroF9f31c96YQI1PKLhXit5tV6MiA==}
-    peerDependencies:
-      react: 19.1.0
-      react-dom: 19.1.0
-
   '@bitdev/react.preview.react-docs-template@1.0.11':
     resolution: {integrity: sha512-eFcFAowv5+aGx0hgx0vRHdqKRgGgsMvZCAR1CoXAScG5iaHRdmrj2U+3//44f16Ft31AzsnR4BcA4jTaU+rWYw==}
     peerDependencies:
@@ -27874,6 +28126,12 @@ packages:
 
   '@bitdev/react.preview.react-docs-template@1.0.13':
     resolution: {integrity: sha512-IoEdnqhqISXkd3B71KkpvuI3JhtGCJwwEDweuQLxZwqBxHVzgOEHmOygSngYV1Dn/CsTjwDMQqpgbxgO9FnUOg==}
+    peerDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0
+
+  '@bitdev/react.preview.react-docs-template@1.0.14':
+    resolution: {integrity: sha512-BoY7huw3hdNHcs+wJhcuOLmnTUU4PVFE3DvxfVzfAhwP9FEQI/ka06b3V5Ghpd2xYNzW4BIlP0aOC1eJjdYNvw==}
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
@@ -34359,8 +34617,8 @@ packages:
     peerDependencies:
       react: 19.1.0
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.0':
-    resolution: {integrity: sha512-s8t6AZwR2k3sdj6EhvMdV3CmayCVv37ygPjM9x2ECoUc7joG45TcvHAA8KMttFL+rg0FH/9BtMUtR7xUopWw6w==}
+  '@teambit/harmony.envs.core-aspect-env@2.0.4':
+    resolution: {integrity: sha512-V2fc45vkwGg7YWKSckT0XdKogfnEo6KxNo/O6q9bLEWqI7L8x8JsjB8AD0a1AfarCxdY4TR+OOrqHKMaGBF6KQ==}
 
   '@teambit/harmony.modules.concurrency@0.0.12':
     resolution: {integrity: sha512-j8u/QH0wyXpoEvpATqspcBcf1wbJ70PR82c7Na/ZbOu8+9w2tQIHl+ME7kozcDMX2wSG3cM9TjhJcWS+goRxMg==}
@@ -34888,8 +35146,8 @@ packages:
   '@teambit/mdx.generator.mdx-templates@1.0.14':
     resolution: {integrity: sha512-ZHWlZISw0TyMgOwIKCGi0HNIuPxKCVikOg5eZLKedZIx5ZoS79Tu4YvUBx0CKAzeQ9PxJN6r9tiLF5FXZ/FnJg==}
 
-  '@teambit/mdx.mdx-env@3.1.0':
-    resolution: {integrity: sha512-rm6Wllwmzxw6VQDHLnKgDDNvFdYc0DA2ukiKWXODair7BUD8qH1A3pO1jSS0Pq+QKomNgICqmOPC52DZc8GMVA==}
+  '@teambit/mdx.mdx-env@3.1.1':
+    resolution: {integrity: sha512-0zS7sWe+WF7nXxPwajcr+bVzxG8nkDa+TVzfzqkYwsEgbGe0kk2VBwJc8v8t3pAXYPO27EWC16fVRJrLhRONtg==}
 
   '@teambit/mdx.modules.mdx-admonitions-adapter@0.0.1':
     resolution: {integrity: sha512-uRGaZaAS+h1junyIjrZagWeUO32uWLwyizA5XhpbwW6tY3aI70S1+K78Pe4zFIhAd9kHyg+TzfCIUb6hZ25c4w==}
@@ -34991,11 +35249,11 @@ packages:
   '@teambit/node.deps-detectors.parser-helper@0.0.6':
     resolution: {integrity: sha512-dSHRaKL9ScGkWx2+NE/smUqBrhC+knh9u5aCREKohkBCejt0siZDsu7toQP5/mtwBOrlU97KjJBxbKXr32rIDQ==}
 
-  '@teambit/node.envs.node-babel-mocha@2.0.0':
-    resolution: {integrity: sha512-tGFASnZS2+tUeQOd3dcbLcgPAv0MH2eprkNKdb5c/XIfVbkoIo7l+OtLzwir7FVzKYVtHBJLG09C7tP7yi3Rqg==}
+  '@teambit/node.envs.node-babel-mocha@2.0.3':
+    resolution: {integrity: sha512-FP+UDSUVFY+iy6pCH5aew0zoo5tTVe9lx4ubBjBKeApfsJL1gIbdkAdrer/NJuQ9h/MRsAlYN4bc/+I2WW+Lzg==}
 
-  '@teambit/node.envs.node-typescript-mocha@2.0.0':
-    resolution: {integrity: sha512-FbeQqfU5GVA/6szQsPgI/6J6UDKqBYte4OAYnkm/4P0zMR0ZnheEsrE5PraVT14+bjtHliqgurYaa2shA1io9w==}
+  '@teambit/node.envs.node-typescript-mocha@2.0.2':
+    resolution: {integrity: sha512-3Z3mVsuaDt7kvjUHAeGyXNWRO7drIIVicRIa1ej0Lnh7akZCPUzyDxHtr0SeQow0HJDPSQdV7vq1B3nqzDMUKQ==}
 
   '@teambit/node.generator.node-starters@1.0.0':
     resolution: {integrity: sha512-EkEt8XJVx/+JAiC9eMQR7CH3tgYKGuZ7bu9raFDUi4EpWvdEkjR7Q6enXj/Ifqu3ekXtl2XecN/Nr1VxMBcGsQ==}
@@ -35003,8 +35261,8 @@ packages:
   '@teambit/node.generator.node-templates@1.0.22':
     resolution: {integrity: sha512-NwqgNWeAiw3rqqayPoQF2dY3fEdhjQS3Kf0xeEPuqIEkaq4rV73qp7bJZl7Bph0fGQ/l+kqBE7+9tTrz/nRxoQ==}
 
-  '@teambit/node.node@4.0.0':
-    resolution: {integrity: sha512-zSOjuwAOgkbFxvaWbGRQpgJWaqjRU7PdgQkWRkAkyz0BnzC6Vigu5w+4Jwbtdjz4HFKjlyQxhPH+9WIhXZiotw==}
+  '@teambit/node.node@4.0.1':
+    resolution: {integrity: sha512-8o2WqZFHgeNNJbhvac1M8nHr2Uxqy5u6IhysKJ3xCZPTCw+j2rG2TEe6svjFy0ZQFXgTOeeOmnCBACZ2FtTTyw==}
 
   '@teambit/node.utils.esm-loader@0.0.7':
     resolution: {integrity: sha512-DlihQpBgfMTI+onyqGgsDrcV3TfV/aCEVgjidc4JvyYeaOY2vCk0bLwwkkBSHJbvALrltK5p2/Z5lVpnlZ+01w==}
@@ -35120,14 +35378,14 @@ packages:
   '@teambit/preview.modules.preview-modules@1.0.3':
     resolution: {integrity: sha512-XirvCPuO/OS2RLRKMvBXVLq5RZqucDJjumuDD6aceqwUm5AIR6rOP4ACCl8/lOZBcE29NMXehfszQ/UvfoXAgQ==}
 
-  '@teambit/preview.react-preview@1.1.11':
-    resolution: {integrity: sha512-x61oM8CTKEi+MS2qcXB4uYzTxFavGCYz5ovHXQPRUOt+/T8zUk2fKav0cx6SR4FyJ1aQAIVOrxOIaFdt/XP2Xw==}
+  '@teambit/preview.react-preview@1.1.12':
+    resolution: {integrity: sha512-8i5+YS8QzGGuTX1iXtYvGv6iK2V/yrSRtmOqjtoPj3dbUPMxQXgc8fcBY5RHZJCwUixuoWboXKNvnztYjbKCCw==}
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
 
-  '@teambit/preview.react-preview@1.1.12':
-    resolution: {integrity: sha512-8i5+YS8QzGGuTX1iXtYvGv6iK2V/yrSRtmOqjtoPj3dbUPMxQXgc8fcBY5RHZJCwUixuoWboXKNvnztYjbKCCw==}
+  '@teambit/preview.react-preview@1.1.13':
+    resolution: {integrity: sha512-XsQcI9hWeWprbkRzB2QW1ylMY31pH+I4rQ6mKvvqzSFHiuVCULmyhqRrKIL5HTtmUBBe8tbe+wcmKC679p/Stw==}
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
@@ -35184,12 +35442,12 @@ packages:
     resolution: {integrity: sha512-u98RV02GSaFPnvPVS5+GQm5/3eq97C7J+OOBfL6oqA4KxXsrbL3MdNY/zIE2gMA94OUPLnWIY4/FBt4nTGw7MA==}
     engines: {node: '>=12.22.0'}
 
-  '@teambit/react.babel.bit-react-transformer@1.0.48':
-    resolution: {integrity: sha512-vrpRtse62SsFeKasbumrbi0IGoDwKslmmvq1zcIVM9aEy/xyKMNb+IsM1xxgbnTCth1HtLsP3KOgcULinsbn/Q==}
-    engines: {node: '>=16.0.0'}
-
   '@teambit/react.babel.bit-react-transformer@1.0.49':
     resolution: {integrity: sha512-4JXtX5iN3gme0uOt84qk8h8pxbQB0gFgjJ2oHjl0Fr6RZddahWSlVNySy/SVIkmgRYRyxflNwXUVNPDKrOOKGQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@teambit/react.babel.bit-react-transformer@1.0.59':
+    resolution: {integrity: sha512-dEVUw3uJdzTfAmm2HZJrBxIexsn9rHQixlmnHWvIwh4rP9sF00M7YBPIUs7AHVL4H1GyQ4HQIIBy4t2DbnycSw==}
     engines: {node: '>=16.0.0'}
 
   '@teambit/react.babel.bit-react-transformer@file:scopes/react/bit-react-transformer':
@@ -35206,6 +35464,12 @@ packages:
 
   '@teambit/react.eslint-config-bit-react@2.0.10':
     resolution: {integrity: sha512-OPH00pp3pRscL0PEKLbux4W4LN1JnxD4nY0orn2v0nu+lkt72pUeOVGK4FrqsSbxHExojIfWd0VBja4K7/k3/g==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      eslint: '> 8.0.0'
+
+  '@teambit/react.eslint-config-bit-react@2.0.17':
+    resolution: {integrity: sha512-GvB1EtMAo1XThhXocX+AGx80xMmenTmIz2UNqJIXVXTdwt8b3ACyE0O0Yqb/8jrhjIl3AhETuVyBAKk/Yqgxtw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       eslint: '> 8.0.0'
@@ -35257,20 +35521,20 @@ packages:
   '@teambit/react.modules.react-live-controls-from-schema@0.0.2':
     resolution: {integrity: sha512-edt0wFfmkj/JdIST0GPRlmPD+8BPcu5OJuSELoabaGYT1zW8rXMnHx9QaNYCLCgvFlaAISvBTgLF3+xIJait4A==}
 
-  '@teambit/react.mounter@1.1.6':
-    resolution: {integrity: sha512-Xc4WZlS36G4mtSUv3vTm56cFiYz7KVaxkhuA84r2ajTqZNUtf7XeXNZ5nKVKKii7D/nnbaaDLjTwUPQVCyp8dw==}
-    peerDependencies:
-      react: 19.1.0
-      react-dom: 19.1.0
-
   '@teambit/react.mounter@1.1.7':
     resolution: {integrity: sha512-n3y8Q+pPQDkcfVvggaUOMWC4qvIZRSr4W0ITws12NFXGNF8tD36Z+3ynCgSKmAcSGwVA1KjdlrB+4E4e6ZTbOg==}
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
 
-  '@teambit/react.react-env@2.0.2':
-    resolution: {integrity: sha512-BtWCzNNYWnGXXth0tasPCO6SbFEyJQP1I6dZTMgcis6dcma/m9j89jNUMVizrKSFIC8WucU6SfpzCTvxg9Rpwg==}
+  '@teambit/react.mounter@1.1.9':
+    resolution: {integrity: sha512-1k1fQNYwpQ1B9xrdx1lrRJHksb3D2lEYqxCEnOvZtVpFwbr0YFH70gPHxfNNE69tvMrydPI/9UqLxEhze9XMCA==}
+    peerDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0
+
+  '@teambit/react.react-env@2.0.3':
+    resolution: {integrity: sha512-JWNWXIRy47+v6YrTjiNYp9QTkfTfzUBZGtlOYU3TmrxMSO08971Ukst8VhB70REvQlIr0hKRUw06YBdcYFS1Rw==}
 
   '@teambit/react.rendering.ssr@1.0.2':
     resolution: {integrity: sha512-enLbLjRJ5H3wicrPhToRq3G5PzsFY0TMewIDoyFySLOcsbiZMAIZ6ljzNFZPFIncMjfE+jkrrK+yLHxVZaMcxw==}
@@ -35300,6 +35564,12 @@ packages:
 
   '@teambit/react.ui.component-highlighter@0.2.7':
     resolution: {integrity: sha512-WOqNY403iwIJ1j8dVaPwKzJy/JTZMO23XAGgY7tSgG9u9nZLEr/lfGkBG5mEQbNZyZeCRlnqlB9TEPFUz/ASuw==}
+    peerDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0
+
+  '@teambit/react.ui.component-highlighter@0.2.8':
+    resolution: {integrity: sha512-4gpQvhbgdrBPSZQhgDVKc6ka8lpk36eCOuhAYK5YnpUAqST8aUWh2+jbhL314Umuq2kQ7V8+M6KAqwSf6LK2qA==}
     peerDependencies:
       react: 19.1.0
       react-dom: 19.1.0
@@ -35360,6 +35630,11 @@ packages:
     peerDependencies:
       react: 19.1.0
 
+  '@teambit/react.ui.highlighter-provider@0.0.228':
+    resolution: {integrity: sha512-TUgzdPnQjRye4p6vU3H1sxXSSdOC8d5cihpn8YF51iHQCzlfPgUPP4Y+e+ZAqcXCpW1wMTkJfJeVwrt+KEQcJQ==}
+    peerDependencies:
+      react: 19.1.0
+
   '@teambit/react.ui.highlighter-provider@file:scopes/react/ui/highlighter-provider':
     resolution: {directory: scopes/react/ui/highlighter-provider, type: directory}
     peerDependencies:
@@ -35410,13 +35685,13 @@ packages:
     peerDependencies:
       react-dom: 19.1.0
 
-  '@teambit/react.webpack.react-webpack@1.0.57':
-    resolution: {integrity: sha512-aeuUqJMPcFLx/GBjbTmg6QYlWdOB8hKy/B9YgkzvXN0/wcaSGkSuvzd8NM3fqZa24I+jXttio1ldPm0zkxomsQ==}
+  '@teambit/react.webpack.react-webpack@1.0.58':
+    resolution: {integrity: sha512-AlzXNwggQFxPFhZxiiHYdJTlbFPxla+fsr5YNyYwUoqyNsIY65XlGU9/GV+bY8Ow+lftqv0JQgayQHihOQMTMw==}
     peerDependencies:
       react-dom: 19.1.0
 
-  '@teambit/react.webpack.react-webpack@1.0.58':
-    resolution: {integrity: sha512-AlzXNwggQFxPFhZxiiHYdJTlbFPxla+fsr5YNyYwUoqyNsIY65XlGU9/GV+bY8Ow+lftqv0JQgayQHihOQMTMw==}
+  '@teambit/react.webpack.react-webpack@1.0.59':
+    resolution: {integrity: sha512-RSQxu4XAdxDBnbc22xfo4NtcFQmehNmoS4OfonU5hy+nt3VUjGhwYTXfnB19UW3goSYXofCN4TuifARTl02G3Q==}
     peerDependencies:
       react-dom: 19.1.0
 
@@ -35445,8 +35720,8 @@ packages:
   '@teambit/ripple@file:scopes/cloud/ripple':
     resolution: {directory: scopes/cloud/ripple, type: directory}
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.10':
-    resolution: {integrity: sha512-lheobH9uoIp+Prvjf7pXivqTuoRVN6zRXv+zQfyQAzz2+J4bBS/bRDeiq+UU4CXgbjK4O0CpjNuNePXYoI4Rig==}
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14':
+    resolution: {integrity: sha512-vOg1Sdo7vyYe5KQMdiAMDonWhD8TNiZUSwE67clS7PBIdEK3dOTlbdkTSGWiQ3QNbRE9GF+YcF9fFSwKtVX0KA==}
     peerDependencies:
       react: 19.1.0
 
@@ -35946,6 +36221,11 @@ packages:
 
   '@teambit/typescript.typescript-compiler@5.0.0':
     resolution: {integrity: sha512-fPXpWjoyq+Tkl1K+wmZEZQ6MS//AX1T/y7wOfXfhdcUhz26L+nvUnJ/s307wLTqPTfOkNUUhPn9/Q1LwJMC9Vw==}
+    peerDependencies:
+      react: 19.1.0
+
+  '@teambit/typescript.typescript-compiler@5.0.1':
+    resolution: {integrity: sha512-BIFHc21qX9gFMvhb7AaPC6Ie231s65Gtbs/Ag/Gqeyhyt7cDUPZ4Yh0RzBtBx5vakaSRfL7akY7qWfAHqy3nWg==}
     peerDependencies:
       react: 19.1.0
 
@@ -52088,14 +52368,6 @@ snapshots:
 
   '@bitdev/react.preview.react-docs-app@0.0.11': {}
 
-  '@bitdev/react.preview.react-docs-template@1.0.10(react-dom@19.2.7)(react@19.2.7)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@bitdev/react.preview.react-docs-template@1.0.11(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
@@ -52105,6 +52377,14 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@bitdev/react.preview.react-docs-template@1.0.13(react-dom@19.2.7)(react@19.2.7)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@bitdev/react.preview.react-docs-template@1.0.14(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
       '@types/react': 19.2.14
@@ -56626,7 +56906,7 @@ snapshots:
 
   '@teambit/api-reference.models.api-node-renderer@0.0.53(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
       react: 18.3.1
@@ -56686,7 +56966,7 @@ snapshots:
   '@teambit/api-reference.overview.api-reference-table-of-contents@0.0.41(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53(react-dom@19.1.0)(react@18.3.1)
+      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -58834,6 +59114,10 @@ snapshots:
   '@teambit/api-reference.utils.schema-node-signature-transform@0.0.47':
     dependencies:
       '@teambit/semantics.entities.semantic-schema': 0.0.92
+
+  '@teambit/api-reference.utils.sort-api-nodes@0.0.53':
+    dependencies:
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
 
   '@teambit/api-reference.utils.sort-api-nodes@0.0.53(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
@@ -61211,6 +61495,7 @@ snapshots:
 
   '@teambit/bit.get-bit-version@file:components/bit/get-bit-version':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61353,6 +61638,7 @@ snapshots:
 
   '@teambit/builder-data@file:scopes/pipelines/modules/builder-data':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61542,7 +61828,7 @@ snapshots:
       lodash: 4.17.21
       p-limit: 2.3.0
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61550,7 +61836,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61596,7 +61882,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61604,7 +61890,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61849,6 +62135,7 @@ snapshots:
 
   '@teambit/cli-table@file:scopes/toolbox/tables/cli-table':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       cli-table: 0.3.6
@@ -61921,6 +62208,7 @@ snapshots:
       '@teambit/scopes.scope-descriptor': 0.0.34(react@19.1.0)
       '@teambit/scopes.scope-id': 0.0.9
       '@teambit/ui-foundation.ui.hooks.use-data-query': 0.0.506(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61932,6 +62220,7 @@ snapshots:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(subscriptions-transport-ws@0.9.19)
       '@teambit/cloud.models.cloud-user': file:scopes/cloud/models/cloud-user
       '@teambit/ui-foundation.ui.hooks.use-data-query': 0.0.506(@apollo/client@3.12.2)(react-dom@19.1.0)(react@18.3.1)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -61943,6 +62232,7 @@ snapshots:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/cloud.models.cloud-user': file:scopes/cloud/models/cloud-user
       '@teambit/ui-foundation.ui.hooks.use-data-query': 0.0.506(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61952,6 +62242,7 @@ snapshots:
   '@teambit/cloud.hooks.use-logout@file:scopes/cloud/hooks/use-logout(@apollo/client@3.12.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61961,6 +62252,7 @@ snapshots:
   '@teambit/cloud.models.cloud-scope@file:scopes/cloud/models/cloud-scope':
     dependencies:
       '@teambit/scopes.scope-descriptor': 0.0.34(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61969,6 +62261,7 @@ snapshots:
 
   '@teambit/cloud.models.cloud-user@file:scopes/cloud/models/cloud-user':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -61980,6 +62273,7 @@ snapshots:
       '@teambit/cloud.models.cloud-user': file:scopes/cloud/models/cloud-user
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/scope.network': file:scopes/scope/network(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63593,7 +63887,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.babel@file:scopes/compilation/aspect-docs/babel(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63613,7 +63907,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.compiler@file:scopes/compilation/aspect-docs/compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63633,7 +63927,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.multi-compiler@file:scopes/compilation/aspect-docs/multi-compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63758,6 +64052,7 @@ snapshots:
   '@teambit/compilation.modules.babel-compiler@file:scopes/compilation/modules/babel-compiler':
     dependencies:
       '@babel/core': 7.28.3
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64067,6 +64362,7 @@ snapshots:
   '@teambit/component-issues@file:components/component-issues':
     dependencies:
       '@teambit/component-id': 1.2.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -64137,6 +64433,7 @@ snapshots:
   '@teambit/component-package-version@file:scopes/component/component-package-version':
     dependencies:
       '@teambit/component-version': 1.0.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64283,7 +64580,7 @@ snapshots:
   '@teambit/component.aspect-docs.component@file:scopes/component/aspect-docs/component(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64509,6 +64806,7 @@ snapshots:
     dependencies:
       '@teambit/base-ui.utils.string.affix': 1.0.1
       '@teambit/component-id': 1.2.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       query-string: 7.0.0
@@ -64520,6 +64818,7 @@ snapshots:
     dependencies:
       '@teambit/base-ui.utils.string.affix': 1.0.1
       '@teambit/component-id': 1.2.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       query-string: 7.0.0
@@ -64542,6 +64841,7 @@ snapshots:
       '@teambit/toolbox.crypto.sha1': file:components/crypto/sha1
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/toolbox.string.eol': file:scopes/toolbox/string/eol
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -64573,6 +64873,7 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/graph.cleargraph': 0.0.11
       '@teambit/legacy.scope': file:components/legacy/scope(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -64597,7 +64898,7 @@ snapshots:
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.logger': 0.0.19
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
-      '@teambit/pkg.modules.component-package-name': 0.0.56
+      '@teambit/pkg.modules.component-package-name': 0.0.56(graphql@15.8.0)
       '@teambit/toolbox.fs.link-or-symlink': 0.0.20
       '@teambit/toolbox.fs.remove-empty-dir': 0.0.5
       '@teambit/toolbox.path.path': 0.0.8
@@ -64636,6 +64937,7 @@ snapshots:
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/toolbox.promise.map-pool': file:scopes/toolbox/promise/map-pool
       '@teambit/toolbox.string.eol': file:scopes/toolbox/string/eol
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       detect-indent: 5.0.0
@@ -64661,6 +64963,7 @@ snapshots:
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -67582,7 +67885,7 @@ snapshots:
   '@teambit/compositions.aspect-docs.compositions@file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -67617,6 +67920,7 @@ snapshots:
 
   '@teambit/compositions.model.composition-type@file:scopes/compositions/model/composition-type(react@18.3.1)':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
@@ -67625,6 +67929,7 @@ snapshots:
 
   '@teambit/compositions.model.composition-type@file:scopes/compositions/model/composition-type(react@19.1.0)':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -67860,7 +68165,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -67891,11 +68196,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -67992,7 +68297,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -68023,11 +68328,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -68353,6 +68658,7 @@ snapshots:
   '@teambit/defender.eslint.config-mutator@file:scopes/defender/eslint-config-mutator(eslint@8.56.0)':
     dependencies:
       '@teambit/defender.eslint-linter': 1.0.60(eslint@8.56.0)(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       eslint: 8.56.0
@@ -68513,6 +68819,7 @@ snapshots:
 
   '@teambit/defender.prettier.config-mutator@file:scopes/defender/prettier-config-mutator':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -68566,18 +68873,18 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68647,18 +68954,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68698,7 +69005,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -68710,7 +69017,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68785,7 +69092,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -68797,7 +69104,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -68884,7 +69191,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.dependency-resolver@file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68904,7 +69211,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.pnpm@file:scopes/dependencies/aspect-docs/pnpm(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68924,7 +69231,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.yarn@file:scopes/dependencies/aspect-docs/yarn(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68934,6 +69241,7 @@ snapshots:
   '@teambit/dependencies.fs.linked-dependencies@file:scopes/dependencies/fs/linked-dependencies':
     dependencies:
       '@teambit/toolbox.fs.link-or-symlink': file:scopes/toolbox/fs/link-or-symlink
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68958,7 +69266,7 @@ snapshots:
     dependencies:
       '@pnpm/dependency-path': 1001.1.10
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -68988,77 +69296,9 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      archy: 1.0.0
-      chai: 5.2.1
-      chalk: 4.1.2
-      cli-table: 0.3.6
-      debug: 4.3.4(supports-color@9.4.0)
-      detective-amd: 3.0.1
-      detective-stylus: 1.0.0
-      fs-extra: 10.0.0
-      lodash: 4.17.21
-      module-definition: 3.3.1
-      moment: 2.29.4
-      node-source-walk: 4.2.0
-      p-map-series: 2.1.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      read-pkg-up: 7.0.1
-      resolve-dependency-path: 2.0.0
-      semver: 7.7.1
-      stylus-lookup: 3.0.2
-      table: 6.7.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@pnpm/logger'
-      - domexception
-      - encoding
-      - graphql
-      - postcss
-      - supports-color
-      - typanion
-      - typescript
-
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/bit-error': 0.0.404
-      '@teambit/component-id': 1.2.4
-      '@teambit/component-issues': file:components/component-issues
-      '@teambit/component-package-version': file:scopes/component/component-package-version
-      '@teambit/component-version': 1.0.4
-      '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/component.testing.mock-components': file:scopes/component/testing/mock-components(graphql@15.8.0)
-      '@teambit/harmony': 0.4.12
-      '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
-      '@teambit/legacy.bit-map': file:components/legacy/bit-map(graphql@15.8.0)
-      '@teambit/legacy.constants': file:components/legacy/constants
-      '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
-      '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
-      '@teambit/legacy.dependency-graph': file:components/legacy/dependency-graph(graphql@15.8.0)
-      '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
-      '@teambit/legacy.logger': file:components/legacy/logger
-      '@teambit/legacy.utils': file:components/legacy/utils
-      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
-      '@teambit/node.deps-detectors.detective-es6': 0.0.6
-      '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-sass': 0.0.9(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-scss': 0.0.9(postcss@8.4.45)
-      '@teambit/styling.deps-lookups.lookup-styling': 0.0.4
-      '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
-      '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
-      '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
-      '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -69125,6 +69365,74 @@ snapshots:
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@6.0.3)
+      '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      archy: 1.0.0
+      chai: 5.2.1
+      chalk: 4.1.2
+      cli-table: 0.3.6
+      debug: 4.3.4(supports-color@9.4.0)
+      detective-amd: 3.0.1
+      detective-stylus: 1.0.0
+      fs-extra: 10.0.0
+      lodash: 4.17.21
+      module-definition: 3.3.1
+      moment: 2.29.4
+      node-source-walk: 4.2.0
+      p-map-series: 2.1.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+      read-pkg-up: 7.0.1
+      resolve-dependency-path: 2.0.0
+      semver: 7.7.1
+      stylus-lookup: 3.0.2
+      table: 6.7.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@pnpm/logger'
+      - domexception
+      - encoding
+      - graphql
+      - postcss
+      - supports-color
+      - typanion
+      - typescript
+
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/component-id': 1.2.4
+      '@teambit/component-issues': file:components/component-issues
+      '@teambit/component-package-version': file:scopes/component/component-package-version
+      '@teambit/component-version': 1.0.4
+      '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
+      '@teambit/component.testing.mock-components': file:scopes/component/testing/mock-components(graphql@15.8.0)
+      '@teambit/harmony': 0.4.12
+      '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
+      '@teambit/legacy.bit-map': file:components/legacy/bit-map(graphql@15.8.0)
+      '@teambit/legacy.constants': file:components/legacy/constants
+      '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
+      '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
+      '@teambit/legacy.dependency-graph': file:components/legacy/dependency-graph(graphql@15.8.0)
+      '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
+      '@teambit/legacy.logger': file:components/legacy/logger
+      '@teambit/legacy.utils': file:components/legacy/utils
+      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
+      '@teambit/node.deps-detectors.detective-es6': 0.0.6
+      '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-sass': 0.0.9(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-scss': 0.0.9(postcss@8.4.45)
+      '@teambit/styling.deps-lookups.lookup-styling': 0.0.4
+      '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
+      '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
+      '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
@@ -73352,22 +73660,6 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
-      '@types/react': 19.2.14
-      classnames: 2.5.1
-      prism-react-renderer: 1.3.5(react@19.1.0)
-      react: 19.1.0
-      react-live: 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
-      use-debounce: 9.0.4(react@19.1.0)
-    transitivePeerDependencies:
-      - react-dom
-      - typescript
-
   '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
@@ -73449,9 +73741,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73462,9 +73754,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73521,19 +73813,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-syntax-highlighter'
@@ -73682,11 +73961,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -73711,11 +73990,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -73820,35 +74099,6 @@ snapshots:
       '@types/react': 19.2.14
       classnames: 2.5.1
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
-      '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.image': 4.0.4(react@19.1.0)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
-      '@teambit/documenter.ui.italic': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.ol': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.separator': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.sup': 4.0.9(react@19.1.0)
-      '@teambit/documenter.ui.table.base-table': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.table.td': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.table.tr': 4.1.7(react@19.1.0)
-      '@teambit/documenter.ui.ul': 4.1.7(react@19.1.0)
-      '@types/react': 19.2.14
-      classnames: 2.5.1
-      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-dom'
@@ -74407,19 +74657,6 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.table-row': 4.1.14(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@types/react': 19.2.14
-      react: 19.1.0
-      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
-      use-debounce: 3.4.3(react@19.1.0)
-    transitivePeerDependencies:
-      - '@types/react-dom'
-      - react-dom
-      - typescript
-
   '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -74782,17 +75019,17 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/harmony': 0.4.12
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -74808,17 +75045,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
     dependencies:
       '@teambit/harmony': 0.4.12
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -74847,7 +75084,7 @@ snapshots:
   '@teambit/envs.aspect-docs.envs@file:scopes/envs/aspect-docs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -75978,7 +76215,7 @@ snapshots:
   '@teambit/generator.aspect-docs.generator@file:scopes/generator/aspect-docs/generator(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76061,6 +76298,7 @@ snapshots:
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76078,6 +76316,7 @@ snapshots:
   '@teambit/git.modules.ignore-file-reader@file:scopes/git/modules/ignore-file-reader':
     dependencies:
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -76456,7 +76695,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.logger@file:scopes/harmony/aspect-docs/logger(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76476,7 +76715,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.node@file:scopes/harmony/aspect-docs/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76499,7 +76738,7 @@ snapshots:
       react-dom: 18.3.1(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@19.1.0)
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76516,9 +76755,9 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76574,7 +76813,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76591,84 +76830,9 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
-      '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
-      '@types/chai': 5.2.2
-      '@types/chai-fs': 2.0.5
-      '@types/mocha': 10.0.10
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)
-      chai: 5.2.1
-      chai-fs: 1.0.0(chai@5.2.1)
-      core-js: 3.13.0
-      graphql: 15.8.0
-      mocha: 11.7.1
-      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
-      oxlint-tsgolint: 0.17.0
-      ramda: 0.29.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      sass: 1.72.0
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/traverse'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - react-test-renderer
-      - rollup
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.28.3)
-      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
-      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/runtime': 7.20.0
-      '@bitdev/react.preview.react-docs-template': 1.0.11(react-dom@19.1.0)(react@19.1.0)
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
-      '@teambit/compilation.babel-compiler': 1.1.18(react@19.1.0)
-      '@teambit/defender.mocha-tester': 1.1.1(@babel/core@7.28.3)(react@19.1.0)
-      '@teambit/defender.prettier-formatter': 1.0.24
-      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
-      '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@19.1.0)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76724,7 +76888,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
@@ -76741,9 +76905,159 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/preview.react-preview': 1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
+      '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
+      '@types/chai': 5.2.2
+      '@types/chai-fs': 2.0.5
+      '@types/mocha': 10.0.10
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)
+      chai: 5.2.1
+      chai-fs: 1.0.0(chai@5.2.1)
+      core-js: 3.13.0
+      graphql: 15.8.0
+      mocha: 11.7.1
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      ramda: 0.29.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+      sass: 1.72.0
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - react-test-renderer
+      - rollup
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/harmony.envs.core-aspect-env@2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.28.3)
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
+      '@babel/runtime': 7.20.0
+      '@bitdev/react.preview.react-docs-template': 1.0.11(react-dom@19.1.0)(react@19.1.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
+      '@teambit/compilation.babel-compiler': 1.1.18(react@19.1.0)
+      '@teambit/defender.mocha-tester': 1.1.1(@babel/core@7.28.3)(react@19.1.0)
+      '@teambit/defender.prettier-formatter': 1.0.24
+      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
+      '@teambit/oxc.linter.oxlint-linter': 2.0.5
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
+      '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
+      '@types/chai': 5.2.2
+      '@types/chai-fs': 2.0.5
+      '@types/mocha': 10.0.10
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)
+      chai: 5.2.1
+      chai-fs: 1.0.0(chai@5.2.1)
+      core-js: 3.13.0
+      graphql: 15.8.0
+      mocha: 11.7.1
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      ramda: 0.29.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+      sass: 1.72.0
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - react-test-renderer
+      - rollup
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/harmony.envs.core-aspect-env@2.0.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-test-renderer@17.0.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.28.3)
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
+      '@babel/runtime': 7.20.0
+      '@bitdev/react.preview.react-docs-template': 1.0.11(react-dom@19.1.0)(react@19.1.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
+      '@teambit/compilation.babel-compiler': 1.1.18(react@19.1.0)
+      '@teambit/defender.mocha-tester': 1.1.1(@babel/core@7.28.3)(react@19.1.0)
+      '@teambit/defender.prettier-formatter': 1.0.24
+      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
+      '@teambit/oxc.linter.oxlint-linter': 2.0.5
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.1.0)(react-test-renderer@17.0.2)(react@19.1.0)
       '@types/chai': 5.2.2
@@ -76806,6 +77120,7 @@ snapshots:
   '@teambit/harmony.modules.concurrency@file:scopes/harmony/modules/concurrency':
     dependencies:
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76819,6 +77134,7 @@ snapshots:
   '@teambit/harmony.modules.feature-toggle@file:scopes/harmony/modules/feature-toggle':
     dependencies:
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76830,6 +77146,7 @@ snapshots:
       '@teambit/cloud.modules.get-cloud-user': file:scopes/cloud/modules/get-cloud-user(graphql@15.8.0)
       '@teambit/lane-id': 0.0.312
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76845,6 +77162,7 @@ snapshots:
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/toolbox.path.to-windows-compatible-path': file:scopes/toolbox/path/to-windows-compatible-path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -76860,6 +77178,7 @@ snapshots:
   '@teambit/harmony.modules.in-memory-cache@file:scopes/harmony/modules/in-memory-cache':
     dependencies:
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lru-cache: 10.4.3
@@ -76869,6 +77188,7 @@ snapshots:
 
   '@teambit/harmony.modules.load-trace@file:scopes/harmony/modules/load-trace':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76877,6 +77197,7 @@ snapshots:
 
   '@teambit/harmony.modules.requireable-component@file:scopes/harmony/modules/requireable-component':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76885,6 +77206,7 @@ snapshots:
 
   '@teambit/harmony.modules.resolved-component@file:scopes/harmony/modules/resolved-component':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76895,6 +77217,7 @@ snapshots:
 
   '@teambit/harmony.modules.send-server-sent-events@file:scopes/harmony/modules/send-server-sent-events':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76911,6 +77234,7 @@ snapshots:
       '@teambit/scope.modules.find-scope-path': file:components/modules/find-scope-path
       '@teambit/workspace.modules.node-modules-linker': file:scopes/workspace/modules/node-modules-linker(graphql@15.8.0)
       '@teambit/workspace.modules.workspace-locator': file:scopes/workspace/modules/workspace-locator
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77035,7 +77359,7 @@ snapshots:
   '@teambit/html.aspect-docs.html@file:scopes/html/aspect-docs/html(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77044,6 +77368,7 @@ snapshots:
 
   '@teambit/html.modules.create-element-from-string@file:scopes/html/modules/create-element-from-string':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77052,6 +77377,7 @@ snapshots:
 
   '@teambit/html.modules.fetch-html-from-url@file:scopes/html/modules/fetch-html-from-url':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77441,6 +77767,7 @@ snapshots:
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/lane-id': 0.0.312
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77700,6 +78027,7 @@ snapshots:
       '@teambit/lane-id': 0.0.312
       '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(react-dom@19.1.0)(react@19.1.0)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77714,6 +78042,7 @@ snapshots:
       '@teambit/lane-id': 0.0.312
       '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(react-dom@19.1.0)(react@19.1.0)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77731,6 +78060,7 @@ snapshots:
       '@teambit/legacy-bit-id': 1.1.3
       '@teambit/legacy.component-list': file:components/legacy/component-list(graphql@15.8.0)
       '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -77751,6 +78081,7 @@ snapshots:
       '@teambit/lane-id': 0.0.312
       '@teambit/legacy.component-diff': file:components/legacy/component-diff(graphql@15.8.0)
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -79048,6 +79379,7 @@ snapshots:
 
   '@teambit/legacy-component-log@file:components/legacy-component-log':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -79072,6 +79404,7 @@ snapshots:
     dependencies:
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79130,6 +79463,7 @@ snapshots:
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.object.sorter': 0.0.2
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -79164,6 +79498,7 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.logger': file:components/legacy/logger
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79193,6 +79528,7 @@ snapshots:
       '@teambit/legacy.logger': file:components/legacy/logger
       '@teambit/pkg.modules.component-package-name': file:components/modules/component-package-name(graphql@15.8.0)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       array-difference: 0.0.2
@@ -79241,6 +79577,7 @@ snapshots:
       '@teambit/legacy.scope': file:components/legacy/scope(graphql@15.8.0)
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/scope.remotes': file:components/scope/remotes(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79261,6 +79598,7 @@ snapshots:
   '@teambit/legacy.constants@file:components/legacy/constants':
     dependencies:
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -79280,7 +79618,7 @@ snapshots:
       '@teambit/legacy.cli.error': 0.0.19
       '@teambit/legacy.constants': 0.0.11
       '@teambit/legacy.consumer': 0.0.49(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': 0.0.49
+      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.loader': 0.0.7
       '@teambit/legacy.logger': 0.0.19
@@ -79331,6 +79669,7 @@ snapshots:
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/toolbox.promise.map-pool': file:scopes/toolbox/promise/map-pool
       '@teambit/workspace.modules.fs-cache': file:scopes/workspace/modules/fs-cache
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -79347,7 +79686,7 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/legacy.consumer-config@0.0.49':
+  '@teambit/legacy.consumer-config@0.0.49(graphql@15.8.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -79364,7 +79703,9 @@ snapshots:
       lodash: 4.17.21
       p-map-series: 2.1.0
     transitivePeerDependencies:
+      - domexception
       - encoding
+      - graphql
       - supports-color
 
   '@teambit/legacy.consumer-config@file:components/legacy/consumer-config(graphql@15.8.0)':
@@ -79379,6 +79720,7 @@ snapshots:
       '@teambit/legacy.logger': file:components/legacy/logger
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -79405,7 +79747,7 @@ snapshots:
       '@teambit/legacy.bit-map': 0.0.106(graphql@15.8.0)
       '@teambit/legacy.constants': 0.0.11
       '@teambit/legacy.consumer-component': 0.0.50(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': 0.0.49
+      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.logger': 0.0.19
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.utils': 0.0.21
@@ -79440,6 +79782,7 @@ snapshots:
       '@teambit/toolbox.object.sorter': 0.0.2
       '@teambit/workspace.modules.fs-cache': file:scopes/workspace/modules/fs-cache
       '@teambit/workspace.modules.workspace-locator': file:scopes/workspace/modules/workspace-locator
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -79492,6 +79835,7 @@ snapshots:
       '@teambit/legacy.scope': file:components/legacy/scope(graphql@15.8.0)
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       '@viz-js/viz': 3.11.0
@@ -79662,6 +80006,7 @@ snapshots:
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
       '@teambit/toolbox.object.sorter': 0.0.2
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79684,6 +80029,7 @@ snapshots:
   '@teambit/legacy.loader@file:components/legacy/loader':
     dependencies:
       '@teambit/harmony.modules.send-server-sent-events': file:scopes/harmony/modules/send-server-sent-events
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       cli-spinners: 1.3.1
@@ -79717,6 +80063,7 @@ snapshots:
       '@teambit/legacy.analytics': file:components/legacy/analytics
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.loader': file:components/legacy/loader
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -79762,6 +80109,7 @@ snapshots:
       '@teambit/legacy.scope': file:components/legacy/scope(graphql@15.8.0)
       '@teambit/scope.network': file:scopes/scope/network(graphql@15.8.0)
       '@teambit/scope.remote-actions': file:scopes/scope/remote-actions(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -79794,7 +80142,7 @@ snapshots:
       '@teambit/legacy.constants': 0.0.11
       '@teambit/legacy.consumer': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.consumer-component': 0.0.50(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': 0.0.49
+      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.dependency-graph': 0.0.52(graphql@15.8.0)
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.loader': 0.0.7
@@ -79855,6 +80203,7 @@ snapshots:
       '@teambit/scope.remotes': file:components/scope/remotes(graphql@15.8.0)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/toolbox.promise.map-pool': file:scopes/toolbox/promise/map-pool
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       async-mutex: 0.3.1
@@ -79898,6 +80247,7 @@ snapshots:
       '@teambit/component-id': 1.2.4
       '@teambit/toolbox.fs.readdir-skip-system-files': 0.0.2
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       checksum: 0.1.1
@@ -80016,6 +80366,7 @@ snapshots:
 
   '@teambit/mcp.mcp-config-writer@file:components/mcp/mcp-config-writer':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -80039,7 +80390,7 @@ snapshots:
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -80158,7 +80509,7 @@ snapshots:
 
   '@teambit/mdx.generator.mdx-templates@1.0.14': {}
 
-  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80172,10 +80523,10 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80242,7 +80593,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80256,10 +80607,10 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80326,7 +80677,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80340,10 +80691,10 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80410,7 +80761,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80424,10 +80775,10 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80494,7 +80845,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.1.0(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
@@ -80508,10 +80859,10 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80687,9 +81038,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -80701,9 +81052,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -80763,20 +81114,6 @@ snapshots:
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@testing-library/react'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
-      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
@@ -80877,11 +81214,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80893,11 +81230,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -80947,22 +81284,6 @@ snapshots:
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       react: 18.3.1
-    transitivePeerDependencies:
-      - '@mdx-js/react'
-      - '@teambit/mdx.ui.mdx-scope-context'
-      - '@testing-library/react'
-      - '@types/react'
-      - '@types/react-dom'
-      - '@types/react-syntax-highlighter'
-      - react-dom
-      - typescript
-
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
-    dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
       - '@teambit/mdx.ui.mdx-scope-context'
@@ -81331,7 +81652,7 @@ snapshots:
 
   '@teambit/node.deps-detectors.parser-helper@0.0.6': {}
 
-  '@teambit/node.envs.node-babel-mocha@2.0.0(@babel/core@7.19.6)':
+  '@teambit/node.envs.node-babel-mocha@2.0.3(@babel/core@7.19.6)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.19.6)
       '@babel/preset-env': 7.28.3(@babel/core@7.19.6)
@@ -81345,9 +81666,10 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/mocha': 10.0.10
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       core-js: 3.13.0
@@ -81363,7 +81685,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@teambit/node.envs.node-babel-mocha@2.0.0(@babel/core@7.28.3)':
+  '@teambit/node.envs.node-babel-mocha@2.0.3(@babel/core@7.28.3)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
@@ -81377,9 +81699,10 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/mocha': 10.0.10
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       core-js: 3.13.0
@@ -81395,7 +81718,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@teambit/node.envs.node-typescript-mocha@2.0.0(@babel/core@7.28.3)':
+  '@teambit/node.envs.node-typescript-mocha@2.0.2(@babel/core@7.28.3)':
     dependencies:
       '@babel/preset-env': 7.22.15(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.22.15(@babel/core@7.28.3)
@@ -81405,7 +81728,7 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/mocha': 10.0.10
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -81430,7 +81753,7 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  '@teambit/node.node@4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -81447,9 +81770,10 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.17(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/jest': 29.5.14
       '@types/node': 22.10.5
@@ -81513,7 +81837,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/node.node@4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -81530,9 +81854,10 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.17(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/jest': 29.5.14
       '@types/node': 22.10.5
@@ -81596,7 +81921,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/node.node@4.0.0(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/node.node@4.0.1(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)
@@ -81613,9 +81938,10 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.react-env': 2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+      '@teambit/react.eslint-config-bit-react': 2.0.17(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
       '@types/jest': 29.5.14
       '@types/node': 22.10.5
@@ -81918,7 +82244,7 @@ snapshots:
   '@teambit/pipelines.aspect-docs.builder@file:scopes/pipelines/aspect-docs/builder(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -81931,6 +82257,7 @@ snapshots:
 
   '@teambit/pipelines.modules.merge-component-results@file:scopes/pipelines/modules/merge-component-results':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -81951,7 +82278,7 @@ snapshots:
   '@teambit/pkg.aspect-docs.pkg@file:scopes/pkg/aspect-docs/pkg(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82005,16 +82332,19 @@ snapshots:
 
   '@teambit/pkg.entities.registry@0.0.4': {}
 
-  '@teambit/pkg.modules.component-package-name@0.0.56':
+  '@teambit/pkg.modules.component-package-name@0.0.56(graphql@15.8.0)':
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/legacy.constants': 0.0.11
-      '@teambit/legacy.consumer-config': 0.0.49
+      '@teambit/legacy.consumer-config': 0.0.49(graphql@15.8.0)
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.utils': 0.0.21
       '@teambit/toolbox.path.path': 0.0.8
     transitivePeerDependencies:
+      - domexception
       - encoding
+      - graphql
+      - supports-color
 
   '@teambit/pkg.modules.component-package-name@file:components/modules/component-package-name(graphql@15.8.0)':
     dependencies:
@@ -82025,6 +82355,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82039,6 +82370,7 @@ snapshots:
   '@teambit/pkg.modules.semver-helper@file:scopes/pkg/modules/semver-helper':
     dependencies:
       '@teambit/component-version': 1.0.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82467,7 +82799,7 @@ snapshots:
   '@teambit/preview.aspect-docs.preview@file:scopes/preview/aspect-docs/preview(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82478,6 +82810,7 @@ snapshots:
 
   '@teambit/preview.cli.webpack-events-listener@file:scopes/preview/cli/webpack-events-listener':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82485,382 +82818,6 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
 
   '@teambit/preview.modules.preview-modules@1.0.3': {}
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.11(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.webpack.react-webpack': 1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
-      object-hash: 3.0.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      webpack: 5.97.1(esbuild@0.14.29)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - html-webpack-plugin
-      - less
-      - lightningcss
-      - node-sass
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
 
   '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)':
     dependencies:
@@ -82909,11 +82866,58 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
@@ -82956,17 +82960,440 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.12(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.webpack.react-webpack': 1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
       html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
       object-hash: 3.0.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.3.2)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.1.0)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.97.1(esbuild@0.14.29)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - html-webpack-plugin
+      - less
+      - lightningcss
+      - node-sass
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-webpack-plugin@5.6.3)(less@4.2.1)(lightningcss@1.28.2)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@18.3.1)
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      html-webpack-inject-plugin: 5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1)
+      object-hash: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       webpack: 5.97.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.4)(utf-8-validate@5.0.5)(webpack@5.97.1)
     transitivePeerDependencies:
@@ -83654,59 +84081,6 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.apps.react-app-types@2.1.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@teambit/bit-error': 0.0.404
-      '@teambit/react.rendering.ssr': 1.0.3(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/react.webpack.react-webpack': 1.0.54(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/toolbox.network.get-port': 1.0.10
-      '@teambit/ui-foundation.ui.pages.static-error': 0.0.108(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/webpack.transformers.favicon-reload': 1.0.0
-      '@teambit/webpack.webpack-bundler': 1.0.18(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(react@19.2.7)
-      '@teambit/webpack.webpack-dev-server': 1.0.24(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.2.7)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      express: 4.22.1
-      fs-extra: 10.1.0
-      lodash: 4.17.21
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      url-join: 4.0.0
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@testing-library/react'
-      - '@types/react'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - less
-      - lightningcss
-      - node-sass
-      - react
-      - react-dom
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
   '@teambit/react.apps.react-app-types@2.1.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)':
     dependencies:
       '@teambit/bit-error': 0.0.404
@@ -83773,7 +84147,7 @@ snapshots:
   '@teambit/react.aspect-docs.react@file:scopes/react/aspect-docs/react(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -83802,18 +84176,7 @@ snapshots:
       - react
       - react-dom
 
-  '@teambit/react.babel.bit-react-transformer@1.0.48(react-dom@18.3.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/component-id': 1.2.4
-      '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@18.3.1)(react@18.3.1)
-      find-root: 1.1.0
-      fs-extra: 10.0.0
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@teambit/react.babel.bit-react-transformer@1.0.48(react-dom@19.1.0)(react@19.1.0)':
+  '@teambit/react.babel.bit-react-transformer@1.0.49(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@19.1.0)(react@19.1.0)
@@ -83824,7 +84187,18 @@ snapshots:
       - react
       - react-dom
 
-  '@teambit/react.babel.bit-react-transformer@1.0.49(react-dom@19.1.0)(react@19.1.0)':
+  '@teambit/react.babel.bit-react-transformer@1.0.59(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/component-id': 1.2.4
+      '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@18.3.1)(react@18.3.1)
+      find-root: 1.1.0
+      fs-extra: 10.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@teambit/react.babel.bit-react-transformer@1.0.59(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@19.1.0)(react@19.1.0)
@@ -83839,6 +84213,7 @@ snapshots:
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@19.1.0)(react@19.1.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       find-root: 1.1.0
@@ -83898,20 +84273,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
+  '@teambit/react.eslint-config-bit-react@2.0.17(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
     dependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
     transitivePeerDependencies:
       - jest
       - supports-color
@@ -83919,6 +84289,7 @@ snapshots:
 
   '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.9.2)
@@ -83938,6 +84309,7 @@ snapshots:
 
   '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
@@ -83945,6 +84317,26 @@ snapshots:
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
       eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+    transitivePeerDependencies:
+      - jest
+      - supports-color
+      - typescript
+
+  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
+    dependencies:
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
+      eslint: 8.56.0
+      eslint-config-prettier: 8.5.0(eslint@8.56.0)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
       react: 19.1.0
@@ -84314,30 +84706,6 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@teambit/react.mounter@1.1.6(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
-    dependencies:
-      '@bitdev/react.live-controls': 0.0.4(react@19.2.7)
-      '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@19.2.7)
-      '@teambit/react.ui.highlighter-provider': 0.0.224(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-error-boundary: 3.1.4(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@teambit/react.mounter@1.1.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)':
-    dependencies:
-      '@bitdev/react.live-controls': 0.0.4(react@18.3.1)
-      '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@18.3.1)
-      '@teambit/react.ui.highlighter-provider': 0.0.224(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-error-boundary: 3.1.4(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@teambit/react.mounter@1.1.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@bitdev/react.live-controls': 0.0.4(react@19.1.0)
@@ -84350,11 +84718,35 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@teambit/react.mounter@1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
+  '@teambit/react.mounter@1.1.9(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@bitdev/react.live-controls': 0.0.4(react@18.3.1)
+      '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@18.3.1)
+      '@teambit/react.ui.highlighter-provider': 0.0.228(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-error-boundary: 3.1.4(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@teambit/react.mounter@1.1.9(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@bitdev/react.live-controls': 0.0.4(react@19.1.0)
+      '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@19.1.0)
+      '@teambit/react.ui.highlighter-provider': 0.0.228(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-error-boundary: 3.1.4(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@teambit/react.mounter@1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@bitdev/react.live-controls': 0.0.4(react@19.2.7)
       '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@19.2.7)
-      '@teambit/react.ui.highlighter-provider': 0.0.224(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.ui.highlighter-provider': 0.0.228(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -84362,7 +84754,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@teambit/react.react-env@2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
@@ -84379,8 +84771,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.26.9)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -84440,7 +84832,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.react-env@2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
@@ -84457,8 +84849,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.26.9)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -84518,7 +84910,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.react-env@2.0.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
@@ -84535,8 +84927,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.26.9)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -84596,7 +84988,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.react-env@2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
@@ -84613,8 +85005,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -84674,7 +85066,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.react-env@2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
@@ -84691,8 +85083,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -84752,85 +85144,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.react-env@2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack@5.97.1)':
-    dependencies:
-      '@babel/runtime': 7.20.0
-      '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
-      '@rspack/core': 2.1.4
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.14.2)
-      '@teambit/defender.jest-tester': 2.1.3(@babel/traverse@7.29.7)(jest@29.3.1)
-      '@teambit/defender.prettier-formatter': 1.0.24
-      '@teambit/dependencies.modules.packages-excluder': 1.0.8(react@19.2.7)
-      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
-      '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/react.apps.react-app-types': 2.1.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(@testing-library/react@16.3.2)(@types/react@19.2.14)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@teambit/react.generator.react-starters': 1.0.9
-      '@teambit/react.generator.react-templates': 1.0.13
-      '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
-      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
-      '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
-      '@testing-library/dom': 10.4.1
-      '@testing-library/jest-dom': 6.5.0
-      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@types/jest': 29.5.14
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      core-js: 3.13.0
-      graphql: 15.8.0
-      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
-      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
-      oxlint-tsgolint: 0.17.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      sass: 1.72.0
-      sass-loader: 16.0.8(@rspack/core@2.1.4)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/traverse'
-      - '@module-federation/runtime-tools'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/helpers'
-      - '@types/webpack'
-      - babel-plugin-macros
-      - browserslist
-      - bufferutil
-      - canvas
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint
-      - fibers
-      - less
-      - lightningcss
-      - node-notifier
-      - node-sass
-      - react-refresh
-      - rollup
-      - sass-embedded
-      - selfsigned
-      - sockjs-client
-      - supports-color
-      - ts-node
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.react-env@2.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.2)(rollup@4.53.3)(sass-embedded@1.100.0)(type-fest@4.41.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
@@ -84847,8 +85161,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.10(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -85048,27 +85362,6 @@ snapshots:
       use-debounce: 6.0.1(react@19.1.0)
       uuid: 3.4.0
 
-  '@teambit/react.ui.component-highlighter@0.2.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)':
-    dependencies:
-      '@floating-ui/react-dom': 0.7.2(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/base-ui.routing.native-link': 1.0.1(react@18.3.1)
-      '@teambit/component-id': 1.2.2
-      '@teambit/component.modules.component-url': 0.0.188(react@18.3.1)
-      '@teambit/react.modules.dom-to-react': 0.2.1(react@18.3.1)
-      '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/react.ui.hover-selector': 0.2.1(react@18.3.1)
-      '@tippyjs/react': 4.2.0(react-dom@18.3.1)(react@18.3.1)
-      classnames: 2.5.1
-      get-xpath: 3.2.0
-      lodash.compact: 3.0.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      url-join: 4.0.1
-      use-debounce: 8.0.4(react@18.3.1)
-      uuid: 10.0.0
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@teambit/react.ui.component-highlighter@0.2.7(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 0.7.2(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
@@ -85111,7 +85404,49 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@teambit/react.ui.component-highlighter@0.2.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
+  '@teambit/react.ui.component-highlighter@0.2.8(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 0.7.2(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/base-ui.routing.native-link': 1.0.1(react@18.3.1)
+      '@teambit/component-id': 1.2.2
+      '@teambit/component.modules.component-url': 0.0.188(react@18.3.1)
+      '@teambit/react.modules.dom-to-react': 0.2.1(react@18.3.1)
+      '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.ui.hover-selector': 0.2.1(react@18.3.1)
+      '@tippyjs/react': 4.2.0(react-dom@18.3.1)(react@18.3.1)
+      classnames: 2.5.1
+      get-xpath: 3.2.0
+      lodash.compact: 3.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      url-join: 4.0.1
+      use-debounce: 8.0.4(react@18.3.1)
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@teambit/react.ui.component-highlighter@0.2.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@floating-ui/react-dom': 0.7.2(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/base-ui.routing.native-link': 1.0.1(react@19.1.0)
+      '@teambit/component-id': 1.2.2
+      '@teambit/component.modules.component-url': 0.0.188(react@19.1.0)
+      '@teambit/react.modules.dom-to-react': 0.2.1(react@19.1.0)
+      '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.ui.hover-selector': 0.2.1(react@19.1.0)
+      '@tippyjs/react': 4.2.0(react-dom@19.1.0)(react@19.1.0)
+      classnames: 2.5.1
+      get-xpath: 3.2.0
+      lodash.compact: 3.0.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      url-join: 4.0.1
+      use-debounce: 8.0.4(react@19.1.0)
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@teambit/react.ui.component-highlighter@0.2.8(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@floating-ui/react-dom': 0.7.2(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/base-ui.routing.native-link': 1.0.1(react@19.2.7)
@@ -85234,13 +85569,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85278,13 +85613,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85426,10 +85761,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85464,10 +85799,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85515,11 +85850,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -85531,11 +85866,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -85603,16 +85938,6 @@ snapshots:
     transitivePeerDependencies:
       - '@testing-library/react'
 
-  '@teambit/react.ui.highlighter-provider@0.0.224(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)':
-    dependencies:
-      '@teambit/react.ui.component-highlighter': 0.2.7(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
-      classnames: 2.5.1
-      query-string: 7.0.0
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-
   '@teambit/react.ui.highlighter-provider@0.0.224(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
     dependencies:
       '@teambit/react.ui.component-highlighter': 0.2.7(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -85623,9 +85948,29 @@ snapshots:
       - '@types/react'
       - react-dom
 
-  '@teambit/react.ui.highlighter-provider@0.0.224(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
+  '@teambit/react.ui.highlighter-provider@0.0.228(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@teambit/react.ui.component-highlighter': 0.2.7(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.ui.component-highlighter': 0.2.8(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
+      classnames: 2.5.1
+      query-string: 7.0.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+
+  '@teambit/react.ui.highlighter-provider@0.0.228(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)':
+    dependencies:
+      '@teambit/react.ui.component-highlighter': 0.2.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      classnames: 2.5.1
+      query-string: 7.0.0
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+
+  '@teambit/react.ui.highlighter-provider@0.0.228(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)':
+    dependencies:
+      '@teambit/react.ui.component-highlighter': 0.2.8(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       classnames: 2.5.1
       query-string: 7.0.0
       react: 19.2.7
@@ -86286,76 +86631,6 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.54(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@bitdev/react.webpack.refresh-overlay': 0.0.6
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@5.9.2)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.2(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.34(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.24(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.2.7)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.9.2)(webpack@5.97.1)
-      react-dom: 19.2.7(react@19.2.7)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
   '@teambit/react.webpack.react-webpack@1.0.54(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)':
     dependencies:
       '@babel/preset-env': 7.22.15(@babel/core@7.28.3)
@@ -86497,574 +86772,6 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
-      '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.26.9)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
-      react-dom: 19.1.0(react@19.1.0)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
-      '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.26.9)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
-      react-dom: 19.1.0(react@19.1.0)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
-      '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.26.9)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
-      react-dom: 19.1.0(react@19.1.0)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.57(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@6.0.3)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.48(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
-    dependencies:
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
-      '@bitdev/react.webpack.refresh-overlay': 1.0.0
-      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
-      '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
-      '@svgr/webpack': 8.1.0(typescript@7.0.2)
-      '@swc/css': 0.0.20
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.49(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
-      '@teambit/webpack.modules.style-regexps': 1.0.10
-      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
-      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
-      css-loader: 6.7.2(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
-      esbuild: 0.14.29
-      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
-      lightningcss: 1.28.2
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      new-url-loader: 0.1.1(webpack@5.97.1)
-      postcss: 8.4.19
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
-      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
-      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
-      postcss-preset-env: 7.8.3(postcss@8.4.19)
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
-      react-dom: 19.1.0(react@19.1.0)
-      react-refresh: 0.14.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
-      source-map-loader: 4.0.1(webpack@5.97.1)
-      style-loader: 3.3.1(webpack@5.97.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
-      webpack: 5.97.1(esbuild@0.14.29)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - browserslist
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - eslint
-      - fibers
-      - less
-      - node-sass
-      - react
-      - rollup
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
   '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
@@ -87136,7 +86843,291 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
+      '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.26.9)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dom: 19.1.0(react@19.1.0)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
+      '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.26.9)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dom: 19.1.0(react@19.1.0)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.26.9)
+      '@babel/preset-react': 7.22.15(@babel/core@7.26.9)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.26.9)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.26.9)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dom: 19.1.0(react@19.1.0)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.100.0)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.5)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -87150,7 +87141,149 @@ snapshots:
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
       '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.49(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dom: 19.1.0(react@19.1.0)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@0.21.3)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
@@ -87207,7 +87340,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.webpack.react-webpack@1.0.58(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@0.21.3)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
     dependencies:
       '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
@@ -87215,13 +87348,155 @@ snapshots:
       '@bitdev/react.webpack.refresh-overlay': 1.0.0
       '@mdx-js/loader': 3.1.1(webpack@5.97.1)
       '@parcel/css': 1.14.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@0.21.3)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
       '@svgr/webpack': 8.1.0(typescript@7.0.2)
       '@swc/css': 0.0.20
       '@teambit/component-id': 1.2.4
       '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
       '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
-      '@teambit/react.babel.bit-react-transformer': 1.0.49(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.23.3)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dom: 19.1.0(react@19.1.0)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.8)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@19.1.0)(react@19.1.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@7.0.2)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': 1.0.21
       '@teambit/webpack.modules.style-regexps': 1.0.10
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
@@ -87241,6 +87516,77 @@ snapshots:
       postcss-preset-env: 7.8.3(postcss@8.4.19)
       react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
+      react-refresh: 0.14.0
+      resolve-url-loader: 5.0.0
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
+      source-map-loader: 4.0.1(webpack@5.97.1)
+      style-loader: 3.3.1(webpack@5.97.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.29)(webpack@5.97.1)
+      webpack: 5.97.1(esbuild@0.14.29)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/webpack'
+      - browserslist
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - eslint
+      - fibers
+      - less
+      - node-sass
+      - react
+      - rollup
+      - sass
+      - sass-embedded
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.webpack.react-webpack@1.0.59(@babel/core@7.28.3)(@rspack/core@2.1.4)(@types/webpack@5.28.5)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-dom@18.3.1)(react@18.3.1)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(type-fest@4.41.0)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)':
+    dependencies:
+      '@babel/preset-env': 7.29.2(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.3)
+      '@bitdev/react.webpack.refresh-overlay': 1.0.0
+      '@mdx-js/loader': 3.1.1(webpack@5.97.1)
+      '@parcel/css': 1.14.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.0)(webpack@5.97.1)
+      '@svgr/webpack': 8.1.0(typescript@6.0.3)
+      '@swc/css': 0.0.20
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)
+      '@teambit/react.babel.bit-react-transformer': 1.0.59(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/webpack.modules.generate-style-loaders': 1.0.21
+      '@teambit/webpack.modules.style-regexps': 1.0.10
+      '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@2.1.4)(@swc/css@0.0.20)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(lightningcss@1.28.2)(react@18.3.1)(typescript@6.0.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
+      babel-loader: 9.1.0(@babel/core@7.28.3)(webpack@5.97.1)
+      css-loader: 6.7.2(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 6.0.0(@parcel/css@1.14.0)(@swc/css@0.0.20)(esbuild@0.14.29)(lightningcss@1.28.2)(webpack@5.97.1)
+      esbuild: 0.14.29
+      less-loader: 11.1.0(less@4.2.1)(webpack@5.97.1)
+      lightningcss: 1.28.2
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      new-url-loader: 0.1.1(webpack@5.97.1)
+      postcss: 8.4.19
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.4.19)
+      postcss-loader: 7.0.1(postcss@8.4.19)(webpack@5.97.1)
+      postcss-normalize: 10.0.1(browserslist@4.28.2)(postcss@8.4.19)
+      postcss-preset-env: 7.8.3(postcss@8.4.19)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@6.0.3)(webpack@5.97.1)
+      react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       resolve-url-loader: 5.0.0
       sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
@@ -88001,12 +88347,12 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       strip-ansi: 6.0.0
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.10(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
-      '@bitdev/react.preview.react-docs-template': 1.0.10(react-dom@19.2.7)(react@19.2.7)
+      '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.4
       '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@teambit/react.mounter': 1.1.6(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.26.9)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.26.9)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
@@ -88032,12 +88378,12 @@ snapshots:
       - vue-template-compiler
       - webpack
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.10(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.26.9)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
-      '@bitdev/react.preview.react-docs-template': 1.0.10(react-dom@19.2.7)(react@19.2.7)
+      '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.4
       '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@teambit/react.mounter': 1.1.6(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
       '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.26.9)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.26.9)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
@@ -88063,12 +88409,12 @@ snapshots:
       - vue-template-compiler
       - webpack
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.10(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
-      '@bitdev/react.preview.react-docs-template': 1.0.10(react-dom@19.2.7)(react@19.2.7)
+      '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.4
       '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@teambit/react.mounter': 1.1.6(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
@@ -88094,12 +88440,12 @@ snapshots:
       - vue-template-compiler
       - webpack
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.10(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
-      '@bitdev/react.preview.react-docs-template': 1.0.10(react-dom@19.2.7)(react@19.2.7)
+      '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.4
       '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@teambit/react.mounter': 1.1.6(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.2)(react@19.2.7)(webpack@5.97.1)
       '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.14.2)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)
@@ -88551,6 +88897,7 @@ snapshots:
     dependencies:
       '@teambit/component-descriptor': file:scopes/component/component-descriptor(chai@5.2.1)
       '@teambit/component-id': 1.2.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -88568,6 +88915,7 @@ snapshots:
   '@teambit/scope.modules.find-scope-path@file:components/modules/find-scope-path':
     dependencies:
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -88625,6 +88973,7 @@ snapshots:
       '@teambit/legacy.scope': file:components/legacy/scope(graphql@15.8.0)
       '@teambit/legacy.scope-api': file:components/legacy/scope-api(graphql@15.8.0)
       '@teambit/toolbox.network.agent': 0.0.554
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       agentkeepalive: 4.1.4
@@ -88671,6 +89020,7 @@ snapshots:
       '@teambit/legacy.scope': file:components/legacy/scope(graphql@15.8.0)
       '@teambit/scope.network': file:scopes/scope/network(graphql@15.8.0)
       '@teambit/toolbox.promise.map-pool': file:scopes/toolbox/promise/map-pool
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       glob: 13.0.0
@@ -88727,6 +89077,7 @@ snapshots:
       '@teambit/legacy.scope-api': file:components/legacy/scope-api(graphql@15.8.0)
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/scope.network': file:scopes/scope/network(graphql@15.8.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       async-retry: 1.3.3
@@ -89431,6 +89782,7 @@ snapshots:
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/workspace.modules.fs-cache': file:scopes/workspace/modules/fs-cache
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       doctrine: 2.1.0
@@ -89446,6 +89798,7 @@ snapshots:
   '@teambit/semantics.entities.semantic-schema-diff@file:components/entities/semantic-schema-diff':
     dependencies:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -89476,6 +89829,7 @@ snapshots:
   '@teambit/semantics.entities.semantic-schema@file:components/entities/semantic-schema':
     dependencies:
       '@teambit/component-id': 1.2.4
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       chalk: 4.1.2
@@ -89776,16 +90130,16 @@ snapshots:
       - '@apollo/client'
       - '@teambit/base-react.navigation.link'
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -89864,16 +90218,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -89912,6 +90266,7 @@ snapshots:
 
   '@teambit/toolbox.array.duplications-finder@file:scopes/toolbox/array/duplications-finder':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -89951,6 +90306,7 @@ snapshots:
 
   '@teambit/toolbox.fs.hard-link-directory@file:scopes/toolbox/fs/hard-link-directory':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -90033,6 +90389,7 @@ snapshots:
 
   '@teambit/toolbox.json.jsonc-utils@file:scopes/toolbox/json/jsonc-utils':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       comment-json: 4.2.5
@@ -90293,6 +90650,7 @@ snapshots:
 
   '@teambit/ts-server@file:scopes/typescript/ts-server':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       command-exists: 1.2.9
@@ -90318,7 +90676,7 @@ snapshots:
   '@teambit/typescript.aspect-docs.typescript@file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -90352,6 +90710,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@teambit/typescript.deps-detectors.detective-typescript@0.0.10(typescript@7.0.2)':
+    dependencies:
+      '@teambit/node.deps-detectors.parser-helper': 0.0.6
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@7.0.2)
+      node-source-walk: 6.0.2
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@teambit/typescript.deps-lookups.lookup-typescript@0.0.2':
     dependencies:
       app-module-path: 2.2.0
@@ -90364,6 +90731,7 @@ snapshots:
 
   '@teambit/typescript.modules.ts-config-mutator@file:scopes/typescript/modules/ts-config-mutator':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -90499,6 +90867,20 @@ snapshots:
       typescript: 6.0.3
 
   '@teambit/typescript.typescript-compiler@5.0.0(react@19.1.0)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/compilation.compiler-task': 1.0.12
+      comment-json: 4.2.3
+      fs-extra: 11.3.4
+      get-tsconfig: 4.2.0
+      glob: 10.4.5
+      globby: 11.1.0
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      react: 19.1.0
+      typescript: 6.0.3
+
+  '@teambit/typescript.typescript-compiler@5.0.1(react@19.1.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/compilation.compiler-task': 1.0.12
@@ -92401,7 +92783,7 @@ snapshots:
     dependencies:
       url-parse: 1.5.3
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92454,7 +92836,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92569,7 +92951,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92622,7 +93004,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92779,7 +93161,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -92794,7 +93176,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      vue-component-meta: 2.2.10(typescript@5.5.3)
+      vue-component-meta: 2.2.10(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
 
@@ -92902,6 +93284,7 @@ snapshots:
 
   '@teambit/webpack.modules.generate-expose-loaders@file:scopes/webpack/modules/generate-expose-loaders(webpack@5.97.1)':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       expose-loader: 3.1.0(webpack@5.97.1)
@@ -92915,6 +93298,7 @@ snapshots:
 
   '@teambit/webpack.modules.generate-externals@file:scopes/webpack/modules/generate-externals':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -92935,6 +93319,7 @@ snapshots:
 
   '@teambit/webpack.modules.style-regexps@file:scopes/webpack/style-regexps':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -92943,6 +93328,7 @@ snapshots:
 
   '@teambit/webpack.plugins.inject-head-webpack-plugin@file:scopes/webpack/plugins/inject-head-webpack-plugin(html-webpack-plugin@5.3.2)':
     dependencies:
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       html-webpack-plugin: 5.3.2(webpack@5.97.1)
@@ -93688,7 +94074,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/harmony': 0.4.12
@@ -93724,7 +94110,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       stream-browserify: 3.0.0
@@ -93812,7 +94198,7 @@ snapshots:
   '@teambit/workspace.aspect-docs.variants@file:scopes/workspace/aspect-docs/variants(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -93902,6 +94288,7 @@ snapshots:
       '@teambit/harmony.modules.feature-toggle': file:scopes/harmony/modules/feature-toggle
       '@teambit/legacy.logger': file:components/legacy/logger
       '@teambit/legacy.utils': file:components/legacy/utils
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       cacache: 20.0.3
@@ -93917,6 +94304,7 @@ snapshots:
       '@teambit/bit-error': 0.0.404
       '@teambit/toolbox.path.is-path-inside': file:scopes/toolbox/path/is-path-inside
       '@teambit/toolbox.string.strip-trailing-char': file:scopes/toolbox/string/strip-trailing-char
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -93940,6 +94328,7 @@ snapshots:
       '@teambit/pkg.modules.component-package-name': file:components/modules/component-package-name(graphql@15.8.0)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/workspace.root-components': 1.0.1
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -93962,6 +94351,7 @@ snapshots:
   '@teambit/workspace.modules.workspace-locator@file:scopes/workspace/modules/workspace-locator':
     dependencies:
       '@teambit/legacy.constants': file:components/legacy/constants
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       fs-extra: 10.0.0
@@ -93976,6 +94366,7 @@ snapshots:
   '@teambit/workspace.testing.mock-workspace@file:scopes/workspace/testing/mock-workspace(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)':
     dependencies:
       '@teambit/legacy.e2e-helper': file:components/legacy/e2e-helper(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(react@19.1.0)(typanion@3.14.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       comment-json: 4.2.5
@@ -93995,6 +94386,7 @@ snapshots:
   '@teambit/workspace.testing.mock-workspace@file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)':
     dependencies:
       '@teambit/legacy.e2e-helper': file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(react@19.1.0)(typanion@3.14.0)
+      '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       comment-json: 4.2.5
@@ -95792,6 +96184,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.39.0(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/types': 8.39.0
+      debug: 4.3.4(supports-color@9.4.0)
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@4.4.1':
     dependencies:
       '@typescript-eslint/types': 4.4.1
@@ -95828,6 +96229,10 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.39.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@7.0.2)':
+    dependencies:
+      typescript: 7.0.2
 
   '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
@@ -96132,6 +96537,22 @@ snapshots:
       semver: 7.7.1
       ts-api-utils: 2.1.0(typescript@6.0.3)
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.39.0(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
+      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/visitor-keys': 8.39.0
+      debug: 4.3.4(supports-color@9.4.0)
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -96552,19 +96973,6 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-
-  '@vue/language-core@2.2.10(typescript@5.5.3)':
-    dependencies:
-      '@volar/language-core': 2.4.14
-      '@vue/compiler-dom': 3.5.17
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.17
-      alien-signals: 1.0.13
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.5.3
 
   '@vue/language-core@2.2.10(typescript@5.9.2)':
     dependencies:
@@ -100433,17 +100841,6 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3):
-    dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.5.3)
-      eslint: 8.56.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
-      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
@@ -101964,7 +102361,7 @@ snapshots:
 
   html-webpack-inject-plugin@5.3.1(html-webpack-plugin@5.6.3)(webpack@5.97.1):
     dependencies:
-      html-webpack-plugin: 5.6.3(@rspack/core@2.1.4)(webpack@5.97.1)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.7.8)(webpack@5.97.1)
       webpack: 5.97.1(esbuild@0.14.29)
 
   html-webpack-plugin@5.3.2(webpack@5.97.1):
@@ -107070,12 +107467,6 @@ snapshots:
       react: 18.3.1
       typescript: 7.0.2
 
-  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3):
-    dependencies:
-      '@types/react': 19.2.14
-      react: 19.1.0
-      typescript: 5.5.3
-
   react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.9.2):
     dependencies:
       '@types/react': 19.2.14
@@ -109144,6 +109535,10 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
+  ts-api-utils@2.1.0(typescript@7.0.2):
+    dependencies:
+      typescript: 7.0.2
+
   ts-easing@0.2.0: {}
 
   ts-graphviz@2.1.6:
@@ -109930,15 +110325,6 @@ snapshots:
   vscode-languageserver-types@3.16.0: {}
 
   vscode-uri@3.1.0: {}
-
-  vue-component-meta@2.2.10(typescript@5.5.3):
-    dependencies:
-      '@volar/typescript': 2.4.14
-      '@vue/language-core': 2.2.10(typescript@5.5.3)
-      path-browserify: 1.0.1
-      vue-component-type-helpers: 2.2.10
-    optionalDependencies:
-      typescript: 5.5.3
 
   vue-component-meta@2.2.10(typescript@5.9.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,8 +1001,8 @@ importers:
         specifier: ~0.0.2
         version: 0.0.2
       '@teambit/typescript.typescript-compiler':
-        specifier: ^5.0.0
-        version: 5.0.0(react@19.1.0)
+        specifier: ^5.0.1
+        version: 5.0.1(react@19.1.0)
       '@teambit/ui-foundation.ui.constants.z-indexes':
         specifier: ^0.0.504
         version: 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -3253,8 +3253,8 @@ importers:
         specifier: ~0.0.312
         version: 0.0.312
       '@teambit/typescript.typescript-compiler':
-        specifier: ^5.0.0
-        version: 5.0.0(react@19.1.0)
+        specifier: ^5.0.1
+        version: 5.0.1(react@19.1.0)
       '@teambit/workspace.root-components':
         specifier: ^1.0.1
         version: 1.0.1
@@ -6486,7 +6486,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -6663,7 +6663,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6699,13 +6699,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -6753,7 +6753,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -7080,13 +7080,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7095,10 +7095,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -7182,7 +7182,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -7278,7 +7278,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -7311,13 +7311,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -7440,7 +7440,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -7617,7 +7617,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7653,13 +7653,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -7707,7 +7707,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -8040,13 +8040,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8055,10 +8055,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
@@ -8142,7 +8142,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -8238,7 +8238,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -8271,13 +8271,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -9459,7 +9459,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -9636,7 +9636,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9672,13 +9672,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -9726,7 +9726,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -10059,13 +10059,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10074,10 +10074,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -10161,7 +10161,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -10257,7 +10257,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -10290,13 +10290,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -10446,7 +10446,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -10623,7 +10623,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10659,13 +10659,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -10713,7 +10713,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -11046,13 +11046,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11061,10 +11061,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -11148,7 +11148,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -11244,7 +11244,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -11277,13 +11277,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -11433,7 +11433,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -11610,7 +11610,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11646,13 +11646,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -11700,7 +11700,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -12033,13 +12033,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12048,10 +12048,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -12135,7 +12135,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -12231,7 +12231,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -12264,13 +12264,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -12348,10 +12348,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -12360,7 +12360,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -12435,7 +12435,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -12612,7 +12612,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12648,13 +12648,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -12702,7 +12702,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -13029,7 +13029,7 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.internal.base-react-env':
         specifier: 1.1.4
         version: 1.1.4(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.5)(@swc/css@0.0.20)(@types/node@22.10.5)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(less@4.2.1)(lightningcss@1.28.2)(sass-embedded@1.100.0)(type-fest@0.21.3)(utf-8-validate@5.0.5)
@@ -13038,7 +13038,7 @@ importers:
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13047,10 +13047,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -13134,7 +13134,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -13230,7 +13230,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -13263,13 +13263,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -13341,10 +13341,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: 6.19.1
-        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: 6.19.1
-        version: 6.19.1(eslint@8.56.0)(typescript@7.0.2)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.5.3)
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -13353,7 +13353,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)
       eslint-plugin-jest:
         specifier: 27.6.3
-        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: 27.6.3(@typescript-eslint/eslint-plugin@6.19.1)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       eslint-plugin-jsx-a11y:
         specifier: 6.8.0
         version: 6.8.0(eslint@8.56.0)
@@ -13428,7 +13428,7 @@ importers:
         version: file:scopes/harmony/cache(chai@5.2.1)(react@19.1.0)
       '@teambit/changelog':
         specifier: workspace:*
-        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)
       '@teambit/checkout':
         specifier: workspace:*
         version: file:scopes/component/checkout(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai-fs@1.0.0)(chai@5.2.1)(graphql@15.8.0)(typanion@3.14.0)
@@ -13605,7 +13605,7 @@ importers:
         version: file:scopes/compositions/composition-card(react-dom@19.1.0)(react@19.1.0)
       '@teambit/compositions':
         specifier: workspace:*
-        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/compositions.aspect-docs.compositions':
         specifier: workspace:*
         version: file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13641,13 +13641,13 @@ importers:
         version: file:scopes/defender/prettier-config-mutator
       '@teambit/defender.ui.test-compare':
         specifier: workspace:*
-        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-page':
         specifier: workspace:*
-        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+        version: file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/dependencies':
         specifier: workspace:*
-        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)
+        version: file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)
       '@teambit/dependencies.aspect-docs.dependency-resolver':
         specifier: workspace:*
         version: file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
@@ -13695,7 +13695,7 @@ importers:
         version: file:scopes/workspace/eject(graphql@15.8.0)(react@19.1.0)
       '@teambit/env':
         specifier: workspace:*
-        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/envs':
         specifier: workspace:*
         version: file:scopes/envs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(graphql@15.8.0)(react@19.1.0)
@@ -14022,13 +14022,13 @@ importers:
         version: file:scopes/react/bit-react-transformer
       '@teambit/react.eslint-config-bit-react':
         specifier: workspace:*
-        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+        version: file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       '@teambit/react.ui.compositions-app':
         specifier: workspace:*
         version: file:scopes/react/ui/compositions-app(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs-app':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.apply-providers':
         specifier: workspace:*
         version: file:scopes/react/ui/docs/apply-providers(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14037,10 +14037,10 @@ importers:
         version: file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.docs-content':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.docs.properties-table':
         specifier: workspace:*
-        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback':
         specifier: workspace:*
         version: file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
@@ -14124,7 +14124,7 @@ importers:
         version: file:components/tagged-exports(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/tester':
         specifier: workspace:*
-        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/toolbox.array.duplications-finder':
         specifier: workspace:*
         version: file:scopes/toolbox/array/duplications-finder
@@ -14220,7 +14220,7 @@ importers:
         version: file:scopes/typescript/modules/ts-config-mutator
       '@teambit/ui':
         specifier: workspace:*
-        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)
+        version: file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.buttons.collapser':
         specifier: workspace:*
         version: file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -14253,13 +14253,13 @@ importers:
         version: file:scopes/scope/version-history(graphql@15.8.0)
       '@teambit/vue-aspect':
         specifier: workspace:*
-        version: file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)
+        version: file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)
       '@teambit/watcher':
         specifier: workspace:*
         version: file:scopes/workspace/watcher
       '@teambit/webpack':
         specifier: workspace:*
-        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)
+        version: file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)
       '@teambit/webpack.modules.config-mutator':
         specifier: workspace:*
         version: file:scopes/webpack/config-mutator(esbuild@0.14.29)
@@ -19743,8 +19743,8 @@ importers:
         specifier: 0.4.12
         version: 0.4.12
       '@teambit/typescript.typescript-compiler':
-        specifier: ^5.0.0
-        version: 5.0.0(react@19.1.0)
+        specifier: ^5.0.1
+        version: 5.0.1(react@19.1.0)
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -22816,8 +22816,8 @@ importers:
         specifier: 0.0.45
         version: 0.0.45(react-dom@19.1.0)(react@19.1.0)
       '@teambit/typescript.typescript-compiler':
-        specifier: ^5.0.0
-        version: 5.0.0(react@19.1.0)
+        specifier: ^5.0.1
+        version: 5.0.1(react@19.1.0)
       '@typescript-eslint/eslint-plugin':
         specifier: 7.1.0
         version: 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.9.2)
@@ -25066,8 +25066,8 @@ importers:
         specifier: 0.4.12
         version: 0.4.12
       '@teambit/typescript.typescript-compiler':
-        specifier: ^5.0.0
-        version: 5.0.0(react@19.1.0)
+        specifier: ^5.0.1
+        version: 5.0.1(react@19.1.0)
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -56906,7 +56906,7 @@ snapshots:
 
   '@teambit/api-reference.models.api-node-renderer@0.0.53(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/semantics.entities.semantic-schema': 0.0.95
       core-js: 3.13.0
       react: 18.3.1
@@ -56966,7 +56966,7 @@ snapshots:
   '@teambit/api-reference.overview.api-reference-table-of-contents@0.0.41(@teambit/base-react.navigation.link@2.0.33)(react-dom@19.1.0)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@18.3.1)
-      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53
+      '@teambit/api-reference.utils.sort-api-nodes': 0.0.53(react-dom@19.1.0)(react@18.3.1)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -59115,10 +59115,6 @@ snapshots:
     dependencies:
       '@teambit/semantics.entities.semantic-schema': 0.0.92
 
-  '@teambit/api-reference.utils.sort-api-nodes@0.0.53':
-    dependencies:
-      '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
-
   '@teambit/api-reference.utils.sort-api-nodes@0.0.53(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@18.3.1)(react@18.3.1)
@@ -59379,7 +59375,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -59430,7 +59426,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -59481,7 +59477,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -61828,7 +61824,7 @@ snapshots:
       lodash: 4.17.21
       p-limit: 2.3.0
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61836,7 +61832,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -61882,7 +61878,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/changelog@file:scopes/component/changelog(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/component.instructions.exporting-components': 0.0.8(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.version-block': file:components/ui/version-block(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -61890,7 +61886,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.menu-widget-icon': 0.0.502(react-dom@19.1.0)(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
@@ -63887,7 +63883,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.babel@file:scopes/compilation/aspect-docs/babel(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63907,7 +63903,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.compiler@file:scopes/compilation/aspect-docs/compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -63927,7 +63923,7 @@ snapshots:
   '@teambit/compilation.aspect-docs.multi-compiler@file:scopes/compilation/aspect-docs/multi-compiler(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64580,7 +64576,7 @@ snapshots:
   '@teambit/component.aspect-docs.component@file:scopes/component/aspect-docs/component(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -64898,7 +64894,7 @@ snapshots:
       '@teambit/legacy.extension-data': 0.0.51(graphql@15.8.0)
       '@teambit/legacy.logger': 0.0.19
       '@teambit/legacy.scope': 0.0.49(graphql@15.8.0)
-      '@teambit/pkg.modules.component-package-name': 0.0.56(graphql@15.8.0)
+      '@teambit/pkg.modules.component-package-name': 0.0.56
       '@teambit/toolbox.fs.link-or-symlink': 0.0.20
       '@teambit/toolbox.fs.remove-empty-dir': 0.0.5
       '@teambit/toolbox.path.path': 0.0.8
@@ -67885,7 +67881,7 @@ snapshots:
   '@teambit/compositions.aspect-docs.compositions@file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -68165,7 +68161,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -68196,11 +68192,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -68297,7 +68293,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/compositions@file:scopes/compositions/compositions(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(graphql@15.8.0)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/api-reference.hooks.use-api': 0.0.57(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -68328,11 +68324,11 @@ snapshots:
       '@teambit/docs.ui.queries.get-docs': file:scopes/docs/ui/queries/get-docs(@apollo/client@3.12.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.theme.theme-context': 4.0.7(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/harmony': 0.4.12
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/preview.ui.component-preview': file:scopes/preview/ui/component-preview(react-dom@19.1.0)(react@19.1.0)
       '@teambit/toolbox.path.match-patterns': file:scopes/toolbox/path/match-patterns
       '@teambit/ui-foundation.ui.buttons.collapser': file:components/ui/buttons/collapser(react-dom@19.1.0)(react@19.1.0)
@@ -68873,18 +68869,18 @@ snapshots:
       - '@types/react-dom'
       - react-router-dom
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -68954,18 +68950,18 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-compare@file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/component.ui.component-compare.context': file:components/ui/component-compare/context(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.10(react-dom@19.1.0)(react@19.1.0)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-table': 0.0.512(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.alert-card': 0.0.27(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.empty-box': 0.0.364(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -69005,7 +69001,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -69017,7 +69013,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -69092,7 +69088,7 @@ snapshots:
       - react-router-dom
       - typescript
 
-  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/defender.ui.test-page@file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/defender.ui.test-loader': 0.0.504(react-dom@19.1.0)(react@19.1.0)
@@ -69104,7 +69100,7 @@ snapshots:
       '@teambit/design.ui.separator': 0.0.367(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.heading': 4.1.8(react-dom@19.1.0)(react@19.1.0)
       '@teambit/lanes.hooks.use-viewed-lane-from-url': file:components/hooks/use-viewed-lane-from-url_1(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       classnames: 2.5.1
       core-js: 3.13.0
@@ -69191,7 +69187,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.dependency-resolver@file:scopes/dependencies/aspect-docs/dependency-resolver(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -69211,7 +69207,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.pnpm@file:scopes/dependencies/aspect-docs/pnpm(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -69231,7 +69227,7 @@ snapshots:
   '@teambit/dependencies.aspect-docs.yarn@file:scopes/dependencies/aspect-docs/yarn(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -69266,7 +69262,7 @@ snapshots:
     dependencies:
       '@pnpm/dependency-path': 1001.1.10
 
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
@@ -69296,9 +69292,77 @@ snapshots:
       '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.26.9)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      archy: 1.0.0
+      chai: 5.2.1
+      chalk: 4.1.2
+      cli-table: 0.3.6
+      debug: 4.3.4(supports-color@9.4.0)
+      detective-amd: 3.0.1
+      detective-stylus: 1.0.0
+      fs-extra: 10.0.0
+      lodash: 4.17.21
+      module-definition: 3.3.1
+      moment: 2.29.4
+      node-source-walk: 4.2.0
+      p-map-series: 2.1.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+      read-pkg-up: 7.0.1
+      resolve-dependency-path: 2.0.0
+      semver: 7.7.1
+      stylus-lookup: 3.0.2
+      table: 6.7.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@pnpm/logger'
+      - domexception
+      - encoding
+      - graphql
+      - postcss
+      - supports-color
+      - typanion
+      - typescript
+
+  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/component-id': 1.2.4
+      '@teambit/component-issues': file:components/component-issues
+      '@teambit/component-package-version': file:scopes/component/component-package-version
+      '@teambit/component-version': 1.0.4
+      '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
+      '@teambit/component.testing.mock-components': file:scopes/component/testing/mock-components(graphql@15.8.0)
+      '@teambit/harmony': 0.4.12
+      '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
+      '@teambit/legacy.bit-map': file:components/legacy/bit-map(graphql@15.8.0)
+      '@teambit/legacy.constants': file:components/legacy/constants
+      '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
+      '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
+      '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
+      '@teambit/legacy.dependency-graph': file:components/legacy/dependency-graph(graphql@15.8.0)
+      '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
+      '@teambit/legacy.logger': file:components/legacy/logger
+      '@teambit/legacy.utils': file:components/legacy/utils
+      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
+      '@teambit/node.deps-detectors.detective-es6': 0.0.6
+      '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-sass': 0.0.9(postcss@8.4.45)
+      '@teambit/styling.deps-detectors.detective-scss': 0.0.9(postcss@8.4.45)
+      '@teambit/styling.deps-lookups.lookup-styling': 0.0.4
+      '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
+      '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
+      '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
+      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@5.5.3)
+      '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -69365,74 +69429,6 @@ snapshots:
       '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
       '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@6.0.3)
-      '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      archy: 1.0.0
-      chai: 5.2.1
-      chalk: 4.1.2
-      cli-table: 0.3.6
-      debug: 4.3.4(supports-color@9.4.0)
-      detective-amd: 3.0.1
-      detective-stylus: 1.0.0
-      fs-extra: 10.0.0
-      lodash: 4.17.21
-      module-definition: 3.3.1
-      moment: 2.29.4
-      node-source-walk: 4.2.0
-      p-map-series: 2.1.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      read-pkg-up: 7.0.1
-      resolve-dependency-path: 2.0.0
-      semver: 7.7.1
-      stylus-lookup: 3.0.2
-      table: 6.7.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@pnpm/logger'
-      - domexception
-      - encoding
-      - graphql
-      - postcss
-      - supports-color
-      - typanion
-      - typescript
-
-  '@teambit/dependencies@file:scopes/dependencies/dependencies(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(graphql@15.8.0)(postcss@8.4.45)(typanion@3.14.0)(typescript@7.0.2)':
-    dependencies:
-      '@teambit/bit-error': 0.0.404
-      '@teambit/component-id': 1.2.4
-      '@teambit/component-issues': file:components/component-issues
-      '@teambit/component-package-version': file:scopes/component/component-package-version
-      '@teambit/component-version': 1.0.4
-      '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/component.testing.mock-components': file:scopes/component/testing/mock-components(graphql@15.8.0)
-      '@teambit/harmony': 0.4.12
-      '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(graphql@15.8.0)
-      '@teambit/legacy.bit-map': file:components/legacy/bit-map(graphql@15.8.0)
-      '@teambit/legacy.constants': file:components/legacy/constants
-      '@teambit/legacy.consumer': file:components/legacy/consumer(graphql@15.8.0)
-      '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(graphql@15.8.0)
-      '@teambit/legacy.consumer-config': file:components/legacy/consumer-config(graphql@15.8.0)
-      '@teambit/legacy.dependency-graph': file:components/legacy/dependency-graph(graphql@15.8.0)
-      '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)
-      '@teambit/legacy.logger': file:components/legacy/logger
-      '@teambit/legacy.utils': file:components/legacy/utils
-      '@teambit/mdx.deps-detectors.detective-mdx': file:scopes/mdx/deps-detectors/detective-mdx
-      '@teambit/node.deps-detectors.detective-es6': 0.0.6
-      '@teambit/styling.deps-detectors.detective-css': 0.0.6(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-less': 0.0.6(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-sass': 0.0.9(postcss@8.4.45)
-      '@teambit/styling.deps-detectors.detective-scss': 0.0.9(postcss@8.4.45)
-      '@teambit/styling.deps-lookups.lookup-styling': 0.0.4
-      '@teambit/toolbox.fs.extension-getter': file:scopes/toolbox/fs/extension-getter
-      '@teambit/toolbox.fs.last-modified': file:scopes/toolbox/fs/last-modified
-      '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.deps-detectors.detective-typescript': 0.0.10(typescript@7.0.2)
       '@teambit/typescript.deps-lookups.lookup-typescript': 0.0.2
       '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1001.0.1)(chai@5.2.1)(typanion@3.14.0)
       '@types/node': 22.10.5
@@ -73660,6 +73656,22 @@ snapshots:
       - react-dom
       - typescript
 
+  '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      prism-react-renderer: 1.3.5(react@19.1.0)
+      react: 19.1.0
+      react-live: 4.1.8(react-dom@19.1.0)(react@19.1.0)
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
+      use-debounce: 9.0.4(react@19.1.0)
+    transitivePeerDependencies:
+      - react-dom
+      - typescript
+
   '@teambit/documenter.code.react-playground@4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/base-ui.input.error': 1.0.3(react-dom@19.1.0)(react@19.1.0)
@@ -73741,9 +73753,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73754,9 +73766,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -73813,6 +73825,19 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.code.react-playground': 4.1.11(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.code-snippet': 4.2.6(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-syntax-highlighter'
@@ -73961,11 +73986,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -73990,11 +74015,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
       '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
       '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
       '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
@@ -74099,6 +74124,35 @@ snapshots:
       '@types/react': 19.2.14
       classnames: 2.5.1
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/documenter.markdown.mdx@0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.0)
+      '@teambit/documenter.markdown.heading': 0.1.10(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.routing.external-link': 4.1.4(react@19.1.0)
+      '@teambit/documenter.ui.block-quote': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.bold': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.image': 4.0.4(react@19.1.0)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
+      '@teambit/documenter.ui.italic': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.ol': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.paragraph': 4.1.8(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.separator': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.sup': 4.0.9(react@19.1.0)
+      '@teambit/documenter.ui.table.base-table': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.table.td': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.table.tr': 4.1.7(react@19.1.0)
+      '@teambit/documenter.ui.ul': 4.1.7(react@19.1.0)
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react-dom'
@@ -74657,6 +74711,19 @@ snapshots:
       - react-dom
       - typescript
 
+  '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/documenter.ui.table-row': 4.1.14(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.2.14
+      react: 19.1.0
+      react-use-dimensions: 1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3)
+      use-debounce: 3.4.3(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - react-dom
+      - typescript
+
   '@teambit/documenter.ui.property-table@4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/documenter.ui.table': 4.1.10(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
@@ -75019,17 +75086,17 @@ snapshots:
       - graphql
       - supports-color
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
     dependencies:
       '@teambit/harmony': 0.4.12
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -75045,17 +75112,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
+  '@teambit/env@file:scopes/envs/env(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)':
     dependencies:
       '@teambit/harmony': 0.4.12
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@6.0.3)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -75084,7 +75151,7 @@ snapshots:
   '@teambit/envs.aspect-docs.envs@file:scopes/envs/aspect-docs/envs(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76215,7 +76282,7 @@ snapshots:
   '@teambit/generator.aspect-docs.generator@file:scopes/generator/aspect-docs/generator(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76695,7 +76762,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.logger@file:scopes/harmony/aspect-docs/logger(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -76715,7 +76782,7 @@ snapshots:
   '@teambit/harmony.aspect-docs.node@file:scopes/harmony/aspect-docs/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -77359,7 +77426,7 @@ snapshots:
   '@teambit/html.aspect-docs.html@file:scopes/html/aspect-docs/html(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -79871,7 +79938,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@teambit/workspace.root-components': 1.0.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -79916,7 +79983,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@18.3.1)
       '@teambit/workspace.root-components': 1.0.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -79961,7 +80028,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants
       '@teambit/legacy.utils': file:components/legacy/utils
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@teambit/workspace.root-components': 1.0.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -80390,7 +80457,7 @@ snapshots:
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@18.3.1)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       lodash: 4.17.21
@@ -81038,9 +81105,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -81052,9 +81119,9 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
       react: 19.1.0
@@ -81114,6 +81181,20 @@ snapshots:
       '@teambit/documenter.ui.inline-code': 0.1.7(react@18.3.1)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@testing-library/react'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/mdx.ui.docs.snippet@0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.16(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/documenter.ui.inline-code': 0.1.7(react@19.1.0)
+      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.1.0)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
@@ -81214,11 +81295,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -81230,11 +81311,11 @@ snapshots:
       - react-dom
       - typescript
 
-  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
-      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
@@ -81284,6 +81365,22 @@ snapshots:
       '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)
       '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@18.3.1)(typescript@6.0.3)
       react: 18.3.1
+    transitivePeerDependencies:
+      - '@mdx-js/react'
+      - '@teambit/mdx.ui.mdx-scope-context'
+      - '@testing-library/react'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/react-syntax-highlighter'
+      - react-dom
+      - typescript
+
+  '@teambit/mdx.ui.mdx-layout@1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
+    dependencies:
+      '@teambit/documenter.markdown.mdx': 0.1.18(@mdx-js/react@3.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/mdx.ui.docs.link': 0.0.505(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
+      '@teambit/mdx.ui.docs.snippet': 0.0.513(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      react: 19.1.0
     transitivePeerDependencies:
       - '@mdx-js/react'
       - '@teambit/mdx.ui.mdx-scope-context'
@@ -82244,7 +82341,7 @@ snapshots:
   '@teambit/pipelines.aspect-docs.builder@file:scopes/pipelines/aspect-docs/builder(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82278,7 +82375,7 @@ snapshots:
   '@teambit/pkg.aspect-docs.pkg@file:scopes/pkg/aspect-docs/pkg(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -82332,7 +82429,7 @@ snapshots:
 
   '@teambit/pkg.entities.registry@0.0.4': {}
 
-  '@teambit/pkg.modules.component-package-name@0.0.56(graphql@15.8.0)':
+  '@teambit/pkg.modules.component-package-name@0.0.56':
     dependencies:
       '@teambit/component-id': 1.2.4
       '@teambit/legacy.constants': 0.0.11
@@ -82341,10 +82438,7 @@ snapshots:
       '@teambit/legacy.utils': 0.0.21
       '@teambit/toolbox.path.path': 0.0.8
     transitivePeerDependencies:
-      - domexception
       - encoding
-      - graphql
-      - supports-color
 
   '@teambit/pkg.modules.component-package-name@file:components/modules/component-package-name(graphql@15.8.0)':
     dependencies:
@@ -82799,7 +82893,7 @@ snapshots:
   '@teambit/preview.aspect-docs.preview@file:scopes/preview/aspect-docs/preview(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -84147,7 +84241,7 @@ snapshots:
   '@teambit/react.aspect-docs.react@file:scopes/react/aspect-docs/react(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -84287,6 +84381,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)':
+    dependencies:
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@5.5.3)
+      eslint: 8.56.0
+      eslint-config-prettier: 8.5.0(eslint@8.56.0)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3)
+      eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
+    transitivePeerDependencies:
+      - jest
+      - supports-color
+      - typescript
+
   '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)':
     dependencies:
       '@types/node': 22.10.5
@@ -84317,26 +84431,6 @@ snapshots:
       eslint: 8.56.0
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
       eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3)
-      eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-    transitivePeerDependencies:
-      - jest
-      - supports-color
-      - typescript
-
-  '@teambit/react.eslint-config-bit-react@file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)':
-    dependencies:
-      '@types/node': 22.10.5
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@7.0.2)
-      '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(typescript@7.0.2)
-      eslint: 8.56.0
-      eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@7.0.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
       react: 19.1.0
@@ -85569,13 +85663,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85613,13 +85707,13 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs-app@file:scopes/react/ui/docs-app(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/design.theme.icons-font': 2.0.29(react-dom@19.1.0)(react@19.1.0)
       '@teambit/design.themes.theme-toggler': 0.1.69(react-dom@19.1.0)(react@19.1.0)
       '@teambit/react.ui.docs.compositions-carousel': file:scopes/react/ui/docs/compositions-carousel(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
-      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/react.ui.docs.docs-content': file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
+      '@teambit/react.ui.docs.properties-table': file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       classnames: 2.5.1
       core-js: 3.13.0
       react: 19.1.0
@@ -85761,10 +85855,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@14.3.1)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85799,10 +85893,10 @@ snapshots:
       - '@types/react-syntax-highlighter'
       - typescript
 
-  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.docs-content@file:scopes/react/ui/docs/docs-content(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/react.ui.error-fallback': file:scopes/react/ui/error-fallback(@testing-library/react@16.3.2)(react-dom@19.1.0)(react@19.1.0)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -85850,11 +85944,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -85866,11 +85960,11 @@ snapshots:
       - graphql
       - typescript
 
-  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/react.ui.docs.properties-table@file:scopes/react/ui/docs/properties-table(@types/react-dom@19.2.3)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)':
     dependencies:
       '@teambit/component.ui.hooks.use-fetch-docs': 0.0.21(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/documenter.ui.linked-heading': 4.1.10(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/documenter.ui.property-table': 4.1.11(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.9.2)
       '@teambit/documenter.ui.section': 4.1.7(react@19.1.0)
       core-js: 3.13.0
       react: 19.1.0
@@ -87665,7 +87759,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -87803,7 +87897,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -87941,7 +88035,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@18.3.1)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -88079,7 +88173,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps
@@ -90130,16 +90224,16 @@ snapshots:
       - '@apollo/client'
       - '@teambit/base-react.navigation.link'
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -90218,16 +90312,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/tester@file:scopes/defender/tester(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-syntax-highlighter@15.5.13)(chai@5.2.1)(graphql@15.8.0)(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@teambit/base-react.navigation.link': 2.0.33(@testing-library/react@16.3.2)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)
       '@teambit/bit-error': 0.0.404
       '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(graphql@15.8.0)
-      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-compare': file:components/ui/test-compare(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/defender.ui.test-compare-section': 0.0.102(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)
-      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/defender.ui.test-page': file:components/ui/test-page(@apollo/client@3.12.2)(@mdx-js/react@3.1.1)(@teambit/base-react.navigation.link@2.0.33)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react-router-dom@6.30.1)(react@19.1.0)(typescript@5.5.3)
       '@teambit/design.ui.pill-label': 0.0.360(react@19.1.0)
       '@teambit/design.ui.tooltip': file:components/ui/tooltip(react-dom@19.1.0)(react@19.1.0)
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@19.1.0)(react@19.1.0)
@@ -90676,7 +90770,7 @@ snapshots:
   '@teambit/typescript.aspect-docs.typescript@file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -90707,15 +90801,6 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.39.0(typescript@6.0.3)
       node-source-walk: 6.0.2
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@teambit/typescript.deps-detectors.detective-typescript@0.0.10(typescript@7.0.2)':
-    dependencies:
-      '@teambit/node.deps-detectors.parser-helper': 0.0.6
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@7.0.2)
-      node-source-walk: 6.0.2
-      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -90852,20 +90937,6 @@ snapshots:
       react: 18.3.1
       typescript: 6.0.3
 
-  '@teambit/typescript.typescript-compiler@5.0.0(react@18.3.1)':
-    dependencies:
-      '@teambit/bit-error': 0.0.404
-      '@teambit/compilation.compiler-task': 1.0.12
-      comment-json: 4.2.3
-      fs-extra: 11.3.4
-      get-tsconfig: 4.2.0
-      glob: 10.4.5
-      globby: 11.1.0
-      lodash: 4.17.21
-      normalize-path: 3.0.0
-      react: 18.3.1
-      typescript: 6.0.3
-
   '@teambit/typescript.typescript-compiler@5.0.0(react@19.1.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
@@ -90878,6 +90949,20 @@ snapshots:
       lodash: 4.17.21
       normalize-path: 3.0.0
       react: 19.1.0
+      typescript: 6.0.3
+
+  '@teambit/typescript.typescript-compiler@5.0.1(react@18.3.1)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/compilation.compiler-task': 1.0.12
+      comment-json: 4.2.3
+      fs-extra: 11.3.4
+      get-tsconfig: 4.2.0
+      glob: 10.4.5
+      globby: 11.1.0
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      react: 18.3.1
       typescript: 6.0.3
 
   '@teambit/typescript.typescript-compiler@5.0.1(react@19.1.0)':
@@ -90904,7 +90989,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -90934,7 +91019,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator
-      '@teambit/typescript.typescript-compiler': 5.0.0(react@19.1.0)
+      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.1.0)
       '@types/node': 22.10.5
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -92783,7 +92868,7 @@ snapshots:
     dependencies:
       url-parse: 1.5.3
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -92836,7 +92921,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -92951,7 +93036,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@7.0.2)(utf-8-validate@5.0.5)(webpack@5.97.1)':
+  '@teambit/ui@file:scopes/ui-foundation/ui(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@16.3.2)(@types/babel__core@7.20.0)(browserslist@4.28.2)(bufferutil@4.0.3)(debug@4.3.4)(eslint@8.56.0)(react-dom@19.1.0)(react-refresh@0.14.2)(react-router-dom@6.30.1)(react@19.1.0)(sass-embedded@1.100.0)(tslib@2.8.1)(typescript@5.5.3)(utf-8-validate@5.0.5)(webpack@5.97.1)':
     dependencies:
       '@apollo/client': 3.12.2(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)(subscriptions-transport-ws@0.9.19)
       '@babel/runtime': 7.23.2
@@ -93004,7 +93089,7 @@ snapshots:
       postcss-normalize: 10.0.0(browserslist@4.28.2)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       resolve-url-loader: 5.0.0
@@ -93161,7 +93246,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@7.0.2)':
+  '@teambit/vue-aspect@file:scopes/vue/vue(react@19.1.0)(typescript@5.5.3)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.1.0)(react@19.1.0)
       '@teambit/api-reference.models.api-reference-model': 0.0.53(react-dom@19.1.0)(react@19.1.0)
@@ -93176,7 +93261,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
-      vue-component-meta: 2.2.10(typescript@7.0.2)
+      vue-component-meta: 2.2.10(typescript@5.5.3)
     transitivePeerDependencies:
       - typescript
 
@@ -94074,7 +94159,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@7.0.2)(utf-8-validate@5.0.5)':
+  '@teambit/webpack@file:scopes/webpack/webpack(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.5)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/harmony': 0.4.12
@@ -94110,7 +94195,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       react: 19.1.0
-      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@7.0.2)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@8.56.0)(typescript@5.5.3)(webpack@5.97.1)
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0)(react@19.1.0)
       stream-browserify: 3.0.0
@@ -94198,7 +94283,7 @@ snapshots:
   '@teambit/workspace.aspect-docs.variants@file:scopes/workspace/aspect-docs/variants(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.1.0)':
     dependencies:
       '@teambit/documenter.theme.theme-compositions': 4.1.5(react-dom@19.1.0)(react@19.1.0)
-      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@7.0.2)
+      '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.3)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.14)(react-dom@19.1.0)(react@19.1.0)(typescript@5.5.3)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.1.0
@@ -96184,15 +96269,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.0(typescript@7.0.2)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
-      '@typescript-eslint/types': 8.39.0
-      debug: 4.3.4(supports-color@9.4.0)
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@4.4.1':
     dependencies:
       '@typescript-eslint/types': 4.4.1
@@ -96229,10 +96305,6 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.39.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
-
-  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@7.0.2)':
-    dependencies:
-      typescript: 7.0.2
 
   '@typescript-eslint/type-utils@6.19.1(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
@@ -96537,22 +96609,6 @@ snapshots:
       semver: 7.7.1
       ts-api-utils: 2.1.0(typescript@6.0.3)
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.39.0(typescript@7.0.2)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.39.0(typescript@7.0.2)
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@7.0.2)
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.3.4(supports-color@9.4.0)
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@7.0.2)
-      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -96973,6 +97029,19 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
+
+  '@vue/language-core@2.2.10(typescript@5.5.3)':
+    dependencies:
+      '@volar/language-core': 2.4.14
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.17
+      alien-signals: 1.0.13
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.5.3
 
   '@vue/language-core@2.2.10(typescript@5.9.2)':
     dependencies:
@@ -100836,6 +100905,17 @@ snapshots:
       eslint: 8.56.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@7.0.2)
+      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.5.3):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.5.3)
+      eslint: 8.56.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(typescript@5.5.3)
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -107467,6 +107547,12 @@ snapshots:
       react: 18.3.1
       typescript: 7.0.2
 
+  react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.5.3):
+    dependencies:
+      '@types/react': 19.2.14
+      react: 19.1.0
+      typescript: 5.5.3
+
   react-use-dimensions@1.2.1(@types/react@19.2.14)(react@19.1.0)(typescript@5.9.2):
     dependencies:
       '@types/react': 19.2.14
@@ -109535,10 +109621,6 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-api-utils@2.1.0(typescript@7.0.2):
-    dependencies:
-      typescript: 7.0.2
-
   ts-easing@0.2.0: {}
 
   ts-graphviz@2.1.6:
@@ -110325,6 +110407,15 @@ snapshots:
   vscode-languageserver-types@3.16.0: {}
 
   vscode-uri@3.1.0: {}
+
+  vue-component-meta@2.2.10(typescript@5.5.3):
+    dependencies:
+      '@volar/typescript': 2.4.14
+      '@vue/language-core': 2.2.10(typescript@5.5.3)
+      path-browserify: 1.0.1
+      vue-component-type-helpers: 2.2.10
+    optionalDependencies:
+      typescript: 5.5.3
 
   vue-component-meta@2.2.10(typescript@5.9.2):
     dependencies:

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -308,7 +308,6 @@ export class SchemaExtractorContext {
 
   async getFilePathByNode(node: Node) {
     const def = await this.tsserver.getDefinition(this.getPath(node), this.getLocation(node));
-
     const firstDef = head(def?.body);
     return firstDef?.file;
   }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -339,7 +339,7 @@
         "@teambit/toolbox.time.time-format": "^0.0.502",
         "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.10",
         "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.2",
-        "@teambit/typescript.typescript-compiler": "^5.0.0",
+        "@teambit/typescript.typescript-compiler": "^5.0.1",
         "@teambit/ui-foundation.ui.constants.z-indexes": "^0.0.504",
         "@teambit/ui-foundation.ui.corner": "^0.0.520",
         "@teambit/ui-foundation.ui.empty-component-gallery": "^0.0.512",


### PR DESCRIPTION
Updates all envs to the new versions built with the fixed typescript-compiler, and bumps the `@teambit/typescript.typescript-compiler` policy in `workspace.jsonc` to `^5.0.1`.

Background: a shared-tsconfig mutation in the compiler leaked `composite: true` into the root tsconfig of single-program builds, so subsequent env programs trusted a stale `tsconfig.tsbuildinfo` and silently skipped emitting the entry `.d.ts` — packages were published without their main declaration file. This PR rebuilds and republishes all affected components with the fixed compiler, restoring complete declaration output.