### PR TITLE
fix: add missing scope to .bitmap entries of newly exported components

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1785,9 +1785,8 @@
     },
     "ui/api-diff-view": {
         "name": "ui/api-diff-view",
-        "scope": "",
+        "scope": "teambit.semantics",
         "version": "0.0.1",
-        "defaultScope": "teambit.semantics",
         "mainFile": "index.ts",
         "rootDir": "components/ui/api-diff-view"
     },
@@ -1954,9 +1953,8 @@
     },
     "ui/components-overview": {
         "name": "ui/components-overview",
-        "scope": "",
+        "scope": "teambit.explorer",
         "version": "0.0.1",
-        "defaultScope": "teambit.explorer",
         "mainFile": "index.ts",
         "rootDir": "components/ui/components-overview"
     },
@@ -1990,17 +1988,15 @@
     },
     "ui/deps-diff-table": {
         "name": "ui/deps-diff-table",
-        "scope": "",
+        "scope": "teambit.dependencies",
         "version": "0.0.1",
-        "defaultScope": "teambit.dependencies",
         "mainFile": "index.ts",
         "rootDir": "components/ui/deps-diff-table"
     },
     "ui/diff-viewer": {
         "name": "ui/diff-viewer",
-        "scope": "",
+        "scope": "teambit.code",
         "version": "0.0.1",
-        "defaultScope": "teambit.code",
         "mainFile": "index.ts",
         "rootDir": "components/ui/diff-viewer"
     },
@@ -2072,9 +2068,8 @@
     },
     "ui/hooks/use-bulk-paged-query": {
         "name": "ui/hooks/use-bulk-paged-query",
-        "scope": "",
+        "scope": "teambit.ui-foundation",
         "version": "0.0.1",
-        "defaultScope": "teambit.ui-foundation",
         "mainFile": "index.ts",
         "rootDir": "components/ui/hooks/use-bulk-paged-query"
     },
@@ -2101,17 +2096,15 @@
     },
     "ui/inline-config-compare": {
         "name": "ui/inline-config-compare",
-        "scope": "",
+        "scope": "teambit.code",
         "version": "0.0.1",
-        "defaultScope": "teambit.code",
         "mainFile": "index.ts",
         "rootDir": "components/ui/inline-config-compare"
     },
     "ui/inline-deps-compare": {
         "name": "ui/inline-deps-compare",
-        "scope": "",
+        "scope": "teambit.code",
         "version": "0.0.1",
-        "defaultScope": "teambit.code",
         "mainFile": "index.ts",
         "rootDir": "components/ui/inline-deps-compare"
     },
@@ -2124,17 +2117,15 @@
     },
     "ui/inline-preview-compare": {
         "name": "ui/inline-preview-compare",
-        "scope": "",
+        "scope": "teambit.preview",
         "version": "0.0.1",
-        "defaultScope": "teambit.preview",
         "mainFile": "index.ts",
         "rootDir": "components/ui/inline-preview-compare"
     },
     "ui/inline-tests-compare": {
         "name": "ui/inline-tests-compare",
-        "scope": "",
+        "scope": "teambit.code",
         "version": "0.0.1",
-        "defaultScope": "teambit.code",
         "mainFile": "index.ts",
         "rootDir": "components/ui/inline-tests-compare"
     },
@@ -2196,9 +2187,8 @@
     },
     "ui/preview-compare": {
         "name": "ui/preview-compare",
-        "scope": "",
+        "scope": "teambit.preview",
         "version": "0.0.1",
-        "defaultScope": "teambit.preview",
         "mainFile": "index.ts",
         "rootDir": "components/ui/preview-compare"
     },


### PR DESCRIPTION
Fixes the `check_circular_dependencies` failure on all PRs since the 2.0.49 release.

The 2.0.49 bump commit set `version: 0.0.1` on 10 new components (from #10378) but left `scope` empty, so on a fresh clone bit treats them as local tags, can't find the objects, and every command errors. The components were in fact exported — the `bit ci merge` export pushed and persisted them, but the central hub response returned empty `successIds`, so the exporter silently skipped the `.bitmap` scope update before the bump commit was pushed.

This PR fills in the missing `scope` fields. Verified: `bit status` and `scripts/circular-deps-check/ci-check.sh` pass.