### PR TITLE
fix: stop overriding the package manager's network concurrency default

### DIFF
--- a/scopes/scope/network/http/http.ts
+++ b/scopes/scope/network/http/http.ts
@@ -176,7 +176,12 @@ export class Http implements Network {
       fetchTimeout: getAsNumber(CFG_FETCH_TIMEOUT) ?? 60000,
       localAddress: obj[CFG_LOCAL_ADDRESS],
       maxSockets: getAsNumber(CFG_MAX_SOCKETS) ?? 15,
-      networkConcurrency: getAsNumber(CFG_NETWORK_CONCURRENCY) ?? 16,
+      // No fallback on purpose: when the user hasn't configured it, leave it
+      // undefined so the package manager applies its own adaptive default
+      // (pnpm: min(96, max(cpuCores * 3, 64))). A hardcoded 16 here overrode
+      // that default on every install and capped fresh resolutions at ~100
+      // requests/second regardless of machine and network capacity.
+      networkConcurrency: getAsNumber(CFG_NETWORK_CONCURRENCY),
       strictSSL: typeof strictSSL === 'string' ? strictSSL === 'true' : strictSSL,
       ca: obj[CFG_NETWORK_CA] ?? obj[CFG_PROXY_CA],
       cafile: obj[CFG_NETWORK_CA_FILE] ?? obj[CFG_PROXY_CA_FILE],


### PR DESCRIPTION
## Summary

`Http.getNetworkConfig()` falls back to `networkConcurrency: 16` when the user hasn't set `network_concurrency` in bit config. Because this layer always produces a number, the merged network config always carries 16, and the package manager's own adaptive default — pnpm resolves `min(96, max(cpuCores × 3, 64))` since June 2026 (pnpm/pnpm#12329) — never applies. Every install (Rust `@pnpm/napi` engine **and** the TS engine alike) is capped at 16 concurrent registry requests, ~100 req/s, regardless of machine or network capacity.

This PR drops the fallback: when unset, the key stays `undefined` and the package manager's default applies. The two downstream consumers are unaffected — `DependencyVersionResolver` keeps its own `?? 16` for its `pLimit`, and `pnpm.package-manager.getNetworkConfig()` only overrides when pnpm config explicitly sets a value.

Measured on a 345-importer workspace (fresh resolution makes ~3,400 metadata round trips): process-wide stack sampling showed the engine idle — zero busy threads — for two-thirds of the resolution wall time, waiting on the 16-permit semaphore. With the pnpm default applied:

| | `networkConcurrency: 16` | pnpm default (64) |
|---|---|---|
| from-scratch resolution | 38–62 s | 12–28 s |
| full from-scratch `bit install` | 131 s | **94.5 s** |

No HTTP 429s and no retry-after-backoff events at 64 against registry.npmjs.org or node-registry.bit.cloud.

Full diagnosis in teambit/bit#10542.

Possible follow-up (not in this PR): the `maxSockets ?? 15` fallback on the line above has the same always-overrides shape; it was masked in these measurements because another config layer supplied 50.

---
Written by an agent (Claude Code, claude-fable-5).
