### PR TITLE
fix(install): accept package names that collide with Node core module names

### DIFF
--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -1,11 +1,11 @@
 import type { Command, CommandOptions } from '@teambit/cli';
-import packageNameValidate from 'validate-npm-package-name';
 import type { WorkspaceDependencyLifecycleType } from '@teambit/dependency-resolver';
 import type { Logger } from '@teambit/logger';
 import chalk from 'chalk';
 import type { Workspace } from '@teambit/workspace';
 import { OutsideWorkspaceError } from '@teambit/workspace';
 import type { InstallMain, WorkspaceInstallOptions } from './install.main.runtime';
+import { extractPackageName, isValidPackageName } from './package-name-utils';
 
 type InstallCmdOptions = {
   type: WorkspaceDependencyLifecycleType;
@@ -106,7 +106,7 @@ automatically imports components, compiles components, links to node_modules, an
     const validPackages = await Promise.all(
       packages.map(async (pkg) => {
         const pkgName = extractPackageName(pkg);
-        if (packageNameValidate(pkgName).validForNewPackages) {
+        if (isValidPackageName(pkgName)) {
           return pkg;
         }
         // if this is a component-id, find the package name and use it instead.
@@ -221,30 +221,4 @@ export function getAnotherInstallRequiredOutput(recurringInstall = false, oldNon
 
   const msg = `${firstPart}${suggestRecurringInstall}\n${envsStr}\n${docsLink}`;
   return chalk.yellow(msg);
-}
-
-function extractPackageName(packageString: string): string {
-  if (!packageString) return '';
-
-  // Handle https and git protocols. We don't allow "file" protocol here. It won't work for the consumer.
-  const allowedPrefixes = ['https://', 'git:', 'git+ssh://', 'git+https://'];
-  if (allowedPrefixes.some((prefix) => packageString.startsWith(prefix))) {
-    return packageString;
-  }
-
-  // If it's a scoped package
-  if (packageString.startsWith('@')) {
-    // Find the second '@' (first is for scope, second is for version/tag)
-    const atIndex = packageString.indexOf('@', 1);
-    if (atIndex === -1) return packageString;
-    const possibleVersion = packageString.slice(atIndex + 1);
-    // If the part after the second '@' contains a slash, it's not a version/tag
-    if (possibleVersion.includes('/')) return packageString;
-    return packageString.slice(0, atIndex);
-  }
-
-  // For unscoped packages, split at the last '@'
-  const lastAtIndex = packageString.lastIndexOf('@');
-  if (lastAtIndex <= 0) return packageString;
-  return packageString.slice(0, lastAtIndex);
 }

--- a/scopes/workspace/install/package-name-utils.spec.ts
+++ b/scopes/workspace/install/package-name-utils.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { extractPackageName, isValidPackageName } from './package-name-utils';
+
+describe('isValidPackageName', () => {
+  it('should accept regular package names', () => {
+    expect(isValidPackageName('lodash')).to.be.true;
+    expect(isValidPackageName('stream-browserify')).to.be.true;
+  });
+  it('should accept scoped package names', () => {
+    expect(isValidPackageName('@types/node')).to.be.true;
+  });
+  it('should accept existing packages whose names collide with Node core module names', () => {
+    expect(isValidPackageName('events')).to.be.true;
+    expect(isValidPackageName('string_decoder')).to.be.true;
+    expect(isValidPackageName('punycode')).to.be.true;
+    expect(isValidPackageName('constants')).to.be.true;
+  });
+  it('should reject invalid package names', () => {
+    expect(isValidPackageName('')).to.be.false;
+    expect(isValidPackageName('.start-with-period')).to.be.false;
+    expect(isValidPackageName('_start-with-underscore')).to.be.false;
+    expect(isValidPackageName('name with spaces')).to.be.false;
+    expect(isValidPackageName('scope/name')).to.be.false;
+  });
+});
+
+describe('extractPackageName', () => {
+  it('should return the name as-is when no version is specified', () => {
+    expect(extractPackageName('lodash')).to.equal('lodash');
+    expect(extractPackageName('@types/node')).to.equal('@types/node');
+  });
+  it('should strip the version from unscoped packages', () => {
+    expect(extractPackageName('lodash@4.17.21')).to.equal('lodash');
+  });
+  it('should strip the version from scoped packages', () => {
+    expect(extractPackageName('@types/node@20.1.0')).to.equal('@types/node');
+  });
+  it('should keep git and https urls as-is', () => {
+    expect(extractPackageName('https://example.com/foo.tgz')).to.equal('https://example.com/foo.tgz');
+    expect(extractPackageName('git+https://example.com/foo.git')).to.equal('git+https://example.com/foo.git');
+  });
+});

--- a/scopes/workspace/install/package-name-utils.ts
+++ b/scopes/workspace/install/package-name-utils.ts
@@ -1,0 +1,41 @@
+import packageNameValidate from 'validate-npm-package-name';
+
+/**
+ * whether the given name is a package name that can be installed from a registry.
+ * names such as "events" or "string_decoder" collide with Node core module names, so they are not
+ * valid for publishing *new* packages, but they exist on npm and are installable, hence the check
+ * against `validForOldPackages` and not `validForNewPackages`.
+ */
+export function isValidPackageName(pkgName: string): boolean {
+  return packageNameValidate(pkgName).validForOldPackages;
+}
+
+/**
+ * extract the package name out of an install argument, stripping the version/tag suffix if exists.
+ * e.g. "lodash@4.17.21" => "lodash", "@types/node@20" => "@types/node".
+ */
+export function extractPackageName(packageString: string): string {
+  if (!packageString) return '';
+
+  // Handle https and git protocols. We don't allow "file" protocol here. It won't work for the consumer.
+  const allowedPrefixes = ['https://', 'git:', 'git+ssh://', 'git+https://'];
+  if (allowedPrefixes.some((prefix) => packageString.startsWith(prefix))) {
+    return packageString;
+  }
+
+  // If it's a scoped package
+  if (packageString.startsWith('@')) {
+    // Find the second '@' (first is for scope, second is for version/tag)
+    const atIndex = packageString.indexOf('@', 1);
+    if (atIndex === -1) return packageString;
+    const possibleVersion = packageString.slice(atIndex + 1);
+    // If the part after the second '@' contains a slash, it's not a version/tag
+    if (possibleVersion.includes('/')) return packageString;
+    return packageString.slice(0, atIndex);
+  }
+
+  // For unscoped packages, split at the last '@'
+  const lastAtIndex = packageString.lastIndexOf('@');
+  if (lastAtIndex <= 0) return packageString;
+  return packageString.slice(0, lastAtIndex);
+}


### PR DESCRIPTION
Fixes item 4 of #10537.

`bit install events string_decoder` failed with `the package name "events" is invalid` because the validation used `validForNewPackages`, which is false for existing npm packages whose names collide with Node core module names (`events`, `string_decoder`, `punycode`, etc.). Changed the check to `validForOldPackages` — every name npm itself accepts for installation. Truly malformed names and component-ids still get the friendly error.

Extracted the validation and package-name parsing into `package-name-utils.ts` and added unit tests.