### PR TITLE
fix: put node-gyp on PATH for dependency build scripts

### DIFF
--- a/e2e/harmony/dependencies/node-gyp.e2e.ts
+++ b/e2e/harmony/dependencies/node-gyp.e2e.ts
@@ -1,0 +1,61 @@
+import chai, { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/legacy.e2e-helper';
+import chaiFs from 'chai-fs';
+chai.use(chaiFs);
+
+/**
+ * The PATH of this process minus every directory holding a `node-gyp`, so the
+ * installed Bit has to supply its own. Without this the test would pass either
+ * way: `npm run` puts the repo's `node_modules/.bin` — which carries a
+ * `node-gyp` bin link — on PATH, and dependency build scripts inherit it.
+ */
+function pathWithoutNodeGyp(): string {
+  return (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .filter((dir) => !['node-gyp', 'node-gyp.cmd'].some((bin) => fs.existsSync(path.join(dir, bin))))
+    .join(path.delimiter);
+}
+
+// The pnpm engine ships no node-gyp and spawns dependency build scripts with
+// Bit's own PATH, so without the node-gyp Bit puts there, `node-gyp rebuild`
+// dies with "node-gyp: command not found".
+(supportNpmCiRegistryTesting ? describe : describe.skip)('a dependency built by node-gyp', function () {
+  this.timeout(0);
+  let helper: Helper;
+  let npmCiRegistry: NpmCiRegistry;
+  before(async () => {
+    helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+    helper.scopeHelper.setWorkspaceWithRemoteScope();
+    helper.workspaceJsonc.setPackageManager(`teambit.dependencies/pnpm`);
+    npmCiRegistry = new NpmCiRegistry(helper);
+    await npmCiRegistry.init();
+
+    npmCiRegistry.setRegistry();
+    // A store of its own, so the package is built by this install rather than
+    // restored from the side-effects cache of an earlier one — which would
+    // reproduce the build output without ever running node-gyp.
+    fs.writeFileSync(
+      path.join(helper.fixtures.scopes.localPath, 'pnpm-workspace.yaml'),
+      `storeDir: ${path.join(helper.fixtures.scopes.localPath, '.pnpm-store')}\n`
+    );
+    helper.extensions.workspaceJsonc.addKeyValToDependencyResolver('allowScripts', {
+      '@pnpm.e2e/has-binding-gyp': true,
+    });
+    helper.command.install('@pnpm.e2e/has-binding-gyp', undefined, undefined, {
+      envVariables: { PATH: pathWithoutNodeGyp() },
+    });
+  });
+  after(() => {
+    npmCiRegistry.destroy();
+    helper.scopeHelper.destroy();
+  });
+  it('should run its install script through node-gyp', () => {
+    // Written by the gyp action in the package's binding.gyp, so it only exists
+    // if `node-gyp rebuild` was found and ran.
+    expect(
+      path.join(helper.fixtures.scopes.localPath, 'node_modules/@pnpm.e2e/has-binding-gyp/generated.js')
+    ).to.be.a.path();
+  });
+});

--- a/e2e/harmony/dependencies/node-gyp.e2e.ts
+++ b/e2e/harmony/dependencies/node-gyp.e2e.ts
@@ -5,17 +5,30 @@ import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/leg
 import chaiFs from 'chai-fs';
 chai.use(chaiFs);
 
+/** The env keys naming PATH, as this platform spells them — `Path` on Windows. */
+function pathEnvKeys(): string[] {
+  const keys = Object.keys(process.env).filter((key) => key.toUpperCase() === 'PATH');
+  return keys.length ? keys : ['PATH'];
+}
+
 /**
- * The PATH of this process minus every directory holding a `node-gyp`, so the
- * installed Bit has to supply its own. Without this the test would pass either
- * way: `npm run` puts the repo's `node_modules/.bin` — which carries a
- * `node-gyp` bin link — on PATH, and dependency build scripts inherit it.
+ * A PATH override holding this process's PATH minus every directory with a
+ * `node-gyp` in it, so the installed Bit has to supply its own. Without it the
+ * test would pass either way: `npm run` puts the repo's `node_modules/.bin` —
+ * which carries a `node-gyp` bin link — on PATH, and dependency build scripts
+ * inherit it.
+ *
+ * Keyed by the casing already in `process.env`, because the command helper
+ * spreads it into a plain object: an override under a casing of its own would
+ * sit alongside the original rather than replacing it.
  */
-function pathWithoutNodeGyp(): string {
-  return (process.env.PATH ?? '')
+function pathWithoutNodeGyp(): Record<string, string> {
+  const keys = pathEnvKeys();
+  const filtered = (process.env[keys[0]] ?? '')
     .split(path.delimiter)
     .filter((dir) => !['node-gyp', 'node-gyp.cmd'].some((bin) => fs.existsSync(path.join(dir, bin))))
     .join(path.delimiter);
+  return Object.fromEntries(keys.map((key) => [key, filtered]));
 }
 
 // The pnpm engine ships no node-gyp and spawns dependency build scripts with
@@ -44,7 +57,7 @@ function pathWithoutNodeGyp(): string {
       '@pnpm.e2e/has-binding-gyp': true,
     });
     helper.command.install('@pnpm.e2e/has-binding-gyp', undefined, undefined, {
-      envVariables: { PATH: pathWithoutNodeGyp() },
+      envVariables: pathWithoutNodeGyp(),
     });
   });
   after(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1756,6 +1756,9 @@ importers:
       node-fetch:
         specifier: 2.6.7
         version: 2.6.7
+      node-gyp:
+        specifier: 11.5.0
+        version: 11.5.0(supports-color@9.4.0)
       node-source-walk:
         specifier: 4.2.0
         version: 4.2.0
@@ -21232,6 +21235,9 @@ importers:
       nerf-dart:
         specifier: 1.0.0
         version: 1.0.0
+      node-gyp:
+        specifier: 11.5.0
+        version: 11.5.0(supports-color@9.4.0)
       normalize-path:
         specifier: 3.0.0
         version: 3.0.0
@@ -30505,6 +30511,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@npmcli/agent@3.0.0':
+    resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -39729,6 +39739,10 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
 
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   abind@1.0.5:
     resolution: {integrity: sha512-dbaEZphdPje0ihqSdWg36Sb8S20TuqQomiz2593oIx+enQ9Q4vDZRjIzhnkWltGRKVKqC28kTribkgRLBexWVQ==}
     engines: {node: '>=6', npm: '>=3'}
@@ -39785,6 +39799,10 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   agentkeepalive@4.1.4:
     resolution: {integrity: sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==}
@@ -41978,10 +41996,17 @@ packages:
     resolution: {integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==}
     engines: {node: '>=8'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   envinfo@7.14.0:
     resolution: {integrity: sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   errno@0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
@@ -42524,6 +42549,9 @@ packages:
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   expose-loader@3.1.0:
     resolution: {integrity: sha512-2RExSo0yJiqP+xiUue13jQa2IHE8kLDzTI7b6kn+vUlBVvlzNSiLDzo4e5Pp5J039usvTUnxZ8sUOhv0Kg15NA==}
@@ -43429,6 +43457,10 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-proxy-middleware@1.3.1:
     resolution: {integrity: sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==}
     engines: {node: '>=8.0.0'}
@@ -43491,6 +43523,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -44002,6 +44038,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -44853,6 +44893,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  make-fetch-happen@14.0.3:
+    resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -45255,12 +45299,20 @@ packages:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass-fetch@4.0.1:
+    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
     engines: {node: '>= 8'}
 
   minipass-pipeline@1.2.4:
     resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
     engines: {node: '>=8'}
 
   minipass@3.3.6:
@@ -45485,6 +45537,11 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  node-gyp@11.5.0:
+    resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -45523,6 +45580,11 @@ packages:
   node.extend@2.0.3:
     resolution: {integrity: sha512-xwADg/okH48PvBmRZyoX8i8GJaKuJ1CqlqotlZOhUio8egD1P5trJupHKBzcPjSF9ifK2gPcEICRBnkfPqQXZw==}
     engines: {node: '>=0.4.0'}
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -46663,6 +46725,10 @@ packages:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
 
+  proc-log@5.0.0:
+    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -46682,6 +46748,10 @@ packages:
   promise-deferred@2.0.4:
     resolution: {integrity: sha512-clITUrRNue0lRawJPyHwCtgcPryJBtGXN6map89kM268+bKgSfh/1ZXOD51+VfDsihzF66m2PBmNOIHETfko4Q==}
     engines: {node: '>= 0.4'}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
 
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
@@ -47352,6 +47422,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -47922,6 +47996,10 @@ packages:
   socks-proxy-agent@6.1.1:
     resolution: {integrity: sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==}
     engines: {node: '>= 10'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
 
   socks@2.8.3:
     resolution: {integrity: sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==}
@@ -49622,6 +49700,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -49960,7 +50043,19 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 bit:
-  depsRequiringBuild: []
+  depsRequiringBuild:
+    - '@apollo/protobufjs@1.2.2'
+    - '@parcel/watcher@2.5.1'
+    - bufferutil@4.0.3
+    - core-js-pure@3.39.0
+    - core-js@3.13.0
+    - core-js@3.37.1
+    - core-js@3.39.0
+    - core-js@3.9.0
+    - es5-ext@0.10.64
+    - esbuild@0.14.29
+    - msgpackr-extract@3.0.4
+    - utf-8-validate@5.0.5
 
 snapshots:
 
@@ -54803,6 +54898,16 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@npmcli/agent@3.0.0(supports-color@9.4.0)':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2(supports-color@9.4.0)
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
+      lru-cache: 10.4.3
+      socks-proxy-agent: 8.0.5(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@npmcli/fs@4.0.0':
     dependencies:
@@ -82286,6 +82391,7 @@ snapshots:
       fs-extra: 10.0.0
       lodash: 4.17.21
       nerf-dart: 1.0.0
+      node-gyp: 11.5.0(supports-color@9.4.0)
       normalize-path: 3.0.0
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
       oxlint-tsgolint: 0.17.0
@@ -82334,6 +82440,7 @@ snapshots:
       fs-extra: 10.0.0
       lodash: 4.17.21
       nerf-dart: 1.0.0
+      node-gyp: 11.5.0(supports-color@9.4.0)
       normalize-path: 3.0.0
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
       oxlint-tsgolint: 0.17.0
@@ -82382,6 +82489,7 @@ snapshots:
       fs-extra: 10.0.0
       lodash: 4.17.21
       nerf-dart: 1.0.0
+      node-gyp: 11.5.0(supports-color@9.4.0)
       normalize-path: 3.0.0
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
       oxlint-tsgolint: 0.17.0
@@ -98024,6 +98132,8 @@ snapshots:
 
   abab@2.0.6: {}
 
+  abbrev@3.0.1: {}
+
   abind@1.0.5: {}
 
   abort-controller@3.0.0:
@@ -98076,6 +98186,8 @@ snapshots:
       debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   agentkeepalive@4.1.4(supports-color@9.4.0):
     dependencies:
@@ -100734,7 +100846,11 @@ snapshots:
 
   env-editor@0.4.2: {}
 
+  env-paths@2.2.1: {}
+
   envinfo@7.14.0: {}
+
+  err-code@2.0.3: {}
 
   errno@0.1.8:
     dependencies:
@@ -101587,6 +101703,8 @@ snapshots:
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
+
+  exponential-backoff@3.1.3: {}
 
   expose-loader@3.1.0(webpack@5.97.1):
     dependencies:
@@ -102891,6 +103009,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@7.0.2(supports-color@9.4.0):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.3.4(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-middleware@1.3.1(debug@4.3.4):
     dependencies:
       '@types/http-proxy': 1.17.16
@@ -103004,6 +103129,13 @@ snapshots:
   https-proxy-agent@5.0.1(supports-color@9.4.0):
     dependencies:
       agent-base: 6.0.2(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6(supports-color@9.4.0):
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
@@ -103402,6 +103534,8 @@ snapshots:
   isbinaryfile@4.0.6: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   isobject@3.0.1: {}
 
@@ -104523,6 +104657,22 @@ snapshots:
     dependencies:
       semver: 7.7.1
 
+  make-fetch-happen@14.0.3(supports-color@9.4.0):
+    dependencies:
+      '@npmcli/agent': 3.0.0(supports-color@9.4.0)
+      cacache: 19.0.1
+      http-cache-semantics: 4.1.1
+      minipass: 7.1.2
+      minipass-fetch: 4.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+      ssri: 12.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
@@ -105244,11 +105394,21 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  minipass-fetch@4.0.1:
+    dependencies:
+      minipass: 7.1.2
+      minipass-sized: 1.0.3
+      minizlib: 3.0.1
+
   minipass-flush@1.0.5:
     dependencies:
       minipass: 3.3.6
 
   minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@1.0.3:
     dependencies:
       minipass: 3.3.6
 
@@ -105502,6 +105662,21 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
+  node-gyp@11.5.0(supports-color@9.4.0):
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.10
+      make-fetch-happen: 14.0.3(supports-color@9.4.0)
+      nopt: 8.1.0
+      proc-log: 5.0.0
+      semver: 7.7.1
+      tar: 7.4.3
+      tinyglobby: 0.2.17
+      which: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   node-int64@0.4.0: {}
 
   node-polyfill-webpack-plugin@4.1.0(webpack@5.97.1):
@@ -105564,6 +105739,10 @@ snapshots:
     dependencies:
       hasown: 2.0.2
       is: 3.3.0
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -107269,6 +107448,8 @@ snapshots:
 
   prismjs@1.29.0: {}
 
+  proc-log@5.0.0: {}
+
   process-nextick-args@2.0.1: {}
 
   process-warning@1.0.0: {}
@@ -107282,6 +107463,11 @@ snapshots:
   promise-deferred@2.0.4:
     dependencies:
       promise: 8.3.0
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
 
   promise@8.3.0:
     dependencies:
@@ -108475,6 +108661,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  retry@0.12.0: {}
+
   retry@0.13.1: {}
 
   reusify@1.0.4: {}
@@ -109134,6 +109322,14 @@ snapshots:
       agent-base: 6.0.2(supports-color@9.4.0)
       debug: 4.3.4(supports-color@9.4.0)
       socks: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socks-proxy-agent@8.0.5(supports-color@9.4.0):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.3.4(supports-color@9.4.0)
+      socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
 
@@ -111203,6 +111399,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.5
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -31,6 +31,7 @@ import { VIRTUAL_STORE_DIR_MAX_LENGTH } from '@teambit/dependencies.pnpm.dep-pat
 import { isEqual } from 'lodash';
 import { pnpmErrorToBitError } from './pnpm-error-to-bit-error';
 import { readConfig } from './read-config';
+import { addNodeGypToPath } from './node-gyp-bin';
 
 /**
  * Packages that are known to have risky or unnecessary build scripts.
@@ -421,6 +422,9 @@ export async function install(
   let dependenciesChanged = false;
   let depsRequiringBuild: DepPath[] | undefined;
   let resolvedStoreDir = storeDir;
+  // Both the install and the `rebuild` below run dependency build scripts, and
+  // they inherit this process's PATH to do it.
+  addNodeGypToPath(logger);
   if (!options.dryRun) {
     let stopReporting: Function | undefined;
     let installPromise: Promise<nodeApi.InstallResult> | undefined;

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -422,10 +422,10 @@ export async function install(
   let dependenciesChanged = false;
   let depsRequiringBuild: DepPath[] | undefined;
   let resolvedStoreDir = storeDir;
-  // Both the install and the `rebuild` below run dependency build scripts, and
-  // they inherit this process's PATH to do it.
-  addNodeGypToPath(logger);
   if (!options.dryRun) {
+    // Dependency build scripts inherit this process's PATH. Set up inside the
+    // guard, so a dry run neither writes the wrapper nor touches the env.
+    addNodeGypToPath(logger);
     let stopReporting: Function | undefined;
     let installPromise: Promise<nodeApi.InstallResult> | undefined;
     let restoreWantedLockfile: (() => Promise<void>) | undefined;
@@ -474,6 +474,8 @@ export async function install(
     // The Rust engine's rebuild rebuilds every build-needing package and does not
     // support the pending / skipIfHasSideEffectsCache selectors of the old engine.
     rebuild: async () => {
+      // Reached without an install of its own after a dry run.
+      addNodeGypToPath(logger);
       let stopReporting: Function | undefined;
       if (!options.hidePackageManagerOutput) {
         stopReporting = initReporter({

--- a/scopes/dependencies/pnpm/node-gyp-bin.spec.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.spec.ts
@@ -16,7 +16,10 @@ describe('addNodeGypToPath()', () => {
   });
 
   after(() => {
-    process.env.PATH = originalPath;
+    // Assigning `undefined` would leave the literal string "undefined" for
+    // every spec that runs after this one in the same process.
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
     // The wrapper lands in the real Bit cache — writing it there is the
     // behavior under test, so it cannot be redirected without stubbing out the
     // thing being asserted. Take it back out; an install that wants it writes

--- a/scopes/dependencies/pnpm/node-gyp-bin.spec.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { execFileSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { delimiter, join } from 'path';
 import { addNodeGypToPath } from './node-gyp-bin';
 
@@ -17,6 +17,11 @@ describe('addNodeGypToPath()', () => {
 
   after(() => {
     process.env.PATH = originalPath;
+    // The wrapper lands in the real Bit cache — writing it there is the
+    // behavior under test, so it cannot be redirected without stubbing out the
+    // thing being asserted. Take it back out; an install that wants it writes
+    // it again, and a script already running one keeps the inode it opened.
+    addedDirs.forEach((dir) => rmSync(dir, { recursive: true, force: true }));
   });
 
   it('appends exactly one directory to PATH', () => {

--- a/scopes/dependencies/pnpm/node-gyp-bin.spec.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { delimiter, join } from 'path';
+import { addNodeGypToPath } from './node-gyp-bin';
+
+describe('addNodeGypToPath()', () => {
+  let originalPath: string | undefined;
+  let addedDirs: string[];
+
+  before(() => {
+    originalPath = process.env.PATH;
+    addNodeGypToPath();
+    const before = (originalPath ?? '').split(delimiter);
+    addedDirs = (process.env.PATH ?? '').split(delimiter).filter((dir) => !before.includes(dir));
+  });
+
+  after(() => {
+    process.env.PATH = originalPath;
+  });
+
+  it('appends exactly one directory to PATH', () => {
+    expect(addedDirs).to.have.lengthOf(1);
+    expect(process.env.PATH?.startsWith(originalPath ?? '')).to.equal(true);
+  });
+
+  it('the appended directory holds a node-gyp that runs', function () {
+    if (process.platform === 'win32') this.skip();
+    const shim = join(addedDirs[0], 'node-gyp');
+    expect(existsSync(shim)).to.equal(true);
+    expect(execFileSync(shim, ['--version'], { encoding: 'utf8' }).trim()).to.match(/^v\d+\./);
+  });
+
+  it('is idempotent', () => {
+    const pathAfterFirstCall = process.env.PATH;
+    addNodeGypToPath();
+    expect(process.env.PATH).to.equal(pathAfterFirstCall);
+  });
+});

--- a/scopes/dependencies/pnpm/node-gyp-bin.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.ts
@@ -1,5 +1,4 @@
-import { createHash } from 'crypto';
-import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
 import { delimiter, dirname, join } from 'path';
 import { CACHE_ROOT } from '@teambit/legacy.constants';
 import type { Logger } from '@teambit/logger';
@@ -21,36 +20,27 @@ import type { Logger } from '@teambit/logger';
  * install binding accepts no `extraBinPaths`.
  */
 export function addNodeGypToPath(logger?: Logger): void {
-  const dir = getShimDir(logger);
-  if (!dir) return;
+  let dir: string;
+  try {
+    dir = writeShims();
+  } catch (err: any) {
+    // Not fatal on its own: only a dependency that actually builds with
+    // node-gyp will fail, and it may well find one elsewhere on PATH. Warn
+    // rather than throw, but warn loudly enough to explain that failure.
+    logger?.consoleWarning(`failed to set up node-gyp, packages that build with it may fail to install: ${err}`);
+    logger?.warn('failed to set up the node-gyp wrapper', err);
+    return;
+  }
   const currentPath = process.env.PATH ?? '';
   if (currentPath.split(delimiter).includes(dir)) return;
   process.env.PATH = currentPath === '' ? dir : `${currentPath}${delimiter}${dir}`;
 }
 
-/** `undefined` before the first attempt, `null` once an attempt has failed. */
-let shimDir: string | null | undefined;
-
-function getShimDir(logger?: Logger): string | null {
-  if (shimDir === undefined) {
-    try {
-      shimDir = createShimDir();
-    } catch (err: any) {
-      shimDir = null;
-      logger?.debug(`failed to set up the node-gyp shim, native packages may fail to build: ${err.message}`);
-    }
-  }
-  return shimDir;
-}
-
-function createShimDir(): string {
+/** Writes the wrappers if they are not already current, and returns their directory. */
+function writeShims(): string {
   const nodeGypJs = require.resolve('node-gyp/bin/node-gyp.js');
   const node = process.execPath;
-  // Keyed by the paths baked into the wrappers, so a Bit upgrade (new node-gyp)
-  // or a different Node interpreter gets its own directory rather than
-  // rewriting scripts that a concurrent install may be executing.
-  const key = createHash('sha1').update(`${node}\n${nodeGypJs}`).digest('hex').slice(0, 12);
-  const dir = join(CACHE_ROOT, 'node-gyp-bin', key);
+  const dir = join(CACHE_ROOT, 'node-gyp-bin');
   // Written on Windows too: the default shell there is cmd.exe, but a
   // `scriptShell` pointing at bash needs the POSIX wrapper.
   writeShim(join(dir, 'node-gyp'), `#!/bin/sh\nexec ${shQuote(node)} ${shQuote(nodeGypJs)} "$@"\n`);
@@ -61,10 +51,12 @@ function createShimDir(): string {
 }
 
 function writeShim(target: string, content: string): void {
-  if (existsSync(target)) return;
+  if (readIfExists(target) === content) return;
   mkdirSync(dirname(target), { recursive: true });
   // Write and rename, so the wrapper only ever appears at its final path fully
-  // written and executable, whichever of several concurrent Bit processes wins.
+  // written and executable. The rename also replaces a wrapper left by an older
+  // Bit without disturbing a script currently executing it, which keeps reading
+  // the inode it opened.
   const tmp = `${target}.${process.pid}.tmp`;
   try {
     writeFileSync(tmp, content);
@@ -72,10 +64,14 @@ function writeShim(target: string, content: string): void {
     renameSync(tmp, target);
   } catch (err) {
     rmSync(tmp, { force: true });
-    // On Windows a rename over an existing file throws; another process getting
-    // there first is a success, not a failure.
-    if (!existsSync(target)) throw err;
+    // Losing a race with another Bit process writing the same content is a
+    // success, not a failure — on Windows its rename would have thrown.
+    if (readIfExists(target) !== content) throw err;
   }
+}
+
+function readIfExists(target: string): string | undefined {
+  return existsSync(target) ? readFileSync(target, 'utf8') : undefined;
 }
 
 function shQuote(value: string): string {

--- a/scopes/dependencies/pnpm/node-gyp-bin.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.ts
@@ -1,0 +1,83 @@
+import { createHash } from 'crypto';
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'fs';
+import { delimiter, dirname, join } from 'path';
+import { CACHE_ROOT } from '@teambit/legacy.constants';
+import type { Logger } from '@teambit/logger';
+
+/**
+ * pnpm's engine spawns dependency lifecycle scripts with the PATH of this
+ * process, extended only with the relevant `node_modules/.bin` directories. It
+ * ships no `node-gyp` of its own, so a native package that shells out to
+ * `node-gyp rebuild` — `node-gyp-build`, `node-pre-gyp`, or a plain
+ * `"install": "node-gyp rebuild"` — fails with `spawn node-gyp ENOENT` unless
+ * something else put `node-gyp` on PATH.
+ *
+ * npm solves this with a wrapper script directory it prepends to PATH, and Bit
+ * used to inherit that wrapper from `@pnpm/npm-lifecycle`. Reproduce it here
+ * over the `node-gyp` that Bit depends on.
+ *
+ * The directory is *appended*, so a `node-gyp` the user installed themselves
+ * still takes precedence, and it goes on `process.env` because the N-API
+ * install binding accepts no `extraBinPaths`.
+ */
+export function addNodeGypToPath(logger?: Logger): void {
+  const dir = getShimDir(logger);
+  if (!dir) return;
+  const currentPath = process.env.PATH ?? '';
+  if (currentPath.split(delimiter).includes(dir)) return;
+  process.env.PATH = currentPath === '' ? dir : `${currentPath}${delimiter}${dir}`;
+}
+
+/** `undefined` before the first attempt, `null` once an attempt has failed. */
+let shimDir: string | null | undefined;
+
+function getShimDir(logger?: Logger): string | null {
+  if (shimDir === undefined) {
+    try {
+      shimDir = createShimDir();
+    } catch (err: any) {
+      shimDir = null;
+      logger?.debug(`failed to set up the node-gyp shim, native packages may fail to build: ${err.message}`);
+    }
+  }
+  return shimDir;
+}
+
+function createShimDir(): string {
+  const nodeGypJs = require.resolve('node-gyp/bin/node-gyp.js');
+  const node = process.execPath;
+  // Keyed by the paths baked into the wrappers, so a Bit upgrade (new node-gyp)
+  // or a different Node interpreter gets its own directory rather than
+  // rewriting scripts that a concurrent install may be executing.
+  const key = createHash('sha1').update(`${node}\n${nodeGypJs}`).digest('hex').slice(0, 12);
+  const dir = join(CACHE_ROOT, 'node-gyp-bin', key);
+  // Written on Windows too: the default shell there is cmd.exe, but a
+  // `scriptShell` pointing at bash needs the POSIX wrapper.
+  writeShim(join(dir, 'node-gyp'), `#!/bin/sh\nexec ${shQuote(node)} ${shQuote(nodeGypJs)} "$@"\n`);
+  if (process.platform === 'win32') {
+    writeShim(join(dir, 'node-gyp.cmd'), `@echo off\r\n"${node}" "${nodeGypJs}" %*\r\n`);
+  }
+  return dir;
+}
+
+function writeShim(target: string, content: string): void {
+  if (existsSync(target)) return;
+  mkdirSync(dirname(target), { recursive: true });
+  // Write and rename, so the wrapper only ever appears at its final path fully
+  // written and executable, whichever of several concurrent Bit processes wins.
+  const tmp = `${target}.${process.pid}.tmp`;
+  try {
+    writeFileSync(tmp, content);
+    chmodSync(tmp, 0o755); // not umask-masked, unlike writeFileSync's `mode`
+    renameSync(tmp, target);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    // On Windows a rename over an existing file throws; another process getting
+    // there first is a success, not a failure.
+    if (!existsSync(target)) throw err;
+  }
+}
+
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/scopes/dependencies/pnpm/node-gyp-bin.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
 import { delimiter, dirname, join } from 'path';
 import { CACHE_ROOT } from '@teambit/legacy.constants';
@@ -36,11 +37,18 @@ export function addNodeGypToPath(logger?: Logger): void {
   process.env.PATH = currentPath === '' ? dir : `${currentPath}${delimiter}${dir}`;
 }
 
-/** Writes the wrappers if they are not already current, and returns their directory. */
+/** Writes the wrappers if they are not already there, and returns their directory. */
 function writeShims(): string {
   const nodeGypJs = require.resolve('node-gyp/bin/node-gyp.js');
   const node = process.execPath;
-  const dir = join(CACHE_ROOT, 'node-gyp-bin');
+  // The wrappers hardcode the two paths, so the directory is keyed by them:
+  // another Bit install, or the same one under a different Node, resolves to a
+  // directory of its own instead of overwriting this one — which would point
+  // concurrent installs at the wrong node-gyp, and would make two Bit versions
+  // used side by side rewrite the wrapper on every install. What accumulates is
+  // two ~100-byte files per distinct pair, so nothing needs pruning.
+  const key = createHash('sha1').update(`${node}\n${nodeGypJs}`).digest('hex').slice(0, 12);
+  const dir = join(CACHE_ROOT, 'node-gyp-bin', key);
   // Written on Windows too: the default shell there is cmd.exe, but a
   // `scriptShell` pointing at bash needs the POSIX wrapper.
   writeShim(join(dir, 'node-gyp'), `#!/bin/sh\nexec ${shQuote(node)} ${shQuote(nodeGypJs)} "$@"\n`);
@@ -54,9 +62,7 @@ function writeShim(target: string, content: string): void {
   if (readIfExists(target) === content) return;
   mkdirSync(dirname(target), { recursive: true });
   // Write and rename, so the wrapper only ever appears at its final path fully
-  // written and executable. The rename also replaces a wrapper left by an older
-  // Bit without disturbing a script currently executing it, which keeps reading
-  // the inode it opened.
+  // written and executable, whichever of several concurrent Bit processes wins.
   const tmp = `${target}.${process.pid}.tmp`;
   try {
     writeFileSync(tmp, content);
@@ -64,8 +70,8 @@ function writeShim(target: string, content: string): void {
     renameSync(tmp, target);
   } catch (err) {
     rmSync(tmp, { force: true });
-    // Losing a race with another Bit process writing the same content is a
-    // success, not a failure — on Windows its rename would have thrown.
+    // Losing that race is a success, not a failure — on Windows the other
+    // process's rename would have thrown.
     if (readIfExists(target) !== content) throw err;
   }
 }

--- a/scopes/dependencies/pnpm/node-gyp-bin.ts
+++ b/scopes/dependencies/pnpm/node-gyp-bin.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs';
 import { delimiter, dirname, join } from 'path';
 import { CACHE_ROOT } from '@teambit/legacy.constants';
 import type { Logger } from '@teambit/logger';
@@ -77,7 +77,14 @@ function writeShim(target: string, content: string): void {
 }
 
 function readIfExists(target: string): string | undefined {
-  return existsSync(target) ? readFileSync(target, 'utf8') : undefined;
+  try {
+    return readFileSync(target, 'utf8');
+  } catch (err: any) {
+    // Read and handle the absence, rather than testing for it first: another
+    // Bit process replacing the wrapper could remove it between the two.
+    if (err.code === 'ENOENT') return undefined;
+    throw err;
+  }
 }
 
 function shQuote(value: string): string {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -555,6 +555,9 @@
         "multimatch": "5.0.0",
         "nerf-dart": "1.0.0",
         "node-fetch": "2.6.7",
+        // put on PATH by teambit.dependencies/pnpm so dependency build scripts
+        // can shell out to it; the pnpm engine ships no node-gyp of its own
+        "node-gyp": "11.5.0",
         "node-source-walk": "4.2.0",
         "normalize-path": "3.0.0",
         "null-loader": "^4.0.1",
@@ -871,6 +874,17 @@
             "react-dom": "-",
             "react-router-dom": "-",
             "core-js": "-"
+          }
+        }
+      }
+    },
+    "scopes/dependencies/pnpm": {
+      "teambit.dependencies/dependency-resolver": {
+        "policy": {
+          "dependencies": {
+            // Not imported: the aspect only puts its bin on PATH for the build
+            // scripts of installed dependencies, so it has to be declared here.
+            "node-gyp": "11.5.0"
           }
         }
       }


### PR DESCRIPTION
## Summary

`bit install` fails on any dependency that shells out to `node-gyp`:

```
.../node_modules/bufferutil install$ node-gyp-build
│ Error: spawn node-gyp ENOENT
bufferutil@4.0.3 install: `node-gyp-build` exited with exit status: 1
```

The pnpm engine spawns dependency lifecycle scripts with the PATH of the bit process plus the relevant `node_modules/.bin` dirs, and ships no `node-gyp` of its own (`pacquet`'s `node_gyp_bin` / `node_gyp_path` lifecycle options exist, but every caller passes `None`). Before #10508 Bit inherited a `node-gyp` wrapper from `@pnpm/npm-lifecycle`, which depends on node-gyp and prepends its wrapper dir to PATH for every script it spawns — the old lockfile had `node-gyp@11.2.0` through it, the new one has none.

So anything that falls back to `node-gyp rebuild` — `node-gyp-build` with no matching prebuild, `node-pre-gyp`, or a plain `"install": "node-gyp rebuild"` — now dies with `spawn node-gyp ENOENT`. It shows up on platforms a package has no prebuild for: `bufferutil@4.0.3` ships no darwin-arm64 prebuild, so every Apple Silicon install of it fails.

## Changes

- **`node-gyp-bin.ts`** (new) — writes an npm-style `node-gyp` wrapper into `<bit-cache>/node-gyp-bin/<key>` and appends it to `process.env.PATH`. Appended rather than prepended, so a node-gyp the user installed themselves still wins. The directory is keyed by a hash of the `node` and `node-gyp.js` paths baked into the wrapper, so a Bit or Node upgrade gets a fresh directory instead of rewriting a script a concurrent install may be executing; wrappers are written temp-file-then-rename. `process.env` is the only lever available here — `InstallOptions` exposes no `extraBinPaths` (only `PackOptions` does).
- **`lynx.ts`** — call it once in `install()`, which covers both `nodeApi.install` and the returned `rebuild`.
- **`workspace.jsonc`** — `node-gyp: 11.5.0` in the root policy and in a new variant for `scopes/dependencies/pnpm`. The variant entry is required: nothing imports node-gyp, so dependency detection would never add it to `@teambit/pnpm`'s package.json. 11.x rather than 13.x because node-gyp 13 requires Node `^22.22.2` and bvm ships 22.22.0.

The complete fix belongs upstream — `pacquet` already has the `node_gyp_bin` plumbing, it just has nothing to point it at — but Bit needs to ship a `node-gyp` either way.

## Test plan

- [x] `npm run lint`
- [x] `bit test scopes/dependencies/pnpm/node-gyp-bin.spec.ts` — 3/3 passing
- [x] Scratch workspace with `bufferutil@1.2.1` (`"install": "node-gyp rebuild"`): released `bit` → `sh: line 1: node-gyp: command not found`, exit 127. Local build → node-gyp runs (`node-gyp -v v11.5.0`, invoked as `<node> <…>/node-gyp.js`); the compile then fails on its own merits, since that 2016 nan addon does not build against Node 22.
- [x] Same workspace with `bufferutil@4.0.9` and `npm_config_build_from_source=true` to force the gyp path: `bit install` completes green and produces a real `build/Release/bufferutil.node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)