### PR TITLE
chore: update core-aspect-env to 2.0.6 (fix docs rendering on react 19)

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -24,21 +24,30 @@
         "scope": "teambit.api-reference",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1125",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
@@ -55,7 +64,10 @@
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -262,14 +274,20 @@
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
@@ -286,7 +304,10 @@
         "scope": "teambit.harmony",
         "version": "2.0.63",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "bit-map": {
         "name": "bit-map",
@@ -300,7 +321,10 @@
         "scope": "teambit.pipelines",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
@@ -317,56 +341,80 @@
         "scope": "teambit.compilation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1454",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.484",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci"
+        "rootDir": "scopes/git/ci",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.578",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1361",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.224",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server"
+        "rootDir": "scopes/mcp/cli-mcp-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
@@ -403,56 +451,80 @@
         "scope": "teambit.cloud",
         "version": "0.0.1392",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.789",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.461",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor"
+        "rootDir": "scopes/component/component-descriptor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component-diff": {
         "name": "component-diff",
@@ -483,7 +555,10 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
@@ -500,21 +575,30 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -528,28 +612,40 @@
         "scope": "teambit.compositions",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1536",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.960",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.242",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store"
+        "rootDir": "components/config-store",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "constants": {
         "name": "constants",
@@ -601,7 +697,10 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "dependency-graph": {
         "name": "dependency-graph",
@@ -615,14 +714,20 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "deps-detectors/detective-mdx": {
         "name": "deps-detectors/detective-mdx",
@@ -636,14 +741,20 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "doc-parser": {
         "name": "doc-parser",
@@ -657,14 +768,20 @@
         "scope": "teambit.docs",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.778",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor"
+        "rootDir": "scopes/harmony/doctor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "e2e-helper": {
         "name": "e2e-helper",
@@ -678,14 +795,20 @@
         "scope": "teambit.workspace",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "empty-env": {
         "name": "empty-env",
         "scope": "teambit.harmony",
         "version": "0.0.8",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/empty-env"
+        "rootDir": "scopes/harmony/empty-env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
@@ -722,21 +845,30 @@
         "scope": "teambit.envs",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint"
+        "rootDir": "scopes/defender/eslint",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
@@ -760,14 +892,20 @@
         "scope": "teambit.scope",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1460",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "extension-data": {
         "name": "extension-data",
@@ -781,14 +919,20 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
@@ -850,7 +994,10 @@
         "scope": "teambit.generator",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "get-bit-version": {
         "name": "get-bit-version",
@@ -867,35 +1014,50 @@
         "scope": "teambit.git",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1365",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
@@ -970,63 +1132,90 @@
         "scope": "teambit.harmony",
         "version": "0.0.806",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer"
+        "rootDir": "scopes/harmony/host-initializer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.92",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize"
+        "rootDir": "scopes/component/internalize",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
@@ -1043,7 +1232,10 @@
         "scope": "teambit.lanes",
         "version": "1.0.1114",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
@@ -1060,14 +1252,20 @@
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "loader": {
         "name": "loader",
@@ -1094,28 +1292,40 @@
         "scope": "teambit.mdx",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/mdx"
+        "rootDir": "scopes/mdx/mdx",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "merge-lanes": {
         "name": "merge-lanes",
         "scope": "teambit.lanes",
         "version": "1.0.1114",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1096",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.879",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -1489,21 +1699,30 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "network": {
         "name": "network",
@@ -1524,28 +1743,40 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "node": {
         "name": "node",
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/node"
+        "rootDir": "scopes/harmony/node",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "notifications": {
         "name": "notifications",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.600",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects"
+        "rootDir": "scopes/scope/objects",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
@@ -1559,7 +1790,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.1364",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1601,7 +1835,10 @@
         "scope": "teambit.pkg",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
@@ -1625,14 +1862,20 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1132",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
@@ -1649,7 +1892,10 @@
         "scope": "teambit.preview",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
@@ -1663,35 +1909,50 @@
         "scope": "teambit.harmony",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "react": {
         "name": "react",
         "scope": "teambit.react",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/react"
+        "rootDir": "scopes/react/react",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "react-router": {
         "name": "react-router",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "readme": {
         "name": "readme",
         "scope": "teambit.mdx",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/readme"
+        "rootDir": "scopes/mdx/readme",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "refactoring": {
         "name": "refactoring",
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "remote-actions": {
         "name": "remote-actions",
@@ -1712,14 +1973,20 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -1740,14 +2007,20 @@
         "scope": "teambit.cloud",
         "version": "0.0.179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple"
+        "rootDir": "scopes/cloud/ripple",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "scope-api": {
         "name": "scope-api",
@@ -1761,14 +2034,20 @@
         "scope": "teambit.workspace",
         "version": "0.0.312",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "snap-distance": {
         "name": "snap-distance",
@@ -1782,7 +2061,10 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "sources": {
         "name": "sources",
@@ -1796,14 +2078,20 @@
         "scope": "teambit.component",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1118",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
@@ -1859,7 +2147,10 @@
         "scope": "teambit.harmony",
         "version": "0.0.1454",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
@@ -1883,14 +2174,20 @@
         "scope": "teambit.scope",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
@@ -1925,7 +2222,10 @@
         "scope": "teambit.component",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
@@ -1949,14 +2249,20 @@
         "scope": "teambit.typescript",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui"
+        "rootDir": "scopes/ui-foundation/ui",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "ui/api-diff-view": {
         "name": "ui/api-diff-view",
@@ -2491,7 +2797,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "utils": {
         "name": "utils",
@@ -2508,70 +2817,100 @@
         "scope": "teambit.defender",
         "version": "0.0.329",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator"
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1629",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.885",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history"
+        "rootDir": "scopes/scope/version-history",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.459",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue"
+        "rootDir": "scopes/vue/vue",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1665",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1093",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1094",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.6": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2163,8 +2163,8 @@ importers:
         specifier: 0.1.13
         version: 0.1.13(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@rspack/dev-middleware@2.0.3)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(bufferutil@4.0.3)(esbuild@0.14.29)(eslint@8.56.0)(jsdom@29.1.1)(less@4.2.1)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(terser@5.37.0)(type-fest@1.4.0)(typescript@5.9.2)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)(yaml@1.10.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
         version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@rspack/core@1.7.8)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.63.6)(type-fest@1.4.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)
@@ -2280,8 +2280,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -7876,7 +7876,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.10(@types/node@22.10.5)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
 
-  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.5:
+  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.6:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -8287,8 +8287,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/cli-reference(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/harmony.modules.concurrency':
         specifier: workspace:*
         version: file:scopes/harmony/modules/concurrency(react-dom@19.2.7)(react@19.2.7)
@@ -17303,8 +17303,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17370,8 +17370,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -17566,8 +17566,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -17717,8 +17717,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17844,8 +17844,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17887,8 +17887,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17951,8 +17951,8 @@ importers:
         specifier: 1.96.22
         version: 1.96.22(@apollo/client@3.12.11)(@teambit/base-react.navigation.link@2.0.33)(@teambit/community.ui.bit-cli.commands-provider@0.0.52)(@teambit/community.ui.community-highlighter@1.96.28)(@testing-library/react@14.3.1)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18022,8 +18022,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18102,8 +18102,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18151,8 +18151,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18200,8 +18200,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18342,8 +18342,8 @@ importers:
         specifier: ^1.96.10
         version: 1.96.10(@apollo/client@3.12.2)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@14.3.1)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18433,8 +18433,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18473,8 +18473,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18528,8 +18528,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -18602,8 +18602,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18630,8 +18630,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18710,8 +18710,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18765,8 +18765,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18811,8 +18811,8 @@ importers:
         specifier: 1.96.6
         version: 1.96.6(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18866,8 +18866,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18969,8 +18969,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -19018,8 +19018,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19097,8 +19097,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19146,8 +19146,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -19189,8 +19189,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -19241,8 +19241,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19324,8 +19324,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19373,8 +19373,8 @@ importers:
         version: 2.2.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19416,8 +19416,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19474,8 +19474,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19538,8 +19538,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19657,8 +19657,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19776,8 +19776,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19825,8 +19825,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19920,8 +19920,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20139,8 +20139,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -20314,8 +20314,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -20403,8 +20403,8 @@ importers:
         specifier: 1.96.11
         version: 1.96.11(@teambit/community.ui.bit-cli.commands-provider@0.0.52)(@teambit/community.ui.community-highlighter@1.96.28)(@testing-library/react@14.3.1)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20467,8 +20467,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20522,8 +20522,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.52)(@teambit/community.ui.community-highlighter@1.96.28)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20562,8 +20562,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20602,8 +20602,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.52)(@teambit/community.ui.community-highlighter@1.96.28)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20639,8 +20639,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20761,8 +20761,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.52)(@teambit/community.ui.community-highlighter@1.96.28)(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20798,8 +20798,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
 
   scopes/dependencies/aspect-docs/dependency-resolver:
     dependencies:
@@ -21003,8 +21003,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -21127,8 +21127,8 @@ importers:
         version: 0.3.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21261,8 +21261,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21349,8 +21349,8 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21416,8 +21416,8 @@ importers:
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -21548,8 +21548,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
 
   scopes/envs/envs:
     dependencies:
@@ -21597,8 +21597,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21695,8 +21695,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -21750,8 +21750,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21851,8 +21851,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21909,8 +21909,8 @@ importers:
         version: 3.28.0(supports-color@9.4.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21949,8 +21949,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22066,8 +22066,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -22130,8 +22130,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -22236,8 +22236,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22368,8 +22368,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -22516,8 +22516,8 @@ importers:
         specifier: 1.96.13
         version: 1.96.13(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/eventsource':
         specifier: ^1.1.15
         version: 1.1.15
@@ -22559,8 +22559,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -22620,8 +22620,8 @@ importers:
         version: 17.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/didyoumean':
         specifier: 1.2.0
         version: 1.2.0
@@ -22700,8 +22700,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22734,8 +22734,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -22798,8 +22798,8 @@ importers:
         version: 2.2.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22829,8 +22829,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
 
   scopes/harmony/express:
     dependencies:
@@ -22863,8 +22863,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -22915,8 +22915,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -23027,8 +23027,8 @@ importers:
         version: 7.5.10(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -23085,8 +23085,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23119,8 +23119,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23159,8 +23159,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23426,8 +23426,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23460,8 +23460,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.is-browser':
         specifier: ^0.0.500
         version: 0.0.500(react-dom@19.2.7)(react@19.2.7)
@@ -23577,8 +23577,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23826,8 +23826,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23887,8 +23887,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23988,8 +23988,8 @@ importers:
         version: 3.24.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24114,8 +24114,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -24145,8 +24145,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24255,8 +24255,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/archiver':
         specifier: 5.3.1
         version: 5.3.1
@@ -24464,8 +24464,8 @@ importers:
         version: 10.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.96.9
         version: 1.96.9(@apollo/client@3.12.11)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react@19.2.14)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -24635,8 +24635,8 @@ importers:
         version: 13.3.2(sass-embedded@1.100.0)(sass@1.63.6)(webpack@5.97.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25124,8 +25124,8 @@ importers:
         version: 5.97.1(esbuild@0.14.29)(uglify-js@3.19.3)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/react.content.react-overview':
         specifier: 1.96.6
         version: 1.96.6(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.1.0)(react@19.1.0)
@@ -25620,8 +25620,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25684,8 +25684,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -25858,8 +25858,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26034,8 +26034,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/scope.content.scope-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.2)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -26089,8 +26089,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -26141,8 +26141,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/chai-subset':
         specifier: 1.3.5
         version: 1.3.5
@@ -27020,8 +27020,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -27057,8 +27057,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -27097,8 +27097,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -27134,8 +27134,8 @@ importers:
         version: 3.2.0(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -27174,8 +27174,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -27214,8 +27214,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -27374,8 +27374,8 @@ importers:
         version: 7.1.0(@types/babel__core@7.20.0)(supports-color@9.4.0)(webpack@5.97.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -27426,8 +27426,8 @@ importers:
         version: 0.7.40
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -27475,8 +27475,8 @@ importers:
         version: 2.2.10(typescript@5.9.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
 
   scopes/webpack/config-mutator:
     dependencies:
@@ -27773,8 +27773,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -27844,8 +27844,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -27896,8 +27896,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -27936,8 +27936,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -28018,8 +28018,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -28212,8 +28212,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -28280,8 +28280,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/workspace.content.variants':
         specifier: 1.96.7
         version: 1.96.7(react@19.2.7)
@@ -28338,8 +28338,8 @@ importers:
         version: 6.30.1(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -28495,8 +28495,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/workspace.content.workspace-overview':
         specifier: 1.96.7
         version: 1.96.7(@apollo/client@3.12.2)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -28577,8 +28577,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
+        specifier: 2.0.6
+        version: 2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -29678,6 +29678,12 @@ packages:
 
   '@bitdev/react.preview.react-docs-template@1.0.14':
     resolution: {integrity: sha512-BoY7huw3hdNHcs+wJhcuOLmnTUU4PVFE3DvxfVzfAhwP9FEQI/ka06b3V5Ghpd2xYNzW4BIlP0aOC1eJjdYNvw==}
+    peerDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7
+
+  '@bitdev/react.preview.react-docs-template@1.0.15':
+    resolution: {integrity: sha512-MWHr/uB9jsrg3FpoLmbSYJWt0y0SToeG2xO1tgxa1LElseqDWmT1OjLR5hLdI/9i2JFqO2ncoIFd1OKDxnCBkA==}
     peerDependencies:
       react: 19.2.7
       react-dom: 19.2.7
@@ -36003,8 +36009,8 @@ packages:
     peerDependencies:
       react: 19.1.0
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.5':
-    resolution: {integrity: sha512-YjtaK+dP5VD8uHTivsAJ94maBTDx6p6rTNZXtw9zkmsxPDqdacFHZY56R4Su9hNG83+Ff+i4GciCWzq+Zr/Hjg==}
+  '@teambit/harmony.envs.core-aspect-env@2.0.6':
+    resolution: {integrity: sha512-c5pDE0uVzWK/a0fef4+AKzkCY0oyKBmZMsbjX+zcukpI9I6zdIod9C1+zAT5nVeJzxAvPzhrZvKl9mIqBHk3zQ==}
 
   '@teambit/harmony.modules.concurrency@0.0.12':
     resolution: {integrity: sha512-j8u/QH0wyXpoEvpATqspcBcf1wbJ70PR82c7Na/ZbOu8+9w2tQIHl+ME7kozcDMX2wSG3cM9TjhJcWS+goRxMg==}
@@ -53578,6 +53584,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@bitdev/react.preview.react-docs-template@1.0.15(react-dom@19.2.7)(react@19.2.7)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-app': 0.0.11
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@bitdev/react.preview.react-docs-template@1.0.5(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
@@ -59360,7 +59374,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(react-dom@19.2.7)(react@19.2.7)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.9)(@babel/traverse@7.29.7)
       chalk: 4.1.2
@@ -59412,7 +59426,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)
       chalk: 4.1.2
@@ -59464,7 +59478,7 @@ snapshots:
       '@teambit/legacy.extension-data': file:components/legacy/extension-data(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.eslint-config-bit-react': file:scopes/react/eslint-config-bit-react(eslint@8.56.0)(jest@29.3.1)(react-dom@19.2.7)(react@19.2.7)(typescript@5.9.2)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.29.7)
       chalk: 4.1.2
@@ -76027,7 +76041,7 @@ snapshots:
       '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(supports-color@9.4.0)(typescript@5.9.2)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(supports-color@9.4.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -78046,7 +78060,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.5(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.6(@babel/core@7.28.3)(@babel/traverse@7.29.7)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(webpack@5.97.1)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
@@ -78056,7 +78070,7 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
       '@babel/runtime': 7.20.0
-      '@bitdev/react.preview.react-docs-template': 1.0.11(react-dom@19.2.7)(react@19.2.7)
+      '@bitdev/react.preview.react-docs-template': 1.0.15(react-dom@19.2.7)(react@19.2.7)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
       '@teambit/compilation.babel-compiler': 1.1.18(react@19.2.7)(supports-color@9.4.0)
       '@teambit/defender.mocha-tester': 1.1.1(@babel/core@7.28.3)(react@19.2.7)(supports-color@9.4.0)
@@ -81683,7 +81697,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/workspace.root-components': 1.0.1
       chai-fs: 1.0.0(chai@4.3.0)
       chalk: 4.1.2
@@ -81729,7 +81743,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants(react-dom@18.3.1)(react@18.3.1)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@18.3.1)(react@18.3.1)
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@18.3.1)
       '@teambit/workspace.root-components': 1.0.1
       chai-fs: 1.0.0(chai@4.3.0)
       chalk: 4.1.2
@@ -81775,7 +81789,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/workspace.root-components': 1.0.1
       chai-fs: 1.0.0(chai@4.3.0)
       chalk: 4.1.2
@@ -81821,7 +81835,7 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/workspace.root-components': 1.0.1
       chai-fs: 1.0.0(chai@5.2.1)
       chalk: 4.1.2
@@ -84198,7 +84212,7 @@ snapshots:
       '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(supports-color@9.4.0)(typescript@5.9.2)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(supports-color@9.4.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -86263,7 +86277,7 @@ snapshots:
       '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(supports-color@9.4.0)(typescript@5.9.2)
       eslint: 8.56.0(supports-color@9.4.0)
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -86339,7 +86353,7 @@ snapshots:
       '@typescript-eslint/parser': 7.1.0(eslint@8.56.0)(supports-color@9.4.0)(typescript@5.9.2)
       eslint: 8.56.0(supports-color@9.4.0)
       eslint-config-prettier: 8.5.0(eslint@8.56.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -88839,7 +88853,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps(react-dom@19.2.7)(react@19.2.7)
@@ -88854,7 +88868,7 @@ snapshots:
       eslint: 8.56.0(supports-color@9.4.0)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(supports-color@9.4.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -88978,7 +88992,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps(react-dom@19.2.7)(react@19.2.7)
@@ -88993,7 +89007,7 @@ snapshots:
       eslint: 8.56.0(supports-color@9.4.0)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(supports-color@9.4.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -89117,7 +89131,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(supports-color@9.4.0)
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps(react-dom@19.2.7)(react@19.2.7)
@@ -89256,7 +89270,7 @@ snapshots:
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema(react-dom@18.3.1)(react@18.3.1)
       '@teambit/toolbox.network.get-port': file:scopes/toolbox/network/get-port(react-dom@18.3.1)(react@18.3.1)
       '@teambit/toolbox.path.path': file:scopes/toolbox/path/path(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@18.3.1)
       '@teambit/ui-foundation.ui.pages.static-error': file:components/ui/pages/static-error(@testing-library/react@14.3.1)(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/webpack.modules.generate-style-loaders': file:scopes/webpack/modules/generate-style-loaders(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
       '@teambit/webpack.modules.style-regexps': file:scopes/webpack/style-regexps(react-dom@18.3.1)(react@18.3.1)
@@ -89271,7 +89285,7 @@ snapshots:
       eslint: 8.56.0(supports-color@9.4.0)
       eslint-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(supports-color@9.4.0)
-      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint-plugin-jest: 27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-mdx: 1.17.1(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
@@ -93920,20 +93934,6 @@ snapshots:
       react: 19.2.7
       typescript: 6.0.3
 
-  '@teambit/typescript.typescript-compiler@5.0.1(react@18.3.1)':
-    dependencies:
-      '@teambit/bit-error': 0.0.404
-      '@teambit/compilation.compiler-task': 1.0.12
-      comment-json: 4.2.3
-      fs-extra: 11.3.4
-      get-tsconfig: 4.2.0
-      glob: 10.4.5
-      globby: 11.1.0
-      lodash: 4.17.21
-      normalize-path: 3.0.0
-      react: 18.3.1
-      typescript: 6.0.3
-
   '@teambit/typescript.typescript-compiler@5.0.1(react@19.1.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
@@ -93962,6 +93962,20 @@ snapshots:
       react: 19.2.7
       typescript: 6.0.3
 
+  '@teambit/typescript.typescript-compiler@5.0.2(react@18.3.1)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/compilation.compiler-task': 1.0.12
+      comment-json: 4.2.3
+      fs-extra: 11.3.4
+      get-tsconfig: 4.2.0
+      glob: 10.4.5
+      globby: 11.1.0
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      react: 18.3.1
+      typescript: 6.0.3
+
   '@teambit/typescript.typescript-compiler@5.0.2(react@19.2.7)':
     dependencies:
       '@teambit/bit-error': 0.0.404
@@ -93986,7 +94000,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server(react-dom@18.3.1)(react@18.3.1)
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@18.3.1)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@18.3.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@18.3.1)(react@18.3.1)
       chai: 4.3.0
       fs-extra: 10.0.0
@@ -94024,7 +94038,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server(react-dom@19.2.7)(react@19.2.7)
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 4.3.0
       fs-extra: 10.0.0
@@ -94062,7 +94076,7 @@ snapshots:
       '@teambit/ts-server': file:scopes/typescript/ts-server(react-dom@19.2.7)(react@19.2.7)
       '@teambit/typescript.aspect-docs.typescript': file:scopes/typescript/aspect-docs/typescript(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/typescript.modules.ts-config-mutator': file:scopes/typescript/modules/ts-config-mutator(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/typescript.typescript-compiler': 5.0.1(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 5.2.1
       fs-extra: 10.0.0
@@ -104844,6 +104858,17 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@5.9.2):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(supports-color@9.4.0)(typescript@5.9.2)
+      eslint: 8.56.0(supports-color@9.4.0)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.1.0(@typescript-eslint/parser@7.1.0)(eslint@8.56.0)(supports-color@9.4.0)(typescript@5.9.2)
+      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-plugin-jest@27.6.3(@typescript-eslint/eslint-plugin@7.1.0)(eslint@8.56.0)(jest@29.3.1)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@6.0.3)
@@ -110892,7 +110917,7 @@ snapshots:
 
   postcss@8.4.18:
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Proposed Changes

- Update `teambit.harmony/envs/core-aspect-env` from 2.0.5 to 2.0.6 for all components that use this env.
- Version 2.0.6 updates `react-docs-template` to 1.0.15. The old template called the legacy `ReactDOM.render`, which react-dom 19 removed. This broke the Overview docs preview on bit.cloud (`m.render is not a function`).
- The new template selects the correct React root API for react-dom 17, 18, and 19.

Only `.bitmap` and the lockfile change. Previews of versions released after this update render correctly; previously published versions keep their old templates.