### PR TITLE
CI probe: run e2e-helper dependents specs on master base

### DIFF
--- a/components/legacy/e2e-helper/e2e-helper.ts
+++ b/components/legacy/e2e-helper/e2e-helper.ts
@@ -1,3 +1,4 @@
+// CI probe: trivial change to re-snap this component and run its dependents' specs on a clean master base.
 import fs from 'fs-extra';
 import { fromPairs } from 'lodash';
 import { FileStatus } from '@teambit/component.modules.merge-helper';


### PR DESCRIPTION
Throwaway: trivial e2e-helper change so bit ci pr re-snaps it and runs dependents' specs (lanes/checkout/snapping) on a pure master base. Diagnosing MochaTest failures seen on another PR. Do not merge.