### PR TITLE
fix(config-merger): sync newer version of same external env despite 3-way pseudo-conflict

### DIFF
--- a/scopes/workspace/config-merger/component-config-merger.spec.ts
+++ b/scopes/workspace/config-merger/component-config-merger.spec.ts
@@ -132,4 +132,66 @@ describe('ComponentConfigMerger', () => {
       expect(mergedConfig[EnvsAspect.id]).to.be.undefined;
     });
   });
+
+  describe('external env version bump on "other" when the lane already inherited an earlier bump', () => {
+    // Reproduces the `bit ci pr` env-version ratchet: the lane forked when the env was 1.0.2, an earlier
+    // config sync moved the lane's snaps to 2.0.0, then main bumped again to 2.0.6. The 3-way now sees a
+    // base that matches neither side (a pseudo-conflict), and with 'ours' the lane used to stick to 2.0.0
+    // forever. Since both sides use the SAME external env and only the version differs, the newer version
+    // must win.
+    let mergedConfig: Record<string, any>;
+    before(() => {
+      const env = 'other-scope.envs/ext-env'; // external env — not a workspace component.
+      const base = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@1.0.2`));
+      const current = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@2.0.0`));
+      const other = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@2.0.6`));
+      mergedConfig = mergeEnvConfig(current, base, other, []);
+    });
+    it("should adopt other's newer version of the same env despite the pseudo-conflict", () => {
+      expect(mergedConfig[EnvsAspect.id]).to.deep.equal({ env: 'other-scope.envs/ext-env@2.0.6' });
+    });
+  });
+
+  describe('external env version pseudo-conflict where the lane is on the NEWER version', () => {
+    // Same conflict shape as above, but the lane's version is ahead of "other" — nothing to adopt.
+    let mergedConfig: Record<string, any>;
+    before(() => {
+      const env = 'other-scope.envs/ext-env';
+      const base = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@1.0.2`));
+      const current = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@2.0.6`));
+      const other = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@2.0.0`));
+      mergedConfig = mergeEnvConfig(current, base, other, []);
+    });
+    it('should keep the lane env (no sync entry)', () => {
+      expect(mergedConfig[EnvsAspect.id]).to.be.undefined;
+    });
+  });
+
+  describe('external env version pseudo-conflict with the "manual" strategy', () => {
+    // The newer-version auto-resolution is scoped to the 'ours' strategy (the `bit ci pr` config sync).
+    // A manual lane-merge should still surface the conflict to the user rather than auto-resolve.
+    let result: ReturnType<ComponentConfigMerger['merge']>;
+    before(() => {
+      const env = 'other-scope.envs/ext-env';
+      const base = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@1.0.2`));
+      const current = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@2.0.0`));
+      const other = new ExtensionDataList(envsEntry(env), envAspectEntry(`${env}@2.0.6`));
+      const merger = new ComponentConfigMerger(
+        'my-scope/some-comp',
+        [],
+        undefined,
+        current,
+        base,
+        other,
+        'lane',
+        'main',
+        noopLogger,
+        'manual' as MergeStrategy
+      );
+      result = merger.merge();
+    });
+    it('should report a conflict instead of auto-resolving', () => {
+      expect(result.hasConflicts()).to.be.true;
+    });
+  });
 });

--- a/scopes/workspace/config-merger/component-config-merger.ts
+++ b/scopes/workspace/config-merger/component-config-merger.ts
@@ -229,6 +229,34 @@ export class ComponentConfigMerger {
     ) {
       return null;
     }
+    // same (external) env on both sides, only the version differs, and the base matches neither side —
+    // the shape basicConfigMerge treats as a conflict. for an env version this is not a genuine conflict:
+    // a 3-way merge cannot tell whether the current lane deliberately picked its version or merely
+    // inherited an earlier sync from "other" (e.g. `bit ci pr` syncing main's env bump onto the PR lane —
+    // after the first synced bump, base matches neither side forever). with the "ours" strategy that
+    // pseudo-conflict silently pins the lane to the old env version for good. env versions are monotonic
+    // in practice, so resolve by taking the newer of the two. a deliberate explicit pin still wins at
+    // component load: config from .bitmap/component-json takes precedence over this merged config (see
+    // aspects-merger merge order). other strategies keep their semantics: "theirs" already adopts the
+    // other side via basicConfigMerge, and "manual" should still surface the conflict to the user.
+    if (
+      !envIdChanged &&
+      this.mergeStrategy === 'ours' &&
+      this.currentEnv.version &&
+      this.otherEnv.version &&
+      semver.valid(this.currentEnv.version) &&
+      semver.valid(this.otherEnv.version)
+    ) {
+      const envStr = (env: EnvData) => (env.version ? `${env.id}@${env.version}` : env.id);
+      const baseEnvStr = this.baseEnv ? envStr(this.baseEnv) : undefined;
+      const isConflictShape =
+        !baseEnvStr || (baseEnvStr !== envStr(this.currentEnv) && baseEnvStr !== envStr(this.otherEnv));
+      if (isConflictShape) {
+        return semver.gt(this.otherEnv.version, this.currentEnv.version)
+          ? { id: EnvsAspect.id, mergedConfig: { env: envStr(this.otherEnv) } }
+          : null;
+      }
+    }
     return this.basicConfigMerge(mergeStrategyParams);
   }
 


### PR DESCRIPTION
## Proposed Changes

`bit ci pr` reuses the PR's lane and syncs config-only changes from main via a 3-way config merge with the `ours` strategy. When main bumps the version of an env (same env id), the sync propagates the bump only the FIRST time: after that, the lane's snaps carry the previously-synced version, so the 3-way base matches neither side. That shape is treated as a conflict, `ours` keeps the lane's version, and the lane sticks to the old env forever — its builds run under a stale env with a dependency graph that mixes old and new component versions (observed as bizarre MochaTest failures in lane builds).

The fix, scoped to `envStrategy` with the `ours` strategy: when both sides use the same external (non-workspace) env and only the semver version differs in a conflict shape, adopt the newer version. A deliberate explicit pin still wins at component load — `.bitmap`/component-json config takes precedence over the synced merged config. `theirs` and `manual` strategies keep their existing semantics (covered by specs).

Verified on a real stale lane: config sync went from 12 to 165 synced components and the lane build became consistent (single env version) and green.