### PR TITLE
fix(ci): a lane's first export of a component the workspace tracks as new no longer halts the sync

### DIFF
--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -1083,10 +1083,10 @@ describe('bit ci sync', function () {
     });
   });
 
-  // The onboarding-quickstart state: `bit add` a brand-new component, commit the versionless
-  // `.bitmap` entry, and let the component's FIRST export happen on a lane. The sync workspace then
-  // tracks the id as new while the lane provides it — the importer skips the id (it "exists"
-  // locally), and the lane merge dies with "unable to merge lane …, the component … was not found".
+  // The onboarding quickstart creates this state: the user runs `bit add`, commits the versionless
+  // `.bitmap` entry, and exports the component for the first time on a lane. The sync workspace
+  // then tracks the id as new while the lane provides it. Without the adoption guard, the lane
+  // fetch drops the id and the lane merge halts with "the component … was not found".
   describe('a lane component that the workspace tracks as new and unexported (first lane export)', () => {
     const LANE = 'first-lane-export';
     let defaultBranch: string;
@@ -1099,7 +1099,7 @@ describe('bit ci sync', function () {
       helper.command.runCmd('git add .');
       helper.command.runCmd('git commit -m "track comp3 as a new component"');
       helper.command.runCmd(`git push origin ${defaultBranch}`);
-      // the developer's clone carries the same versionless entry; the lane holds comp3's first snap
+      // the developer's clone carries the same versionless entry, and the lane holds comp3's first snap
       createLaneWithSnap(
         LANE,
         { 'comp3/index.js': 'module.exports = () => "comp3: lane-snap-1";' },

--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -1083,23 +1083,21 @@ describe('bit ci sync', function () {
     });
   });
 
-  // The onboarding quickstart creates this state: the user runs `bit add`, commits the versionless
-  // `.bitmap` entry, and exports the component for the first time on a lane. The sync workspace
-  // then tracks the id as new while the lane provides it. Without the adoption guard, the lane
-  // fetch drops the id and the lane merge halts with "the component … was not found".
+  // `bit add` + a committed versionless `.bitmap` entry + the component's first export on a lane —
+  // the onboarding quickstart's state, and the one the adoption retry exists for.
   describe('a lane component that the workspace tracks as new and unexported (first lane export)', () => {
     const LANE = 'first-lane-export';
     let defaultBranch: string;
 
     before(() => {
       ({ defaultBranch } = setupSyncWorkspace({ lanes: ['*'] }));
-      // the documented "commit workspace.jsonc and the new .bitmap" onboarding step
+      // commit the versionless `.bitmap` entry, as the onboarding step does
       helper.fs.outputFile('comp3/index.js', 'module.exports = () => "comp3: initial";');
       helper.command.addComponent('comp3');
       helper.command.runCmd('git add .');
       helper.command.runCmd('git commit -m "track comp3 as a new component"');
       helper.command.runCmd(`git push origin ${defaultBranch}`);
-      // the developer's clone carries the same versionless entry, and the lane holds comp3's first snap
+      // the clone carries the same versionless entry
       createLaneWithSnap(
         LANE,
         { 'comp3/index.js': 'module.exports = () => "comp3: lane-snap-1";' },
@@ -1114,9 +1112,9 @@ describe('bit ci sync', function () {
       expect(remoteBranchExists(LANE)).to.be.true;
       const onBranch = fileOnBranch(LANE, 'comp3/index.js');
       expect(onBranch, `comp3/index.js on origin/${LANE}:\n${onBranch}`).to.include('comp3: lane-snap-1');
-      // the branch's `.bitmap` must carry the lane's comp3, not the versionless entry
+      // the branch `.bitmap` must record the lane version, not the versionless entry
       expect(fileOnBranch(LANE, '.bitmap')).to.include(LANE);
-      // the workspace is restored: back on the default branch, on main, with comp3 still tracked
+      // the workspace is restored: back on the default branch, on main
       expect(helper.command.runCmd('git branch --show-current').trim()).to.equal(defaultBranch);
       expect(helper.command.listLanesParsed().currentLane).to.equal('main');
     });

--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -1082,4 +1082,43 @@ describe('bit ci sync', function () {
       expect(output).to.not.match(/wrote \.github[/\\]workflows[/\\]bit-sync\.yml/);
     });
   });
+
+  // The onboarding-quickstart state: `bit add` a brand-new component, commit the versionless
+  // `.bitmap` entry, and let the component's FIRST export happen on a lane. The sync workspace then
+  // tracks the id as new while the lane provides it — the importer skips the id (it "exists"
+  // locally), and the lane merge dies with "unable to merge lane …, the component … was not found".
+  describe('a lane component that the workspace tracks as new and unexported (first lane export)', () => {
+    const LANE = 'first-lane-export';
+    let defaultBranch: string;
+
+    before(() => {
+      ({ defaultBranch } = setupSyncWorkspace({ lanes: ['*'] }));
+      // the documented "commit workspace.jsonc and the new .bitmap" onboarding step
+      helper.fs.outputFile('comp3/index.js', 'module.exports = () => "comp3: initial";');
+      helper.command.addComponent('comp3');
+      helper.command.runCmd('git add .');
+      helper.command.runCmd('git commit -m "track comp3 as a new component"');
+      helper.command.runCmd(`git push origin ${defaultBranch}`);
+      // the developer's clone carries the same versionless entry; the lane holds comp3's first snap
+      createLaneWithSnap(
+        LANE,
+        { 'comp3/index.js': 'module.exports = () => "comp3: lane-snap-1";' },
+        'comp3 first snap'
+      );
+    });
+
+    it('imports the lane instead of halting on "the component was not found"', () => {
+      const { output, exitCode } = syncRun(LANE);
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.include(`${LANE} -> import-lane`);
+      expect(remoteBranchExists(LANE)).to.be.true;
+      const onBranch = fileOnBranch(LANE, 'comp3/index.js');
+      expect(onBranch, `comp3/index.js on origin/${LANE}:\n${onBranch}`).to.include('comp3: lane-snap-1');
+      // the branch's `.bitmap` must carry the lane's comp3, not the versionless entry
+      expect(fileOnBranch(LANE, '.bitmap')).to.include(LANE);
+      // the workspace is restored: back on the default branch, on main, with comp3 still tracked
+      expect(helper.command.runCmd('git branch --show-current').trim()).to.equal(defaultBranch);
+      expect(helper.command.listLanesParsed().currentLane).to.equal('main');
+    });
+  });
 });

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -490,18 +490,21 @@ export class CiMain {
       const errStr = e?.toString() ?? '';
       const laneMissesLocalComponent = errStr.includes('unable to merge lane') && errStr.includes('was not found');
       if (!laneMissesLocalComponent) return failure(e);
-      // the adoption mutates `.bitmap` entries in memory; a failed retry must not leak that
-      // state into the next `.bitmap` write
-      const bitMapSnapshot = this.workspace.bitMap.takeSnapshot();
+      // the adoption mutates `.bitmap` entries in memory; a failed retry rolls the workspace back
+      // by reloading from disk, which the failed switch never wrote
+      const rollback = async (err: any) => {
+        await this.reloadWorkspaceFromDisk();
+        return failure(err);
+      };
       const adopted = await adoptNewComponentsTheLaneProvides(laneName, {
         workspace: this.workspace,
         lanes: this.lanes,
         logger: this.logger,
-      }).catch(() => []);
-      if (!adopted.length) {
-        this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
-        return failure(e);
-      }
+      }).catch((adoptErr) => {
+        this.logger.console(chalk.yellow(`The adoption retry failed: ${adoptErr?.toString() ?? adoptErr}`));
+        return [];
+      });
+      if (!adopted.length) return rollback(e);
       try {
         await doSwitch();
         if (writeAdoptedFiles) {
@@ -509,8 +512,7 @@ export class CiMain {
           await this.checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
         }
       } catch (retryErr: any) {
-        this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
-        return failure(retryErr);
+        return rollback(retryErr);
       }
     }
     return undefined;

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -471,11 +471,12 @@ export class CiMain {
         skipDependencyInstallation: true,
         ...options,
       });
-      // `forceOurs` defaults to true below, so an omitted option means "the workspace files win"
-      // (the `bit ci pr` calls) — only an explicit forceOurs: false import materializes.
+      // `forceOurs` defaults to true in the switch above. An omitted option therefore means that
+      // the workspace files win (the `bit ci pr` calls). Only an import with an explicit
+      // `forceOurs: false` writes the adopted files.
       if (adopted.length && options.forceOurs === false) {
-        // an adopted entry already records the lane's version, so the switch's checkout skips it
-        // as up to date and never writes its files — materialize them explicitly
+        // An adopted entry already records the lane's version. The checkout of the switch skips
+        // it as up to date and does not write its files. Write them here.
         await this.checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
       }
     } catch (e: any) {

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -39,7 +39,7 @@ import { pMapPool } from '@teambit/toolbox.promise.map-pool';
 import { concurrentComponentsLimit } from '@teambit/harmony.modules.concurrency';
 import { extractSkipTasksFromMessage } from './skip-tasks-from-message';
 import { isPullRequestRef } from './pull-request-ref';
-import { adoptNewComponentsTheLaneProvides } from './sync/adopt-lane-new-components';
+import { adoptNewComponentsTheLaneProvides, isLaneMissingComponentError } from './sync/adopt-lane-new-components';
 
 export type CiSwitchLaneOptions = SwitchLaneOptions & {
   /** after an adoption retry, write the adopted components' files (`checkout --reset`) */
@@ -487,13 +487,17 @@ export class CiMain {
         this.logger.console(chalk.yellow(`Lane ${laneName} already checked out, skipping checkout`));
         return undefined;
       }
-      const errStr = e?.toString() ?? '';
-      const laneMissesLocalComponent = errStr.includes('unable to merge lane') && errStr.includes('was not found');
-      if (!laneMissesLocalComponent) return failure(e);
+      if (!isLaneMissingComponentError(e)) return failure(e);
       // the adoption mutates `.bitmap` entries in memory; a failed retry rolls the workspace back
       // by reloading from disk, which the failed switch never wrote
       const rollback = async (err: any) => {
-        await this.reloadWorkspaceFromDisk();
+        await this.reloadWorkspaceFromDisk().catch((reloadErr) => {
+          this.logger.console(
+            chalk.yellow(
+              `Failed to reload the workspace after the adoption retry: ${reloadErr?.toString() ?? reloadErr}`
+            )
+          );
+        });
         return failure(err);
       };
       const adopted = await adoptNewComponentsTheLaneProvides(laneName, {

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -39,6 +39,7 @@ import { pMapPool } from '@teambit/toolbox.promise.map-pool';
 import { concurrentComponentsLimit } from '@teambit/harmony.modules.concurrency';
 import { extractSkipTasksFromMessage } from './skip-tasks-from-message';
 import { isPullRequestRef } from './pull-request-ref';
+import { adoptNewComponentsTheLaneProvides } from './sync/adopt-lane-new-components';
 import type { CiSyncConfig } from './sync/sync-config';
 import { SyncOrchestrator } from './sync/sync-orchestrator';
 import type { GitHostProvider } from './sync/git-host-provider';
@@ -460,12 +461,23 @@ export class CiMain {
   private async switchToLane(laneName: string, options: SwitchLaneOptions = {}): Promise<Error | undefined> {
     this.logger.console(chalk.blue(`Switching to ${laneName}`));
     try {
+      const adopted = await adoptNewComponentsTheLaneProvides(
+        { workspace: this.workspace, lanes: this.lanes, importer: this.importer, logger: this.logger },
+        laneName
+      );
       await this.lanes.switchLanes(laneName, {
         forceOurs: true,
         workspaceOnly: true,
         skipDependencyInstallation: true,
         ...options,
       });
+      // `forceOurs` defaults to true below, so an omitted option means "the workspace files win"
+      // (the `bit ci pr` calls) — only an explicit forceOurs: false import materializes.
+      if (adopted.length && options.forceOurs === false) {
+        // an adopted entry already records the lane's version, so the switch's checkout skips it
+        // as up to date and never writes its files — materialize them explicitly
+        await this.checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
+      }
     } catch (e: any) {
       if (e?.toString().includes('already checked out')) {
         this.logger.console(chalk.yellow(`Lane ${laneName} already checked out, skipping checkout`));

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -40,6 +40,11 @@ import { concurrentComponentsLimit } from '@teambit/harmony.modules.concurrency'
 import { extractSkipTasksFromMessage } from './skip-tasks-from-message';
 import { isPullRequestRef } from './pull-request-ref';
 import { adoptNewComponentsTheLaneProvides } from './sync/adopt-lane-new-components';
+
+export type CiSwitchLaneOptions = SwitchLaneOptions & {
+  /** after an adoption retry, write the adopted components' files (`checkout --reset`) */
+  writeAdoptedFiles?: boolean;
+};
 import type { CiSyncConfig } from './sync/sync-config';
 import { SyncOrchestrator } from './sync/sync-orchestrator';
 import type { GitHostProvider } from './sync/git-host-provider';
@@ -457,35 +462,56 @@ export class CiMain {
    * out" no-op case). Callers that need to react to a specific failure mode (e.g. stale lane) can
    * inspect the returned error; existing callers ignore it and rely on a follow-up
    * `getCurrentLane()` check.
+   *
+   * A switch that fails because the lane provides a component the workspace tracks as new retries
+   * once after adopting the lane's version — see `adoptNewComponentsTheLaneProvides`.
    */
-  private async switchToLane(laneName: string, options: SwitchLaneOptions = {}): Promise<Error | undefined> {
+  private async switchToLane(laneName: string, options: CiSwitchLaneOptions = {}): Promise<Error | undefined> {
     this.logger.console(chalk.blue(`Switching to ${laneName}`));
-    try {
-      const adopted = await adoptNewComponentsTheLaneProvides(
-        { workspace: this.workspace, lanes: this.lanes, importer: this.importer, logger: this.logger },
-        laneName
-      );
-      await this.lanes.switchLanes(laneName, {
+    const { writeAdoptedFiles, ...switchOptions } = options;
+    const doSwitch = () =>
+      this.lanes.switchLanes(laneName, {
         forceOurs: true,
         workspaceOnly: true,
         skipDependencyInstallation: true,
-        ...options,
+        ...switchOptions,
       });
-      // `forceOurs` defaults to true in the switch above. An omitted option therefore means that
-      // the workspace files win (the `bit ci pr` calls). Only an import with an explicit
-      // `forceOurs: false` writes the adopted files.
-      if (adopted.length && options.forceOurs === false) {
-        // An adopted entry already records the lane's version. The checkout of the switch skips
-        // it as up to date and does not write its files. Write them here.
-        await this.checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
-      }
+    const failure = (err: any) => {
+      this.logger.console(chalk.red(`Failed switching to ${laneName}: ${err?.toString() ?? err}`));
+      return err;
+    };
+    try {
+      await doSwitch();
     } catch (e: any) {
       if (e?.toString().includes('already checked out')) {
         this.logger.console(chalk.yellow(`Lane ${laneName} already checked out, skipping checkout`));
         return undefined;
       }
-      this.logger.console(chalk.red(`Failed switching to ${laneName}: ${e?.toString() ?? e}`));
-      return e;
+      const errStr = e?.toString() ?? '';
+      const laneMissesLocalComponent = errStr.includes('unable to merge lane') && errStr.includes('was not found');
+      if (!laneMissesLocalComponent) return failure(e);
+      // the adoption mutates `.bitmap` entries in memory; a failed retry must not leak that
+      // state into the next `.bitmap` write
+      const bitMapSnapshot = this.workspace.bitMap.takeSnapshot();
+      const adopted = await adoptNewComponentsTheLaneProvides(laneName, {
+        workspace: this.workspace,
+        lanes: this.lanes,
+        logger: this.logger,
+      }).catch(() => []);
+      if (!adopted.length) {
+        this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
+        return failure(e);
+      }
+      try {
+        await doSwitch();
+        if (writeAdoptedFiles) {
+          // the retried switch skips an id already at the lane's version, so its files are still unwritten
+          await this.checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
+        }
+      } catch (retryErr: any) {
+        this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
+        return failure(retryErr);
+      }
     }
     return undefined;
   }
@@ -495,7 +521,7 @@ export class CiMain {
    * throwing. `switchToLane` spreads caller options AFTER its defaults, so `forceOurs: true` is
    * overridable — the sync import direction depends on that. Do not reorder that spread.
    */
-  async switchToLaneForSync(laneName: string, options: SwitchLaneOptions = {}): Promise<Error | undefined> {
+  async switchToLaneForSync(laneName: string, options: CiSwitchLaneOptions = {}): Promise<Error | undefined> {
     return this.switchToLane(laneName, options);
   }
 

--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -39,7 +39,7 @@ import { pMapPool } from '@teambit/toolbox.promise.map-pool';
 import { concurrentComponentsLimit } from '@teambit/harmony.modules.concurrency';
 import { extractSkipTasksFromMessage } from './skip-tasks-from-message';
 import { isPullRequestRef } from './pull-request-ref';
-import { adoptNewComponentsTheLaneProvides, isLaneMissingComponentError } from './sync/adopt-lane-new-components';
+import { adoptAndRetrySwitch, isLaneMissingComponentError } from './sync/adopt-lane-new-components';
 
 export type CiSwitchLaneOptions = SwitchLaneOptions & {
   /** after an adoption retry, write the adopted components' files (`checkout --reset`) */
@@ -488,36 +488,14 @@ export class CiMain {
         return undefined;
       }
       if (!isLaneMissingComponentError(e)) return failure(e);
-      // the adoption mutates `.bitmap` entries in memory; a failed retry rolls the workspace back
-      // by reloading from disk, which the failed switch never wrote
-      const rollback = async (err: any) => {
-        await this.reloadWorkspaceFromDisk().catch((reloadErr) => {
-          this.logger.console(
-            chalk.yellow(
-              `Failed to reload the workspace after the adoption retry: ${reloadErr?.toString() ?? reloadErr}`
-            )
-          );
-        });
-        return failure(err);
-      };
-      const adopted = await adoptNewComponentsTheLaneProvides(laneName, {
+      const retryErr = await adoptAndRetrySwitch(laneName, e, doSwitch, writeAdoptedFiles, {
         workspace: this.workspace,
         lanes: this.lanes,
         logger: this.logger,
-      }).catch((adoptErr) => {
-        this.logger.console(chalk.yellow(`The adoption retry failed: ${adoptErr?.toString() ?? adoptErr}`));
-        return [];
+        checkout: this.checkout,
+        reloadWorkspace: () => this.reloadWorkspaceFromDisk(),
       });
-      if (!adopted.length) return rollback(e);
-      try {
-        await doSwitch();
-        if (writeAdoptedFiles) {
-          // the retried switch skips an id already at the lane's version, so its files are still unwritten
-          await this.checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
-        }
-      } catch (retryErr: any) {
-        return rollback(retryErr);
-      }
+      if (retryErr) return failure(retryErr);
     }
     return undefined;
   }

--- a/scopes/git/ci/sync/adopt-lane-new-components.ts
+++ b/scopes/git/ci/sync/adopt-lane-new-components.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+import type { ComponentID } from '@teambit/component-id';
+import { ComponentIdList } from '@teambit/component-id';
+import type { ImporterMain } from '@teambit/importer';
+import type { LanesMain } from '@teambit/lanes';
+import type { Logger } from '@teambit/logger';
+import type { Workspace } from '@teambit/workspace';
+
+/**
+ * A new (versionless) `.bitmap` entry whose id the target lane also carries breaks the lane
+ * switch twice over: the entry has no scope, so the legacy layer reads the component as "local,
+ * never exported" — the lane fetch's default filter then drops the id and the lane merge dies
+ * with `unable to merge lane …, the component … was not found`, and every import on the way
+ * refuses to fetch a "local" id from the remote. The onboarding quickstart manufactures exactly
+ * this state: `bit add` a component, commit `.bitmap`, and let the component's first export
+ * happen on a lane.
+ *
+ * Adopt the lane's version INTO each shadowing entry (in memory only — a failed switch must not
+ * rewrite `.bitmap` on disk): the entry keeps its rootDir and config, stops reading as local, and
+ * the objects import below succeeds through `importMany`'s existing `includeUnexported` escape
+ * hatch (the ids come from the lane object, so they exist on the remote by construction).
+ * Matching is scope+name, so a same-named new component from another scope stays untouched.
+ *
+ * Returns the adopted ids at the lane's version. The switch skips them as already up to date, so
+ * an importing caller must materialize their files afterwards (`checkout --reset`).
+ */
+export async function adoptNewComponentsTheLaneProvides(
+  deps: { workspace: Workspace; lanes: LanesMain; importer: ImporterMain; logger: Logger },
+  laneName: string
+): Promise<ComponentID[]> {
+  const { workspace, lanes, importer, logger } = deps;
+  const noneAdopted: ComponentID[] = [];
+  const newIds = await workspace.newComponentIds();
+  if (!newIds.length) return noneAdopted;
+  const laneId = await lanes.parseLaneId(laneName);
+  if (laneId.isDefault()) return noneAdopted;
+  const laneData = (await lanes.getLanes({ remote: laneId.scope, name: laneId.name }).catch(() => []))[0];
+  const laneComps = [...(laneData?.components ?? []), ...(laneData?.updateDependents ?? [])];
+  const shadowed = laneComps.filter((laneComp) => newIds.some((newId) => laneComp.id.isEqualWithoutVersion(newId)));
+  if (!shadowed.length) return noneAdopted;
+  logger.console(
+    chalk.blue(
+      `Lane ${laneId.toString()} provides ${shadowed.length} component(s) this workspace tracks as new — ` +
+        `adopting the lane's version: ${shadowed.map((c) => c.id.toStringWithoutVersion()).join(', ')}`
+    )
+  );
+  const bitMap = workspace.consumer.bitMap;
+  shadowed.forEach((laneComp) => {
+    const componentMap = bitMap.getComponentIfExist(laneComp.id, { ignoreVersion: true });
+    if (!componentMap) return;
+    bitMap.updateComponentId(laneComp.id.changeVersion(laneComp.head));
+    componentMap.onLanesOnly = true;
+  });
+  // the workspace caches component lists computed from the pre-adoption `.bitmap`
+  await workspace.clearCache();
+  const lane = await importer.importLaneObject(laneId);
+  const adoptedIds = shadowed.map((c) => c.id.changeVersion(c.head));
+  await workspace.scope.legacyScope.scopeImporter.importMany({
+    ids: ComponentIdList.fromArray(adoptedIds),
+    lane,
+    includeUnexported: true,
+    reason: `${laneId.toString()} provides component(s) this workspace tracks as new`,
+  });
+  return adoptedIds;
+}

--- a/scopes/git/ci/sync/adopt-lane-new-components.ts
+++ b/scopes/git/ci/sync/adopt-lane-new-components.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import type { CheckoutMain } from '@teambit/checkout';
 import type { ComponentID } from '@teambit/component-id';
 import { ComponentIdList } from '@teambit/component-id';
 import type { LanesMain } from '@teambit/lanes';
@@ -10,6 +11,11 @@ export type AdoptLaneNewComponentsDeps = {
   workspace: Workspace;
   lanes: LanesMain;
   logger: Logger;
+};
+
+export type AdoptRetryDeps = AdoptLaneNewComponentsDeps & {
+  checkout: CheckoutMain;
+  reloadWorkspace: () => Promise<void>;
 };
 
 /**
@@ -65,4 +71,58 @@ export async function adoptNewComponentsTheLaneProvides(
     reason: `lane ${laneId.toString()} provides component(s) this workspace tracks as new`,
   });
   return adoptedIds;
+}
+
+/**
+ * Runs after a switch failed with the missing-component marker: adopt the lane's versions, then
+ * retry the switch once. Returns undefined on success, and the error to report on failure. A
+ * failed retry reloads the workspace from disk — the failed switch never wrote to it — so the
+ * in-memory adoption disappears completely (including `updatedIds` and the changed flag).
+ */
+export async function adoptAndRetrySwitch(
+  laneName: string,
+  originalErr: Error,
+  doSwitch: () => Promise<unknown>,
+  writeAdoptedFiles: boolean | undefined,
+  deps: AdoptRetryDeps
+): Promise<Error | undefined> {
+  const { logger, reloadWorkspace } = deps;
+  const rollback = async (err: Error) => {
+    await reloadWorkspace().catch((reloadErr) => {
+      logger.console(
+        chalk.yellow(`Failed to reload the workspace after the adoption retry: ${reloadErr?.toString() ?? reloadErr}`)
+      );
+    });
+    return err;
+  };
+  const adopted = await adoptNewComponentsTheLaneProvides(laneName, deps).catch((adoptErr) => {
+    logger.console(chalk.yellow(`The adoption retry failed: ${adoptErr?.toString() ?? adoptErr}`));
+    return [];
+  });
+  if (!adopted.length) return rollback(originalErr);
+  try {
+    await doSwitch();
+    // the retried switch skips an id already at the lane's version, so its files are still unwritten
+    if (writeAdoptedFiles) await writeFilesKeepingConfig(adopted, deps);
+    return undefined;
+  } catch (retryErr: any) {
+    return rollback(retryErr);
+  }
+}
+
+/**
+ * `checkout --reset` writes the files of an entry that already records the target version, but its
+ * `resetConfig` also deletes the entry's `.bitmap` config — keep the config across the call.
+ */
+async function writeFilesKeepingConfig(adopted: ComponentID[], { workspace, checkout }: AdoptRetryDeps) {
+  const bitMap = workspace.consumer.bitMap;
+  const entryConfig = (id: ComponentID) => bitMap.getComponentIfExist(id, { ignoreVersion: true })?.config;
+  const configs = adopted.map((id) => ({ id, config: entryConfig(id) }));
+  await checkout.checkout({ ids: adopted, reset: true, skipNpmInstall: true });
+  configs.forEach(({ id, config }) => {
+    const entry = bitMap.getComponentIfExist(id, { ignoreVersion: true });
+    if (!config || !entry || entry.config) return;
+    entry.config = config;
+    bitMap.markAsChanged();
+  });
 }

--- a/scopes/git/ci/sync/adopt-lane-new-components.ts
+++ b/scopes/git/ci/sync/adopt-lane-new-components.ts
@@ -7,22 +7,26 @@ import type { Logger } from '@teambit/logger';
 import type { Workspace } from '@teambit/workspace';
 
 /**
- * A new (versionless) `.bitmap` entry whose id the target lane also carries breaks the lane
- * switch twice over: the entry has no scope, so the legacy layer reads the component as "local,
- * never exported" — the lane fetch's default filter then drops the id and the lane merge dies
- * with `unable to merge lane …, the component … was not found`, and every import on the way
- * refuses to fetch a "local" id from the remote. The onboarding quickstart manufactures exactly
- * this state: `bit add` a component, commit `.bitmap`, and let the component's first export
- * happen on a lane.
+ * A lane switch halts when the target lane carries a component that the workspace tracks as a
+ * new component. A versionless `.bitmap` entry has no scope, so the legacy layer reads the
+ * component as local and not exported. The default filter of `importMany` then drops the id from
+ * the lane fetch, and the lane merge halts with `unable to merge lane …, the component … was not
+ * found`. Each later import also refuses to fetch a "local" id from the remote. The onboarding
+ * quickstart creates this state: the user runs `bit add`, commits `.bitmap`, and exports the
+ * component for the first time on a lane.
  *
- * Adopt the lane's version INTO each shadowing entry (in memory only — a failed switch must not
- * rewrite `.bitmap` on disk): the entry keeps its rootDir and config, stops reading as local, and
- * the objects import below succeeds through `importMany`'s existing `includeUnexported` escape
- * hatch (the ids come from the lane object, so they exist on the remote by construction).
- * Matching is scope+name, so a same-named new component from another scope stays untouched.
+ * This function adopts the lane's version into each shadowing entry, in memory only. The entry
+ * keeps its rootDir and its config, and the legacy layer no longer reads it as local. A failed
+ * switch does not change `.bitmap` on disk. The function then imports the objects of the adopted
+ * components with the existing `includeUnexported` option of `importMany`. The ids come from the
+ * lane object, so they exist on the remote.
  *
- * Returns the adopted ids at the lane's version. The switch skips them as already up to date, so
- * an importing caller must materialize their files afterwards (`checkout --reset`).
+ * The match compares scope and name. A new component with the same name from a different scope
+ * does not change.
+ *
+ * The function returns the adopted ids at the lane's version. The switch skips an entry that
+ * already records the target version, so an importing caller must write the files afterwards
+ * (`checkout --reset`).
  */
 export async function adoptNewComponentsTheLaneProvides(
   deps: { workspace: Workspace; lanes: LanesMain; importer: ImporterMain; logger: Logger },

--- a/scopes/git/ci/sync/adopt-lane-new-components.ts
+++ b/scopes/git/ci/sync/adopt-lane-new-components.ts
@@ -1,69 +1,58 @@
 import chalk from 'chalk';
 import type { ComponentID } from '@teambit/component-id';
 import { ComponentIdList } from '@teambit/component-id';
-import type { ImporterMain } from '@teambit/importer';
 import type { LanesMain } from '@teambit/lanes';
 import type { Logger } from '@teambit/logger';
 import type { Workspace } from '@teambit/workspace';
+import { capEntries } from './lane-sync-executor';
+
+export type AdoptLaneNewComponentsDeps = {
+  workspace: Workspace;
+  lanes: LanesMain;
+  logger: Logger;
+};
 
 /**
- * A lane switch halts when the target lane carries a component that the workspace tracks as a
- * new component. A versionless `.bitmap` entry has no scope, so the legacy layer reads the
- * component as local and not exported. The default filter of `importMany` then drops the id from
- * the lane fetch, and the lane merge halts with `unable to merge lane …, the component … was not
- * found`. Each later import also refuses to fetch a "local" id from the remote. The onboarding
- * quickstart creates this state: the user runs `bit add`, commits `.bitmap`, and exports the
- * component for the first time on a lane.
- *
- * This function adopts the lane's version into each shadowing entry, in memory only. The entry
- * keeps its rootDir and its config, and the legacy layer no longer reads it as local. A failed
- * switch does not change `.bitmap` on disk. The function then imports the objects of the adopted
- * components with the existing `includeUnexported` option of `importMany`. The ids come from the
- * lane object, so they exist on the remote.
- *
- * The match compares scope and name. A new component with the same name from a different scope
- * does not change.
- *
- * The function returns the adopted ids at the lane's version. The switch skips an entry that
- * already records the target version, so an importing caller must write the files afterwards
- * (`checkout --reset`).
+ * A versionless `.bitmap` entry reads as local and unexported, so a lane fetch drops its id and
+ * the lane merge fails with `the component … was not found`. Adopt the lane's version into each
+ * such entry, and import the adopted objects (`includeUnexported`, because the entries made them
+ * look local). The mutation is in memory; the caller owns the rollback on a failed retry.
+ * The returned ids already record the lane's version, so a retried switch skips their files; an
+ * importing caller must write them (`checkout --reset`).
  */
 export async function adoptNewComponentsTheLaneProvides(
-  deps: { workspace: Workspace; lanes: LanesMain; importer: ImporterMain; logger: Logger },
-  laneName: string
+  laneName: string,
+  { workspace, lanes, logger }: AdoptLaneNewComponentsDeps
 ): Promise<ComponentID[]> {
-  const { workspace, lanes, importer, logger } = deps;
-  const noneAdopted: ComponentID[] = [];
   const newIds = await workspace.newComponentIds();
-  if (!newIds.length) return noneAdopted;
+  if (!newIds.length) return [];
   const laneId = await lanes.parseLaneId(laneName);
-  if (laneId.isDefault()) return noneAdopted;
-  const laneData = (await lanes.getLanes({ remote: laneId.scope, name: laneId.name }).catch(() => []))[0];
-  const laneComps = [...(laneData?.components ?? []), ...(laneData?.updateDependents ?? [])];
-  const shadowed = laneComps.filter((laneComp) => newIds.some((newId) => laneComp.id.isEqualWithoutVersion(newId)));
-  if (!shadowed.length) return noneAdopted;
+  if (laneId.isDefault()) return [];
+  const lane = await lanes.importLaneObject(laneId);
+  const newIdsList = ComponentIdList.fromArray(newIds);
+  const adoptedIds = lane
+    .toComponentIdsIncludeUpdateDependents()
+    .filter((laneCompId) => newIdsList.hasWithoutVersion(laneCompId));
+  if (!adoptedIds.length) return [];
   logger.console(
     chalk.blue(
-      `Lane ${laneId.toString()} provides ${shadowed.length} component(s) this workspace tracks as new — ` +
-        `adopting the lane's version: ${shadowed.map((c) => c.id.toStringWithoutVersion()).join(', ')}`
+      `Adopting the lane's version for component(s) this workspace tracks as new: ` +
+        capEntries(adoptedIds.map((id) => id.toStringWithoutVersion())).join(', ')
     )
   );
   const bitMap = workspace.consumer.bitMap;
-  shadowed.forEach((laneComp) => {
-    const componentMap = bitMap.getComponentIfExist(laneComp.id, { ignoreVersion: true });
-    if (!componentMap) return;
-    bitMap.updateComponentId(laneComp.id.changeVersion(laneComp.head));
-    componentMap.onLanesOnly = true;
+  adoptedIds.forEach((id) => {
+    bitMap.updateComponentId(id);
+    bitMap.setOnLanesOnly(id, true);
   });
-  // the workspace caches component lists computed from the pre-adoption `.bitmap`
-  await workspace.clearCache();
-  const lane = await importer.importLaneObject(laneId);
-  const adoptedIds = shadowed.map((c) => c.id.changeVersion(c.head));
+  // cached component lists still reflect the pre-adoption `.bitmap`
+  workspace.clearAllComponentsCache();
   await workspace.scope.legacyScope.scopeImporter.importMany({
     ids: ComponentIdList.fromArray(adoptedIds),
     lane,
     includeUnexported: true,
-    reason: `${laneId.toString()} provides component(s) this workspace tracks as new`,
+    includeUpdateDependents: true,
+    reason: `lane ${laneId.toString()} provides component(s) this workspace tracks as new`,
   });
   return adoptedIds;
 }

--- a/scopes/git/ci/sync/adopt-lane-new-components.ts
+++ b/scopes/git/ci/sync/adopt-lane-new-components.ts
@@ -13,6 +13,16 @@ export type AdoptLaneNewComponentsDeps = {
 };
 
 /**
+ * The lane merge (`sources.mergeLane` in the legacy scope) throws a plain Error with this wording
+ * when a lane component's objects are absent. A typed error needs a change outside the ci aspect;
+ * the stale-lane recovery of `bit ci pr` matches the same text.
+ */
+export function isLaneMissingComponentError(err: unknown): boolean {
+  const msg = (err as Error)?.message ?? String(err ?? '');
+  return msg.includes('unable to merge lane') && msg.includes('was not found');
+}
+
+/**
  * A versionless `.bitmap` entry reads as local and unexported, so a lane fetch drops its id and
  * the lane merge fails with `the component … was not found`. Adopt the lane's version into each
  * such entry, and import the adopted objects (`includeUnexported`, because the entries made them

--- a/scopes/git/ci/sync/lane-sync-executor.ts
+++ b/scopes/git/ci/sync/lane-sync-executor.ts
@@ -1142,7 +1142,11 @@ export class LaneSyncExecutor {
       }
     }
 
-    const switchErr = await this.deps.ci.switchToLaneForSync(laneIdStr, { forceOurs: false, forceTheirs: true });
+    const switchErr = await this.deps.ci.switchToLaneForSync(laneIdStr, {
+      forceOurs: false,
+      forceTheirs: true,
+      writeAdoptedFiles: true,
+    });
     if (switchErr) return switchErr;
 
     // Verify before the caller commits a `.bitmap` asserting this lane's content.


### PR DESCRIPTION
## The bug, step by step

1. The user runs `bit add my-comp`. The new `.bitmap` entry has **no version and no scope**. It means: "this component is new, only this workspace has it, nobody exported it".
2. The user commits `.bitmap` to git main. The onboarding quickstart instructs exactly this.
3. The user creates a lane, snaps `my-comp`, and exports. The first version of `my-comp` in the world now lives **on the lane**. Git main's `.bitmap` still says "new and unexported".
4. A CI run (or any fresh clone) now switches onto the lane, for example through `bit ci sync`.

The component now has two identities that contradict each other. The git side says "unborn". The lane says "born here". Bit believes the git side:

- `scope.isExported` reads a scopeless entry as **local — never fetch it from a remote**.
- The lane fetch (`importMany`) therefore drops the id, and the lane merge halts with `unable to merge lane <lane>, the component <id> was not found`.
- Every later import refuses the id for the same reason and throws `ComponentNotFound`.

In `bit ci pr`, the same halt matches the stale-lane marker in the reuse path. The destructive lane recovery can then delete a healthy remote lane because of an out-of-sync `.bitmap`.

We reproduced the halt live on teambit/bit-git-sync-example, with the flow its own README documents.

## The manual recovery, and what this PR automates

A user at the terminal gets out of this state with two commands:

```sh
bit remove my-comp --keep-files   # drop the "new and unexported" claim
bit lane switch my-lane           # the fetch now works, the lane merges cleanly
```

This works, with one defect: the switch re-adds the component at the workspace's `defaultDirectory`, so the files can move to a different folder than the one the user chose at `bit add`.

The fix automates this recovery and keeps the folder:

- `switchToLane` retries once when the switch fails with the missing-component marker. A normal switch pays no extra cost.
- On the retry, `adoptNewComponentsTheLaneProvides` (new module in `scopes/git/ci/sync/`) writes the lane's version into each shadowing entry, in memory. The entry keeps its rootDir and its config — this is the step `bit remove` cannot give you. A `.bitmap` snapshot restores the state when the retry also fails.
- It then imports the adopted objects with the existing `includeUnexported` option of `importMany` — the option that exists for out-of-sync states like this one.
- The caller that sets `writeAdoptedFiles` (the sync import path) writes the files with `checkout --reset`, because the switch skips an entry that already records the target version. A `.bitmap`-only sync commit must not claim content that the branch did not receive.

The match compares scope and name. A new component with the same name from a different scope does not change. All changes are inside the ci aspect.

