### PR TITLE
fix(ci): re-fork a machine-owned bit-sync/main that conflicts with the default branch

### DIFF
--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -1120,9 +1120,6 @@ describe('bit ci sync', function () {
     });
   });
 
-  // The sync branch is machine-owned: every commit it holds beyond the default branch is recomputed
-  // from scope state. When the default branch moves past it and the catch-up merge conflicts, the
-  // run must re-fork the branch instead of halting — unless a human commit sits on it.
   describe('a stale bit-sync/main that conflicts with the default branch', () => {
     const SYNC_BRANCH = 'bit-sync/main';
     let defaultBranch: string;
@@ -1137,8 +1134,8 @@ describe('bit ci sync', function () {
       helper.command.runCmd('bit tag --message "bump to 0.0.2"', devPath);
       helper.command.runCmd('bit export', devPath);
       seedSync('--main');
-      // the default branch then adopts a NEWER comp1 (0.0.3) than the sync branch recorded (0.0.2):
-      // both sides changed the same `.bitmap` line, so the catch-up merge conflicts
+      // the default branch adopts comp1@0.0.3 while the sync branch recorded 0.0.2 — the same
+      // `.bitmap` line on both sides, so the catch-up merge conflicts
       fs.outputFileSync(path.join(devPath, 'comp1', 'index.js'), comp1Src('main-scope-v3'));
       helper.command.runCmd('bit tag comp1 --message "bump comp1 to 0.0.3" --unmodified', devPath);
       helper.command.runCmd('bit export', devPath);

--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -1119,4 +1119,82 @@ describe('bit ci sync', function () {
       expect(helper.command.listLanesParsed().currentLane).to.equal('main');
     });
   });
+
+  // The sync branch is machine-owned: every commit it holds beyond the default branch is recomputed
+  // from scope state. When the default branch moves past it and the catch-up merge conflicts, the
+  // run must re-fork the branch instead of halting — unless a human commit sits on it.
+  describe('a stale bit-sync/main that conflicts with the default branch', () => {
+    const SYNC_BRANCH = 'bit-sync/main';
+    let defaultBranch: string;
+    let devPath: string;
+
+    before(() => {
+      ({ defaultBranch } = setupSyncWorkspace({}));
+      devPath = helper.scopeHelper.cloneWorkspace();
+      // the scope moves ahead: both components tag 0.0.2; the sync branch proposes that drift
+      fs.outputFileSync(path.join(devPath, 'comp1', 'index.js'), comp1Src('main-scope-v2'));
+      fs.outputFileSync(path.join(devPath, 'comp2', 'index.js'), comp2Src('main-scope-v2'));
+      helper.command.runCmd('bit tag --message "bump to 0.0.2"', devPath);
+      helper.command.runCmd('bit export', devPath);
+      seedSync('--main');
+      // the default branch then adopts a NEWER comp1 (0.0.3) than the sync branch recorded (0.0.2):
+      // both sides changed the same `.bitmap` line, so the catch-up merge conflicts
+      fs.outputFileSync(path.join(devPath, 'comp1', 'index.js'), comp1Src('main-scope-v3'));
+      helper.command.runCmd('bit tag comp1 --message "bump comp1 to 0.0.3" --unmodified', devPath);
+      helper.command.runCmd('bit export', devPath);
+      helper.command.runCmd('bit checkout head comp1 -x');
+      helper.command.runCmd('git add -A');
+      helper.command.runCmd('git commit -m "chore: adopt comp1 0.0.3"');
+      helper.command.runCmd(`git push origin ${defaultBranch}`);
+      gitFetch();
+    });
+
+    it('re-forks the machine-owned branch from the default branch and pushes the remaining drift', () => {
+      const tipBefore = branchTipSha(SYNC_BRANCH);
+      const { output, exitCode } = syncRun('--main');
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.not.include('HALTED');
+      expect(output).to.include('re-forking');
+      expect(output).to.include(`main -> pushed sync commit to ${SYNC_BRANCH}`);
+      expect(branchTipSha(SYNC_BRANCH)).to.not.equal(tipBefore);
+      // the re-forked branch carries the default branch's comp1 and the scope's comp2 drift
+      expect(fileOnBranch(SYNC_BRANCH, 'comp1/index.js')).to.include('main-scope-v3');
+      expect(fileOnBranch(SYNC_BRANCH, 'comp2/index.js')).to.include('main-scope-v2');
+      expect(fileOnBranch(SYNC_BRANCH, '.bitmap')).to.include('0.0.3');
+      // non-vacuous: the default branch never gained the scope's comp2
+      expect(fileOnBranch(defaultBranch, 'comp2/index.js')).to.include('comp2: initial');
+      // the re-run is a converged no-op
+      const rerun = syncRun('--main');
+      expect(rerun.exitCode, `bit ci sync output:\n${rerun.output}`).to.equal(0);
+      expect(rerun.output).to.include('main -> converged');
+    });
+
+    it('keeps the halt when a human commit sits on the sync branch', () => {
+      // a human pushes straight to the sync branch, and the default branch conflicts with the edit
+      helper.command.runCmd(`git fetch origin ${SYNC_BRANCH}`);
+      helper.command.runCmd(`git checkout -B ${SYNC_BRANCH} origin/${SYNC_BRANCH}`);
+      helper.fs.outputFile('comp1/index.js', comp1Src('human-edit-on-sync-branch'));
+      helper.command.runCmd('git add -A');
+      helper.command.runCmd('git commit -m "fix: a human edit on the sync branch"');
+      helper.command.runCmd(`git push origin ${SYNC_BRANCH}`);
+      helper.command.runCmd(`git checkout ${defaultBranch}`);
+      fs.outputFileSync(path.join(devPath, 'comp1', 'index.js'), comp1Src('main-scope-v4'));
+      helper.command.runCmd('bit tag comp1 --message "bump comp1 to 0.0.4" --unmodified', devPath);
+      helper.command.runCmd('bit export', devPath);
+      helper.command.runCmd('bit checkout head comp1 -x');
+      helper.command.runCmd('git add -A');
+      helper.command.runCmd('git commit -m "chore: adopt comp1 0.0.4"');
+      helper.command.runCmd(`git push origin ${defaultBranch}`);
+      gitFetch();
+
+      const tipBefore = branchTipSha(SYNC_BRANCH);
+      const { output, exitCode } = syncRun('--main');
+      expect(exitCode, `bit ci sync output:\n${output}`).to.not.equal(0);
+      expect(output).to.include('could not bring the sync branch');
+      expect(output).to.not.include('re-forking');
+      // the human commit survives
+      expect(branchTipSha(SYNC_BRANCH)).to.equal(tipBefore);
+      expect(fileOnBranch(SYNC_BRANCH, 'comp1/index.js')).to.include('human-edit-on-sync-branch');
+    });
+  });
 });

--- a/scopes/git/ci/sync/main-sync-executor.ts
+++ b/scopes/git/ci/sync/main-sync-executor.ts
@@ -83,9 +83,7 @@ export class MainSyncExecutor {
 
       if (syncBranchExists) {
         // Catch up with the default branch: the PR must stay mergeable, and `checkout head` on a stale
-        // tree would re-commit pre-merge content over the default branch's changes. A merge keeps a
-        // branch that carries human commits intact; a machine-owned branch that conflicts is re-forked,
-        // because its content is recomputed from the scope on every run.
+        // tree would re-commit pre-merge content over the default branch's changes.
         const catchUpErr = await this.catchUpWithDefaultBranch(branch);
         if (catchUpErr) {
           const healed = await this.reforkIfMachineOwned(branch);
@@ -193,16 +191,14 @@ export class MainSyncExecutor {
   private async catchUpWithDefaultBranch(branch: string): Promise<string | undefined> {
     const { defaultBranch, logger } = this.deps;
     try {
-      // under the identity: a non-fast-forward merge writes a merge COMMIT. The marker on its own
-      // line keeps the branch machine-owned (`isSyncAuthoredMessage`) across catch-up merges.
+      // the marker line keeps the branch machine-owned across catch-up merges
       const out = await gitWithIdentity([
         'merge',
         '-m',
         `merge origin/${defaultBranch} into ${branch}\n\n${SYNC_COMMIT_MARKER}`,
         `origin/${defaultBranch}`,
       ]);
-      // judge the merge by repository state, never by rejection: simple-git resolves on some
-      // non-zero exits, and a conflicted `.bitmap` would otherwise reach the workspace reload
+      // simple-git resolves on some non-zero exits — judge the merge by state, not by rejection
       const conflicted = (await git.status()).conflicted;
       if (conflicted.length) throw new Error(`merge conflicts in: ${conflicted.join(', ')}`);
       logger.console(chalk.blue(`Brought ${branch} up to date with origin/${defaultBranch}: ${out.trim()}`));
@@ -219,11 +215,9 @@ export class MainSyncExecutor {
   }
 
   /**
-   * A sync branch whose every commit beyond the default branch passes `isSyncAuthoredMessage` is
-   * machine state, recomputable from the scope — re-fork it from the default branch instead of
-   * halting. The force push is leased on the tip the ownership was read from, so a concurrent
-   * run's push rejects this one instead of losing work. Returns false when any commit fails the
-   * probe; the caller keeps the halt, because a human wrote on the branch.
+   * Re-fork the sync branch from the default branch when every commit it holds beyond it passes
+   * `isSyncAuthoredMessage` — machine state is recomputable from the scope. The force push is
+   * leased on the tip the ownership was read from, so a concurrent run's push wins.
    */
   private async reforkIfMachineOwned(branch: string): Promise<boolean> {
     const { defaultBranch, logger } = this.deps;

--- a/scopes/git/ci/sync/main-sync-executor.ts
+++ b/scopes/git/ci/sync/main-sync-executor.ts
@@ -19,6 +19,7 @@ import {
   fetchRemoteHeads,
   gitWithIdentity,
   isNonContentPath,
+  isStaleLeaseRejection,
 } from './git-ops';
 
 export type MainSyncDeps = {
@@ -86,8 +87,9 @@ export class MainSyncExecutor {
         // tree would re-commit pre-merge content over the default branch's changes.
         const catchUpErr = await this.catchUpWithDefaultBranch(branch);
         if (catchUpErr) {
-          const healed = await this.reforkIfMachineOwned(branch);
-          if (!healed) return `${HALT_SUMMARY_PREFIX} main -> ${catchUpErr}`;
+          const refork = await this.reforkIfMachineOwned(branch);
+          if (refork === 'human-owned') return `${HALT_SUMMARY_PREFIX} main -> ${catchUpErr}`;
+          if (refork === 'raced') return `main -> ${branch} was updated by a concurrent run — deferring to it`;
         }
       }
 
@@ -217,9 +219,9 @@ export class MainSyncExecutor {
   /**
    * Re-fork the sync branch from the default branch when every commit it holds beyond it passes
    * `isSyncAuthoredMessage` — machine state is recomputable from the scope. The force push is
-   * leased on the tip the ownership was read from, so a concurrent run's push wins.
+   * leased on the tip the ownership was read from, so a concurrent run's push wins the race.
    */
-  private async reforkIfMachineOwned(branch: string): Promise<boolean> {
+  private async reforkIfMachineOwned(branch: string): Promise<'re-forked' | 'raced' | 'human-owned'> {
     const { defaultBranch, logger } = this.deps;
     const staleTip = (await git.revparse([`origin/${branch}`])).trim();
     const log = await git.raw(['log', `origin/${defaultBranch}..${staleTip}`, '--format=%B%x1e']);
@@ -228,7 +230,7 @@ export class MainSyncExecutor {
       .map((message) => message.trim())
       .filter(Boolean);
     const machineOwned = messages.length > 0 && messages.every((message) => isSyncAuthoredMessage(message));
-    if (!machineOwned) return false;
+    if (!machineOwned) return 'human-owned';
     logger.console(
       formatWarningSummary(
         `main -> ${branch} conflicts with ${defaultBranch} and carries only ${SYNC_COMMIT_MARKER} commits — ` +
@@ -236,8 +238,14 @@ export class MainSyncExecutor {
       )
     );
     await this.resetToStartPoint(branch, `origin/${defaultBranch}`);
-    await git.push([`--force-with-lease=refs/heads/${branch}:${staleTip}`, 'origin', `HEAD:refs/heads/${branch}`]);
-    return true;
+    try {
+      await git.push([`--force-with-lease=refs/heads/${branch}:${staleTip}`, 'origin', `HEAD:refs/heads/${branch}`]);
+    } catch (e: any) {
+      if (!isStaleLeaseRejection(e?.message || String(e))) throw e;
+      logger.console(formatWarningSummary(`main -> ${branch} moved while re-forking — another run owns it now`));
+      return 'raced';
+    }
+    return 're-forked';
   }
 
   /**

--- a/scopes/git/ci/sync/main-sync-executor.ts
+++ b/scopes/git/ci/sync/main-sync-executor.ts
@@ -6,7 +6,7 @@ import type { CheckoutMain } from '@teambit/checkout';
 import { git } from '../git';
 import type { CiMain } from '../ci.main.runtime';
 import type { CiSyncConfig } from './sync-config';
-import { SYNC_COMMIT_MARKER } from './sync-state';
+import { SYNC_COMMIT_MARKER, isSyncAuthoredMessage } from './sync-state';
 import { currentLaneIdStr } from './workspace-lane';
 import type { GitHostProvider } from './git-host-provider';
 import { HALT_SUMMARY_PREFIX, capEntries } from './lane-sync-executor';
@@ -38,7 +38,8 @@ export type MainSyncDeps = {
  * Reconcile the main scope with the repository's default branch. Stateless: `bit checkout head`
  * writes the latest exported versions, so an empty `git status` IS convergence and any diff IS the
  * drift. Under 'pr' the convergence is proposed via `mainSyncBranch`; under 'direct-push' it lands on
- * the default branch with a plain push. Nothing is ever force-pushed in either mode.
+ * the default branch with a plain push. One force push exists: a machine-owned sync branch that
+ * conflicts with the default branch is re-forked under a tip lease (`reforkIfMachineOwned`).
  */
 /** the "nothing to do" line, shared by both modes */
 const CONVERGED_SUMMARY = 'main -> converged (checkout head produced no changes)';
@@ -82,10 +83,14 @@ export class MainSyncExecutor {
 
       if (syncBranchExists) {
         // Catch up with the default branch: the PR must stay mergeable, and `checkout head` on a stale
-        // tree would re-commit pre-merge content over the default branch's changes. A merge — never a
-        // rebase, never a force-push — is the only non-destructive way to move a branch with an open PR.
+        // tree would re-commit pre-merge content over the default branch's changes. A merge keeps a
+        // branch that carries human commits intact; a machine-owned branch that conflicts is re-forked,
+        // because its content is recomputed from the scope on every run.
         const catchUpErr = await this.catchUpWithDefaultBranch(branch);
-        if (catchUpErr) return `${HALT_SUMMARY_PREFIX} main -> ${catchUpErr}`;
+        if (catchUpErr) {
+          const healed = await this.reforkIfMachineOwned(branch);
+          if (!healed) return `${HALT_SUMMARY_PREFIX} main -> ${catchUpErr}`;
+        }
       }
 
       // `checkout head` resolves versions against the CURRENT lane; a lane pointer on this branch
@@ -188,8 +193,18 @@ export class MainSyncExecutor {
   private async catchUpWithDefaultBranch(branch: string): Promise<string | undefined> {
     const { defaultBranch, logger } = this.deps;
     try {
-      // under the identity: a non-fast-forward merge writes a merge COMMIT
-      const out = await gitWithIdentity(['merge', '--no-edit', `origin/${defaultBranch}`]);
+      // under the identity: a non-fast-forward merge writes a merge COMMIT. The marker on its own
+      // line keeps the branch machine-owned (`isSyncAuthoredMessage`) across catch-up merges.
+      const out = await gitWithIdentity([
+        'merge',
+        '-m',
+        `merge origin/${defaultBranch} into ${branch}\n\n${SYNC_COMMIT_MARKER}`,
+        `origin/${defaultBranch}`,
+      ]);
+      // judge the merge by repository state, never by rejection: simple-git resolves on some
+      // non-zero exits, and a conflicted `.bitmap` would otherwise reach the workspace reload
+      const conflicted = (await git.status()).conflicted;
+      if (conflicted.length) throw new Error(`merge conflicts in: ${conflicted.join(', ')}`);
       logger.console(chalk.blue(`Brought ${branch} up to date with origin/${defaultBranch}: ${out.trim()}`));
     } catch (e: any) {
       await git.raw(['merge', '--abort']).catch(() => undefined);
@@ -201,6 +216,34 @@ export class MainSyncExecutor {
     // The merge may have brought a new `.bitmap` in from the default branch.
     await this.deps.ci.reloadWorkspaceFromDisk();
     return undefined;
+  }
+
+  /**
+   * A sync branch whose every commit beyond the default branch passes `isSyncAuthoredMessage` is
+   * machine state, recomputable from the scope — re-fork it from the default branch instead of
+   * halting. The force push is leased on the tip the ownership was read from, so a concurrent
+   * run's push rejects this one instead of losing work. Returns false when any commit fails the
+   * probe; the caller keeps the halt, because a human wrote on the branch.
+   */
+  private async reforkIfMachineOwned(branch: string): Promise<boolean> {
+    const { defaultBranch, logger } = this.deps;
+    const staleTip = (await git.revparse([`origin/${branch}`])).trim();
+    const log = await git.raw(['log', `origin/${defaultBranch}..${staleTip}`, '--format=%B%x1e']);
+    const messages = log
+      .split('\x1e')
+      .map((message) => message.trim())
+      .filter(Boolean);
+    const machineOwned = messages.length > 0 && messages.every((message) => isSyncAuthoredMessage(message));
+    if (!machineOwned) return false;
+    logger.console(
+      formatWarningSummary(
+        `main -> ${branch} conflicts with ${defaultBranch} and carries only ${SYNC_COMMIT_MARKER} commits — ` +
+          `re-forking it from origin/${defaultBranch}`
+      )
+    );
+    await this.resetToStartPoint(branch, `origin/${defaultBranch}`);
+    await git.push([`--force-with-lease=refs/heads/${branch}:${staleTip}`, 'origin', `HEAD:refs/heads/${branch}`]);
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Problem

A stale `bit-sync/main` that conflicts with the default branch halts every `--main` run until a human deletes the branch. The conflict also escapes detection: simple-git resolves on some non-zero exits, so the conflicted catch-up merge reads as success and the run dies at the `.bitmap` parse (`Unexpected token <`). The branch is machine state — every run recomputes it from the scope — so the halt protects nothing. Reproduced live on teambit/bit-git-sync-example.

## Fix

All in `main-sync-executor.ts`:

- Judge the catch-up merge by repository state (`git status` conflicts), never by rejection.
- On a conflict, re-fork the branch from the default branch when every commit beyond it passes `isSyncAuthoredMessage` — the probe branch deletion uses. The force push is leased on the tip the ownership was read from.
- A stale-lease rejection means a concurrent run moved the branch — defer to it with a plain summary.
- A human commit keeps the halt: an auto-resolution would overwrite the one commit a human cared about. The message names the recovery — resolve, or delete the branch.
- The catch-up merge commit carries the sync marker, so ownership survives across runs.
