### PR TITLE
fix(ci sync): stop re-planning a branch whose tip is the reconciler's own commit

### DIFF
--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -1120,6 +1120,57 @@ describe('bit ci sync', function () {
     });
   });
 
+  // A branch commit that touches no bit-tracked file (docs, CI config) gives export-branch nothing
+  // to snap. The sync-ledger commit executeExportBranch still writes is `--allow-empty` and never
+  // touches `.bitmap`, so `stateCommit` (sync-state.ts, derived from `.bitmap`'s content, never
+  // commit messages) never advances past the docs commit — `hasDevCommits` stays true forever, and
+  // every later run re-plans export-branch on top of the ledger commit it just wrote.
+  describe('a commit that touches no bit-tracked file settles instead of looping', () => {
+    const LANE = 'docs-only-lane';
+    let defaultBranch: string;
+    let devPath: string;
+
+    before(() => {
+      ({ defaultBranch } = setupSyncWorkspace({ lanes: ['*'] }));
+      devPath = createLaneWithSnap(LANE, { 'comp1/index.js': comp1Src('lane-snap-1') }, 'lane snap 1');
+      seedSync(LANE);
+      branchSideCommit(LANE, defaultBranch, 'NOTES.md', '# notes\n', 'docs: add notes');
+    });
+
+    it('exports nothing to snap once, then settles — the second run does not redo export-branch work', () => {
+      const first = syncRun(LANE);
+      expect(first.exitCode, `bit ci sync output:\n${first.output}`).to.equal(0);
+      expect(first.output).to.include(`${LANE} -> export-branch`);
+
+      const second = syncRun(LANE);
+      expect(second.exitCode, `bit ci sync output:\n${second.output}`).to.equal(0);
+      // pins the settled summary's exact wording
+      expect(second.output).to.include(
+        `${LANE} -> noop (converged; branch tip is already this reconciler's own sync commit)`
+      );
+      // executeExportBranch's own work (the checkout, the snap attempt) never ran a second time
+      expect(second.output).to.not.include('Exporting branch');
+    });
+
+    // The withhold settles; it does not trap. A real dev commit on top of the recognized ledger tip
+    // must still clear it and export normally — the tip is no longer the reconciler's own commit.
+    it('a real dev commit on top of the settled tip clears the withhold and exports again', () => {
+      branchSideCommit(
+        LANE,
+        defaultBranch,
+        'comp1/index.js',
+        comp1Src('dev-commit-after-settle'),
+        'dev commit after settling'
+      );
+      const { output, exitCode } = syncRun(LANE);
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.include('Exporting branch');
+      expect(output).to.include(`${LANE} -> export-branch`);
+      expect(output).to.not.include('branch tip is already this reconciler');
+      expect(laneTipFile(devPath, 'comp1/index.js')).to.include('dev-commit-after-settle');
+    });
+  });
+
   describe('a stale bit-sync/main that conflicts with the default branch', () => {
     const SYNC_BRANCH = 'bit-sync/main';
     let defaultBranch: string;

--- a/scopes/git/ci/sync/lane-sync-executor.ts
+++ b/scopes/git/ci/sync/lane-sync-executor.ts
@@ -445,6 +445,17 @@ export class LaneSyncExecutor {
           pr,
         });
       case 'export-branch':
+        // The tip is already this reconciler's own commit — it already confirmed everything up to
+        // it (that is what writing it means), and `hasDevCommits`/`stateCommit` cannot tell a real
+        // dev commit from one that touches no bit-tracked file (docs, CI config): `stateCommit` is
+        // derived from `.bitmap`'s content, never from commit messages (sync-state.ts), so a commit
+        // that leaves `.bitmap` byte-identical never advances it, however many runs re-confirm
+        // "nothing to snap" on top. Recognizing our own tip here — not by loosening `hasDevCommits`
+        // itself, which the ownership/retirement path also reads and must stay strict — is what
+        // makes that settle instead of re-planning `export-branch` forever.
+        if (tipIsSyncCommit) {
+          return `${laneName} -> noop (converged; branch tip is already this reconciler's own sync commit)`;
+        }
         return this.executeExportBranch({ target, laneIdStr, branch, defaultBranch });
       case 'merge-diverged':
         return this.executeMergeDiverged({ target, laneIdStr, branch, defaultBranch });

--- a/scopes/git/ci/sync/sync-state.ts
+++ b/scopes/git/ci/sync/sync-state.ts
@@ -86,8 +86,9 @@ export function hasSyncMarker(message: string): boolean {
 
 /**
  * Strict probe for "we wrote this commit": the marker alone on its own line. This is an input to branch
- * deletion, so a developer merely quoting the marker must never count as authorship. `\r?` tolerates CRLF;
- * a recognition failure errs toward keeping the branch.
+ * deletion and to the export-branch withhold (a branch whose tip is already our own commit settles
+ * instead of re-exporting), so a developer merely quoting the marker must never count as authorship.
+ * `\r?` tolerates CRLF; a recognition failure errs toward keeping the branch / re-attempting the export.
  */
 export function isSyncAuthoredMessage(message: string): boolean {
   return new RegExp(`^${SYNC_COMMIT_MARKER.replace(/[[\]]/g, '\\$&')}\\r?$`, 'm').test(message);


### PR DESCRIPTION
## Problem

A synced branch has a done state. The reconciler processes the branch one time. After that, each sweep skips the branch with one cheap git check.

A branch whose last commit touches no bit-tracked file never gets to the done state. Each sweep processes it fully, without end. Each run is green. The branch is the thing that never finishes.

The branch after a docs-only push:

```
C3  "add NOTES.md"          <- tip; touches no component
C2  "[bit-sync] ..."        <- last sync commit; changed .bitmap
```

Run 1 asks the cheap question: are there commits after the last `.bitmap` change? C3 is after C2. The answer is yes. The run then does the expensive work: pristine checkout, workspace load, lane fetch. Then `bit status` gives the answer: nothing to snap. The answer is correct. But it comes after the expensive work. The run ends and pushes its ledger commit C4. Nothing was snapped, so C4 is empty. It changes no files.

Run 2 starts 30 minutes later. The last `.bitmap` change is still C2. C3 touched docs. C4 touched nothing. The cheap question says yes again. The expensive work runs again. Nothing to snap again. Empty commit C5. This repeats on each sweep. The branch gets one empty machine commit per run.

## Cause

The skip decision reads `stateCommit`: the newest commit that changed `.bitmap`. A snap moves it, because the ledger commit then contains new versions. A nothing-to-snap run cannot move it. Its ledger commit is empty. So the verdict "looked, found nothing" has no form that the cheap check can see. The branch cannot get to the done state.

## Fix

Give that verdict a form the check can see. Before the reconciler dispatches `export-branch`, it examines the branch tip. When the tip is the reconciler's own commit (`isSyncAuthoredMessage`, the strict probe) and the lane did not move, the run returns the converged noop. No checkout. No new commit. A real dev commit lands on top of the ledger commit. It clears the check on the next sweep.

The check only withholds work. When it recognizes the tip, the sync does nothing. A forged marker can only cause a missed export. That is safe, self-made, and the next real commit clears it. The check cannot delete or overwrite. `stateCommit` and `hasDevCommits` do not change. The close-pr path reads them and stays strict.

## Tests

`e2e/harmony/ci-sync.e2e.ts`, "a commit that touches no bit-tracked file settles instead of looping":

1. Run 1 processes the docs commit and pushes the ledger. Run 2 reports the converged noop and does not enter `executeExportBranch`.
2. A real dev commit on top of the settled tip clears the check and exports.

The loop was verified on unpatched master first: run 2 re-planned and re-processed. Both tests pass with the fix.
