### PR TITLE
fix(ci sync): probe a state commit that bundles source edits instead of trusting convergence

### DIFF
--- a/e2e/harmony/ci-sync-state.e2e.ts
+++ b/e2e/harmony/ci-sync-state.e2e.ts
@@ -81,10 +81,11 @@ describe('bit ci sync — state model v2', function () {
       expect(branchTipAfterDevWork).to.equal(devCommitSha);
 
       const { output, exitCode } = syncRun(LANE);
+      // The bundled sources plan a PROBING export (the plan line names export-branch), but the snap
+      // finds nothing pending and the run settles as converged with zero writes — the contract here.
       expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
-      expect(output).to.include(`${LANE} -> noop (converged)`);
+      expect(output).to.include(`${LANE} -> noop (converged`);
       expect(output).to.not.include(`${LANE} -> merge-diverged`);
-      expect(output).to.not.include(`${LANE} -> export-branch`);
       expect(output).to.not.include(`${LANE} -> import-lane`);
       expect(branchTipSha(LANE)).to.equal(branchTipAfterDevWork);
       expect(remoteLaneFingerprint(LANE)).to.equal(laneAfterDevWork);
@@ -116,8 +117,9 @@ describe('bit ci sync — state model v2', function () {
       expect(branchTipSha(LANE)).to.equal(tip);
     });
 
-    // The known Stage-1 delta, locked deliberately: the invisible round here, the self-heal below.
-    it('should read an unsnapped edit riding along with a .bitmap commit as converged, and say why', () => {
+    // The Stage-1 delta this suite once locked ("invisible round, then self-heal") is closed: the
+    // probing export snaps the unsnapped edit immediately instead of declaring a blind convergence.
+    it('should export an unsnapped edit riding along with a .bitmap commit, immediately', () => {
       gitFetch();
       helper.command.runCmd(`git checkout -f -B ${LANE} origin/${LANE}`);
       // comp1 is snapped AND exported, so `.bitmap` moves and the branch's state matches the lane's ...
@@ -132,28 +134,23 @@ describe('bit ci sync — state model v2', function () {
       helper.command.runCmd(`git checkout -f ${defaultBranch}`);
       gitFetch();
       const laneAfterDevWork = remoteLaneFingerprint(LANE);
-      const branchTipAfterDevWork = branchTipSha(LANE);
 
       const { output, exitCode } = syncRun(LANE);
-      // converged is true of the BIT state, and that IS the delta
       expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
-      expect(output).to.include(`${LANE} -> noop (converged)`);
-      expect(branchTipSha(LANE)).to.equal(branchTipAfterDevWork);
-      expect(remoteLaneFingerprint(LANE)).to.equal(laneAfterDevWork);
-      // said out loud, rather than claiming a bare convergence
-      expect(output).to.include(`${LANE}'s tip is not a bit ci sync commit`);
-      expect(output).to.include('never snapped stay invisible until the next commit');
-      // non-vacuous: the unsnapped edit really is on the branch and really is NOT on the lane
-      expect(fileOnBranch(LANE, 'comp2/index.js')).to.include('never-snapped-edit');
-      expect(laneTipFile(devPath, 'comp2/index.js')).to.not.include('never-snapped-edit');
+      expect(output).to.include(`${LANE} -> export-branch (lane`);
+      // the probe found real pending work, so the lane moved and now carries BOTH halves of the commit
+      expect(remoteLaneFingerprint(LANE)).to.not.equal(laneAfterDevWork);
+      expect(laneTipFile(devPath, 'comp2/index.js')).to.include('never-snapped-edit');
       expect(laneTipFile(devPath, 'comp1/index.js')).to.include('snapped-and-exported');
     });
 
-    it('should self-heal on the next ordinary commit: the export carries the invisible edit onto the lane', () => {
+    it('should settle a plain non-component commit with a ledger commit, moving nothing on the lane', () => {
+      const laneBefore = remoteLaneFingerprint(LANE);
       branchSideCommit(LANE, defaultBranch, 'docs/note.md', 'a plain commit\n', 'docs: an ordinary commit');
       const { output, exitCode } = syncRun(LANE);
       expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
       expect(output).to.include(`${LANE} -> export-branch`);
+      expect(remoteLaneFingerprint(LANE)).to.equal(laneBefore);
       expect(laneTipFile(devPath, 'comp2/index.js')).to.include('never-snapped-edit');
     });
   });
@@ -173,14 +170,15 @@ describe('bit ci sync — state model v2', function () {
     });
 
     it('should KEEP a branch whose tip is a developer’s .bitmap commit when the lane is removed, twice', () => {
-      // An unexported snap: this commit becomes the state commit AND the tip, and the work exists only
-      // here.
+      // An unexported snap whose commit carries ONLY `.bitmap` — the marker defence in isolation. A
+      // commit that bundles the source edit too reads as dev work outright (`unmerged-commits`) and is
+      // covered by the bundled-commit suite in ci-sync.e2e.ts.
       gitFetch();
       helper.command.runCmd(`git checkout -f -B ${LANE} origin/${LANE}`);
       helper.fs.outputFile('comp2/index.js', comp2Src('unexported-local-snap'));
       helper.command.runCmd('bit snap --message "dev snaps comp2 but never exports it"');
-      helper.command.runCmd('git add -A');
-      helper.command.runCmd('git commit -m "feat: local snap that was never exported"');
+      helper.command.runCmd('git add .bitmap');
+      helper.command.runCmd('git commit -m "chore: record a local snap that was never exported"');
       helper.command.runCmd(`git push origin ${LANE}`);
       helper.command.runCmd(`git checkout -f ${defaultBranch}`);
       gitFetch();
@@ -200,7 +198,8 @@ describe('bit ci sync — state model v2', function () {
       expect(output).to.not.include('branch carries unmerged commits');
       expect(remoteBranchExists(LANE), `origin/${LANE} must survive — its snap exists nowhere else`).to.be.true;
       expect(branchTipSha(LANE)).to.equal(tipBefore);
-      expect(fileOnBranch(LANE, 'comp2/index.js')).to.include('unexported-local-snap');
+      // the .bitmap-only commit is the tip: the unexported pointer is what the guard protected
+      expect(fileOnBranch(LANE, '.bitmap')).to.include('_bit_lane');
 
       const rerun = syncRun('--all');
       expect(rerun.exitCode, `bit ci sync output:\n${rerun.output}`).to.equal(0);

--- a/e2e/harmony/ci-sync.e2e.ts
+++ b/e2e/harmony/ci-sync.e2e.ts
@@ -924,6 +924,96 @@ describe('bit ci sync', function () {
     });
   });
 
+  // A single commit that bundles a source edit WITH a `.bitmap` write is the state commit itself, so
+  // "commits after the state commit" counts zero — the edit used to be invisible and the pair read as
+  // converged while the lane never received it. The conflict-halt comment's resolve-by-hand recipe
+  // (bit lane import + fix + one commit) produces exactly this shape.
+  describe('a commit bundling a source edit with a .bitmap write is dev work, not convergence', () => {
+    const LANE = 'bundled-commit';
+    let defaultBranch: string;
+    let devPath: string;
+
+    before(() => {
+      ({ defaultBranch } = setupSyncWorkspace({ lanes: ['*'] }));
+      devPath = createLaneWithSnap(LANE, { 'comp1/index.js': comp1Src('bundled-v1') }, 'bundled v1');
+      // First sync materializes the branch and converges the pair.
+      const seed = syncRun(LANE);
+      expect(seed.exitCode, `bit ci sync output:\n${seed.output}`).to.equal(0);
+      expect(seed.output).to.include(`${LANE} -> import-lane`);
+
+      // The human's bundled commit: a real source edit riding in the same commit as a `.bitmap` write
+      // that leaves the parsed state identical (so the fingerprints still read converged).
+      gitFetch();
+      helper.command.runCmd(`git checkout -f -B ${LANE} origin/${LANE}`);
+      helper.fs.outputFile('comp1/index.js', comp1Src('bundled-by-hand'));
+      const bitmapPath = path.join(helper.scopes.localPath, '.bitmap');
+      fs.appendFileSync(bitmapPath, '\n');
+      helper.command.runCmd('git add -A');
+      helper.command.runCmd('git commit -m "fix: hand-resolved content riding with a .bitmap write"');
+      helper.command.runCmd(`git push origin ${LANE}`);
+      helper.command.runCmd(`git checkout -f ${defaultBranch}`);
+    });
+
+    it('exports the bundled edit onto the lane instead of declaring convergence', () => {
+      const { output, exitCode } = syncRun(LANE);
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.include(`${LANE} -> export-branch`);
+      expect(output).to.not.include('noop (converged)');
+      expect(laneTipFile(devPath, 'comp1/index.js')).to.include('bundled-by-hand');
+    });
+
+    it('a second run reads the truly converged pair as converged', () => {
+      const { output, exitCode } = syncRun(LANE);
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.include(`${LANE} -> noop (converged)`);
+    });
+  });
+
+  // `commitTouchesBeyondBitmap` asks "any path other than `.bitmap`", so a file no component tracks
+  // plans the probe too. That probe finds nothing pending and exports nothing — but it must still
+  // record the sync ledger. Without it the tip stays the developer's bundled commit, so
+  // `stateCommitBundlesSources` stays true and every later run re-pays the checkout + snap on the
+  // identical tip. One `--allow-empty` ledger commit moves the tip and ends that.
+  describe('a probe that finds nothing pending settles instead of re-probing the same tip forever', () => {
+    const LANE = 'clean-probe';
+    let defaultBranch: string;
+
+    before(() => {
+      ({ defaultBranch } = setupSyncWorkspace({ lanes: ['*'] }));
+      createLaneWithSnap(LANE, { 'comp1/index.js': comp1Src('clean-probe-v1') }, 'clean probe v1');
+      const seed = syncRun(LANE);
+      expect(seed.exitCode, `bit ci sync output:\n${seed.output}`).to.equal(0);
+
+      // A file no component tracks, riding in the same commit as a `.bitmap` write — the shape that
+      // reads exactly like the bundled-source case above and is indistinguishable from it by name.
+      gitFetch();
+      helper.command.runCmd(`git checkout -f -B ${LANE} origin/${LANE}`);
+      helper.fs.outputFile('docs/notes.md', 'a note no component tracks\n');
+      fs.appendFileSync(path.join(helper.scopes.localPath, '.bitmap'), '\n');
+      helper.command.runCmd('git add -A');
+      helper.command.runCmd('git commit -m "docs: a note riding with a .bitmap write"');
+      helper.command.runCmd(`git push origin ${LANE}`);
+      helper.command.runCmd(`git checkout -f ${defaultBranch}`);
+    });
+
+    it('exports nothing, and says so, but records the ledger anyway', () => {
+      const { output, exitCode } = syncRun(LANE);
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.include(`${LANE} -> noop`);
+      expect(output).to.include('already snapped');
+      // The ledger commit IS the settle mechanism: proving it landed proves the next run cannot
+      // read the developer's bundled commit as the tip again.
+      expect(laneHeadTrailer(LANE), `branch tip:\n${branchTipMessage(LANE)}`).to.be.a('string');
+    });
+
+    it('the next run does not probe again', () => {
+      const { output, exitCode } = syncRun(LANE);
+      expect(exitCode, `bit ci sync output:\n${output}`).to.equal(0);
+      expect(output).to.include(`${LANE} -> noop`);
+      expect(output).to.not.include('sources bundled into the state commit');
+    });
+  });
+
   // The cross-scope split: foreign CONTENT is refused outright; a foreign HOST is fine as long as the
   // content is this repo's, addressed by its scope-qualified id.
   describe('a lane whose components span two scopes is refused, never half-mirrored', () => {

--- a/scopes/git/ci/sync/lane-sync-executor.ts
+++ b/scopes/git/ci/sync/lane-sync-executor.ts
@@ -362,7 +362,13 @@ export class LaneSyncExecutor {
     const branchExists = await branchExistsOnRemote(branch);
     const branchState: BranchSyncState = branchExists
       ? await readBranchSyncState(branch, defaultBranch, defaultScope)
-      : { stateCommit: undefined, bitmap: undefined, hasDevCommits: false, tipMessage: '' };
+      : {
+          stateCommit: undefined,
+          bitmap: undefined,
+          hasDevCommits: false,
+          stateCommitBundlesSources: false,
+          tipMessage: '',
+        };
     if (hasSyncMarker(branchState.tipMessage)) {
       logger.console('branch tip is a bit-sync commit; reconciler will no-op unless the lane moved');
     }
@@ -444,7 +450,7 @@ export class LaneSyncExecutor {
 
     const branchNamesDifferentLane = await this.computeBranchNamesDifferentLane(
       lastSyncedHead,
-      branchState.hasDevCommits,
+      branchState.hasDevCommits || branchState.stateCommitBundlesSources,
       mirroredLane,
       laneIdStr,
       branch,
@@ -456,6 +462,7 @@ export class LaneSyncExecutor {
       branchExists,
       lastSyncedHead,
       hasDevCommits: branchState.hasDevCommits,
+      stateCommitBundlesSources: branchState.stateCommitBundlesSources,
       tipIsSyncCommit,
       hasIndependentHistory,
       conflictLabelPresent,
@@ -467,7 +474,9 @@ export class LaneSyncExecutor {
       chalk.blue(
         `${laneName} -> ${action.type} (branch: ${branch}, lane head: ${laneHead?.slice(0, 9) ?? 'none'}, ` +
           `branch state: ${lastSyncedHead?.slice(0, 9) ?? 'none'}, ` +
-          `dev commits: ${branchState.hasDevCommits}${laneIsGone ? `, branch claim: ${ownership}` : ''})`
+          `dev commits: ${branchState.hasDevCommits}` +
+          `${branchState.stateCommitBundlesSources ? ' (+sources bundled into the state commit)' : ''}` +
+          `${laneIsGone ? `, branch claim: ${ownership}` : ''})`
       )
     );
 
@@ -475,25 +484,6 @@ export class LaneSyncExecutor {
       const line = dryRunSummaryLine(laneName, action);
       logger.console(formatWarningSummary(`Dry-run: ${line}`));
       return line;
-    }
-
-    // A pair can be converged at the bit level while the tip still holds unsnapped source edits (a
-    // single commit that rewrites `.bitmap` AND carries an edit is its own state commit) — say so.
-    // `laneHead` must be checked explicitly: with no lane and no attribution both fingerprints are
-    // undefined, and `undefined === undefined` would fire on every ordinary developer branch.
-    if (
-      action.type === 'noop' &&
-      action.reason === 'converged' &&
-      !tipIsSyncCommit &&
-      laneHead &&
-      lastSyncedHead === laneHead
-    ) {
-      logger.console(
-        formatWarningSummary(
-          `converged on bit state, but ${branch}'s tip is not a bit ci sync commit — any source edits it ` +
-            `carries that were never snapped stay invisible until the next commit on the branch`
-        )
-      );
     }
 
     switch (action.type) {
@@ -523,7 +513,7 @@ export class LaneSyncExecutor {
         if (tipIsSyncCommit) {
           return `${laneName} -> noop (converged; branch tip is already this reconciler's own sync commit)`;
         }
-        return this.executeExportBranch({ target, laneIdStr, branch, defaultBranch });
+        return this.executeExportBranch({ target, laneIdStr, branch, defaultBranch, probeOnly: action.probeOnly });
       case 'merge-diverged':
         return this.executeMergeDiverged({ target, laneIdStr, branch, defaultBranch });
       case 'adopt-branch':
@@ -680,17 +670,21 @@ export class LaneSyncExecutor {
   /**
    * Push the branch's dev commits back onto the lane: snap+export the branch's tree, then commit the
    * resulting `.bitmap` back onto the branch so the next run sees the two sides as converged.
+   * `probeOnly` (sources bundled into the state commit, nothing else) lets the snap decide whether
+   * there was anything to export. Either answer records the ledger — see `probedClean` below.
    */
   private async executeExportBranch({
     target,
     laneIdStr,
     branch,
     defaultBranch,
+    probeOnly,
   }: {
     target: LaneTarget;
     laneIdStr: string;
     branch: string;
     defaultBranch: string;
+    probeOnly?: boolean;
   }): Promise<string> {
     const { logger } = this.deps;
     const laneName = target.name;
@@ -711,6 +705,14 @@ export class LaneSyncExecutor {
           pr: await this.findPr(branch),
         });
       }
+      // The probe found nothing pending: nothing reached the lane, but the ledger is still recorded.
+      // Skipping it is what makes the probe repeat — `stateCommit` (sync-state.ts) is derived from
+      // `.bitmap`'s content, so as long as the developer's bundled commit stays the tip,
+      // `stateCommitBundlesSources` stays true and every later run re-pays the checkout + snap on the
+      // identical sha. The ledger commit is `--allow-empty`, so it lands either way, and moving the tip
+      // is what lets the `tipIsSyncCommit` check in `syncLane` settle the next run before any
+      // workspace work — the same way a commit that touches no bit-tracked file settles.
+      const probedClean = Boolean(probeOnly) && exported.status === 'noop';
 
       const recorded = await this.recordLaneHeadOnBranch(target, laneIdStr, branch);
       if (recorded.status === 'raced') return racedLedgerPushSummary(laneName);
@@ -719,9 +721,17 @@ export class LaneSyncExecutor {
           laneName,
           laneIdStr,
           branch,
-          reason: `lane ${laneIdStr} could not be read back from the remote after export`,
+          reason: probedClean
+            ? `lane ${laneIdStr} could not be read back from the remote while recording the probe's sync ledger`
+            : `lane ${laneIdStr} could not be read back from the remote after export`,
           pr: await this.findPr(branch),
         });
+      }
+      if (probedClean) {
+        return (
+          `${laneName} -> noop (converged; the sources bundled into the state commit were already ` +
+          `snapped — recorded the sync ledger so the next run stops probing)`
+        );
       }
       return (
         `${laneName} -> export-branch (lane ${laneIdStr} @ ${recorded.laneHead.slice(0, 9)}, ` +
@@ -1137,13 +1147,13 @@ export class LaneSyncExecutor {
   /** Gates `differentLaneStillClaims` to the planner's first-contact path, the only one that reads it. */
   private async computeBranchNamesDifferentLane(
     lastSyncedHead: string | undefined,
-    hasDevCommits: boolean,
+    mayCarryWork: boolean,
     mirroredLane: string | undefined,
     laneIdStr: string,
     branch: string,
     defaultBranch: string
   ): Promise<boolean> {
-    if (lastSyncedHead || !hasDevCommits) return false;
+    if (lastSyncedHead || !mayCarryWork) return false;
     return this.differentLaneStillClaims(mirroredLane, laneIdStr, branch, defaultBranch);
   }
 

--- a/scopes/git/ci/sync/sync-planner.spec.ts
+++ b/scopes/git/ci/sync/sync-planner.spec.ts
@@ -116,6 +116,31 @@ const table: Array<{
   { name: 'dev commits, lane unchanged -> export-branch', input: { hasDevCommits: true }, type: 'export-branch' },
   { name: 'both moved -> merge-diverged', input: { laneHead: 'L2', hasDevCommits: true }, type: 'merge-diverged' },
   {
+    // Suspected work only — git cannot tell whether the bundled sources are inside the recorded snap,
+    // so the executor probes with the snap and settles without writing when nothing was pending.
+    name: 'sources bundled into the state commit, otherwise converged -> export-branch, probe only',
+    input: { stateCommitBundlesSources: true, tipIsSyncCommit: false },
+    type: 'export-branch',
+    action: { type: 'export-branch', probeOnly: true },
+  },
+  {
+    name: 'bundled sources count as work when the lane also moved -> merge-diverged',
+    input: { laneHead: 'L2', stateCommitBundlesSources: true, tipIsSyncCommit: false },
+    type: 'merge-diverged',
+  },
+  {
+    name: 'own-live with bundled sources -> KEEP the branch, naming the commits',
+    input: { ...laneGone('own-live'), stateCommitBundlesSources: true, tipIsSyncCommit: false },
+    type: 'close-pr',
+    action: { type: 'close-pr', deleteBranch: false, keepReason: 'unmerged-commits' },
+  },
+  {
+    // Adoption probes via `bit status`, so suspected bundled work routes there like dev commits do.
+    name: 'existing branch, never synced, bundled sources -> adopt-branch (first contact)',
+    input: { lastSyncedHead: undefined, ownership: 'inherited-or-none', stateCommitBundlesSources: true },
+    type: 'adopt-branch',
+  },
+  {
     name: 'existing branch, never synced, no dev commits, lane EXISTS -> import-lane (adopt branch)',
     input: { lastSyncedHead: undefined, ownership: 'inherited-or-none' },
     type: 'import-lane',

--- a/scopes/git/ci/sync/sync-planner.ts
+++ b/scopes/git/ci/sync/sync-planner.ts
@@ -24,6 +24,13 @@ export type LaneSyncInput = {
   /** whether the branch carries commits on top of the commit that last wrote its `.bitmap` */
   hasDevCommits: boolean;
   /**
+   * Whether the state commit itself (not written by this reconciler) also touched non-`.bitmap` files
+   * — SUSPECTED work git cannot confirm (the files may already be inside the recorded snap). Plans the
+   * probing `export-branch` when everything else reads converged; treated like dev commits everywhere
+   * a wrong "no work" answer could lose something (deletion, divergence, first contact).
+   */
+  stateCommitBundlesSources?: boolean;
+  /**
    * Whether the reconciler itself wrote the tip commit. The one exception to "markers are annotations":
    * consulted only on the branch-deletion path, and only ever to WITHHOLD a deletion. Must be computed
    * with `isSyncAuthoredMessage`, not the loop guard's substring match.
@@ -54,7 +61,10 @@ export type BranchKeepReason =
 export type LaneSyncAction =
   | { type: 'noop'; reason: string }
   | { type: 'import-lane' }
-  | { type: 'export-branch' }
+  // `probeOnly`: the only evidence of work is sources bundled into the state commit — the snap decides.
+  // Nothing pending → the executor settles as converged WITHOUT the ledger commit a plain export ends
+  // with (there is nothing to record, and writing one would put a commit on a converged dev branch).
+  | { type: 'export-branch'; probeOnly?: boolean }
   | { type: 'merge-diverged' }
   | { type: 'adopt-branch' }
   // Two variants rather than an optional `keepReason` so the type enforces that a keep always says why.
@@ -64,7 +74,10 @@ export type LaneSyncAction =
 
 export function planLaneSync(input: LaneSyncInput): LaneSyncAction {
   const { laneHead, branchExists, lastSyncedHead, hasDevCommits, conflictLabelPresent, ownership } = input;
-  const { tipIsSyncCommit, hasIndependentHistory, branchNamesDifferentLane } = input;
+  const { tipIsSyncCommit, hasIndependentHistory, branchNamesDifferentLane, stateCommitBundlesSources } = input;
+  // Suspected-or-real work: everywhere a wrong "no work" answer could lose something, bundled sources
+  // count like dev commits — only the converged/export split below distinguishes them (the probe).
+  const mayCarryWork = hasDevCommits || Boolean(stateCommitBundlesSources);
   if (conflictLabelPresent) {
     return { type: 'noop', reason: 'PR is labeled bit-sync-conflict; resolve and remove the label to resume' };
   }
@@ -72,11 +85,11 @@ export function planLaneSync(input: LaneSyncInput): LaneSyncAction {
     if (!branchExists) return { type: 'noop', reason: 'lane and branch both absent' };
     switch (ownership) {
       case 'own-live':
-        // Each check is a separate reason to withhold a delete: dev commits are work that exists
-        // nowhere else; a non-sync tip may be a developer's own `.bitmap` write; an adopted branch's
+        // Each check is a separate reason to withhold a delete: real or suspected work exists nowhere
+        // else; a non-sync tip may be a developer's own `.bitmap` write; an adopted branch's
         // pre-existing history was never proven disposable. A false keep is harmless, a false delete
         // destroys the only copy.
-        if (hasDevCommits) {
+        if (mayCarryWork) {
           return { type: 'close-pr', deleteBranch: false, keepReason: 'unmerged-commits' };
         }
         if (!tipIsSyncCommit) {
@@ -99,21 +112,23 @@ export function planLaneSync(input: LaneSyncInput): LaneSyncAction {
   }
   if (!branchExists) return { type: 'import-lane' };
   if (!lastSyncedHead) {
-    if (hasDevCommits) {
+    if (mayCarryWork) {
       if (branchNamesDifferentLane) {
         return {
           type: 'halt',
           reason: 'branch has commits but its .bitmap names a different lane; cannot tell which side is newer',
         };
       }
-      // The lane exists but the pair has no sync history: first contact, not a conflict.
+      // The lane exists but the pair has no sync history: first contact, not a conflict — and
+      // adoption already probes via `bit status`, so bundled sources are safe to route here too.
       return { type: 'adopt-branch' };
     }
     return { type: 'import-lane' };
   }
   const laneMoved = laneHead !== lastSyncedHead;
-  if (laneMoved && hasDevCommits) return { type: 'merge-diverged' };
+  if (laneMoved && mayCarryWork) return { type: 'merge-diverged' };
   if (laneMoved) return { type: 'import-lane' };
   if (hasDevCommits) return { type: 'export-branch' };
+  if (stateCommitBundlesSources) return { type: 'export-branch', probeOnly: true };
   return { type: 'noop', reason: 'converged' };
 }

--- a/scopes/git/ci/sync/sync-state.spec.ts
+++ b/scopes/git/ci/sync/sync-state.spec.ts
@@ -11,6 +11,7 @@ import {
   isSyncAuthoredMessage,
   parseBranchBitmap,
   parseDevCommitCount,
+  touchesBeyondBitmap,
 } from './sync-state';
 
 const DEFAULT_SCOPE = 'acme.shop';
@@ -205,6 +206,19 @@ describe('parseDevCommitCount', () => {
     it(`${hasDevCommits ? 'keeps the branch' : 'permits retirement'} for ${name}`, () => {
       expect(parseDevCommitCount(raw), JSON.stringify(raw)).to.equal(hasDevCommits);
     });
+  });
+});
+
+describe('touchesBeyondBitmap', () => {
+  it('is false for an empty diff and for a .bitmap-only commit', () => {
+    expect(touchesBeyondBitmap('')).to.equal(false);
+    expect(touchesBeyondBitmap('\n')).to.equal(false);
+    expect(touchesBeyondBitmap('.bitmap\n')).to.equal(false);
+  });
+
+  it('is true when any source file rides in the same commit as the .bitmap write', () => {
+    expect(touchesBeyondBitmap('.bitmap\ncomp1/index.js\n')).to.equal(true);
+    expect(touchesBeyondBitmap('comp1/index.js\n')).to.equal(true);
   });
 });
 

--- a/scopes/git/ci/sync/sync-state.ts
+++ b/scopes/git/ci/sync/sync-state.ts
@@ -160,6 +160,14 @@ export type BranchSyncState = {
   bitmap?: BranchBitmapState;
   /** Whether the branch carries commits on top of its bit state — work bit has not seen. */
   hasDevCommits: boolean;
+  /**
+   * Whether the state commit itself — a commit this reconciler did not write — also touched files
+   * besides `.bitmap`. SUSPECTED work only: those files may already be inside the snap the `.bitmap`
+   * records, which git cannot tell, so the executor probes with a snap. Note this is true for ANY
+   * other path, `docs/` and CI config included — the probe is the only thing that distinguishes real
+   * work, and it records the sync ledger either way so a clean answer is not re-probed forever.
+   */
+  stateCommitBundlesSources: boolean;
   /** The branch tip's full commit message (subject + body), for the sync-marker loop-guard probe. */
   tipMessage: string;
   /**
@@ -200,7 +208,65 @@ export async function readBranchSyncState(
   const range = stateCommit ? `${stateCommit}..${revision}` : `origin/${defaultBranch}..${revision}`;
   const count = await git.raw(['rev-list', range, '--count']);
 
-  return { stateCommit, bitmap, hasDevCommits: parseDevCommitCount(count), tipMessage, tipSha };
+  // Source edits can RIDE IN the state commit itself — one commit changing `.bitmap` AND sources (the
+  // exact shape the conflict-halt comment's resolve-by-hand recipe produces) — and the range count
+  // starts after that commit, so they were invisible. Git file names alone cannot tell whether those
+  // sources are already inside the snap the `.bitmap` records (a dev who snapped, exported, and
+  // committed everything at once) or were never snapped at all — so this is SUSPECTED work, reported
+  // separately for the planner to probe rather than folded into `hasDevCommits`. Only a commit this
+  // reconciler did not write can be that shape: its own ledger commits legitimately bundle merged
+  // sources (merge-diverged) and are already-exported state.
+  const stateCommitBundlesSources =
+    !parseDevCommitCount(count) &&
+    stateCommit !== undefined &&
+    stateCommit === tipSha &&
+    !isSyncAuthoredMessage(tipMessage) &&
+    (await commitTouchesBeyondBitmap(stateCommit));
+
+  return {
+    stateCommit,
+    bitmap,
+    hasDevCommits: parseDevCommitCount(count),
+    stateCommitBundlesSources,
+    tipMessage,
+    tipSha,
+  };
+}
+
+/**
+ * Whether `commit` changed any file besides `.bitmap`, against its first parent (`--root` covers an
+ * initial commit; `-m --first-parent` makes a merge commit report the files it brought in, instead of
+ * the silent empty diff plain `diff-tree` gives merges). Unreadable answers `true`: this feeds
+ * `stateCommitBundlesSources`, where not knowing must plan the probe, never declare convergence.
+ */
+async function commitTouchesBeyondBitmap(commit: string): Promise<boolean> {
+  try {
+    const names = await git.raw([
+      'diff-tree',
+      '--no-commit-id',
+      '--name-only',
+      '-r',
+      '--root',
+      '-m',
+      '--first-parent',
+      commit,
+    ]);
+    // A state commit changed `.bitmap` by definition, so its first-parent diff is never empty — empty
+    // output is simple-git resolving on a non-zero exit (see `parseDevCommitCount`), i.e. unreadable.
+    if (!names.trim()) return true;
+    return touchesBeyondBitmap(names);
+  } catch {
+    return true;
+  }
+}
+
+/** The pure half of `commitTouchesBeyondBitmap`, split out so it is testable without a real git log. */
+export function touchesBeyondBitmap(rawNames: string): boolean {
+  return rawNames
+    .split('\n')
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .some((name) => name !== BIT_MAP);
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

- Fix `bit ci sync` wrongly reporting "converged" when one git commit contains both a source edit and a `.bitmap` change. The edit never reached the lane, and the next lane update would overwrite it on the branch.

## The bug

Sync decides "does the branch have new work?" by counting commits AFTER the last commit that touched `.bitmap`. When a single commit changes `.bitmap` AND source files, that count is zero — so sync reports `noop (converged)` even though the source edit was never snapped. The lane never gets the edit, and a later `import-lane` overwrites it.

This is exactly the commit shape sync's own conflict-resolution instructions produce (`bit lane import`, fix the files, commit once). Found live while testing the halt → resolve → resume flow.

## The fix

Git alone can't tell whether the bundled files are already inside the recorded snap (a dev who snapped, exported, and committed everything at once) or were never snapped. So instead of guessing, sync checks with bit:

- Nothing to snap → truly converged. Sync writes nothing, same as before.
- Something to snap → real work. Sync exports it to the lane, like any other dev commit.

Where a wrong "no work" answer could lose something (branch deletion, divergence, first contact), the bundled commit counts as work — the safe direction. Sync's own ledger commits are exempt (they legitimately bundle merged sources).

## Tests

- New e2e reproducing the bug: red on master (`noop (converged)`), green with the fix (the lane gets the edit; the next run converges).
- The three `ci-sync-state.e2e.ts` cells that had locked the old behavior are updated: the converged-dev case still ends with zero writes, the invisible-edit case exports immediately.
- 257 unit tests, all 59 ci-sync e2e cells (both suites, post-merge with #10593), lint, prettier — green.

## Note

Master (with #10593 merged) is merged in. At first contact, a bundled commit routes to `adopt-branch` — adoption already checks with bit before writing — and the different-lane guard now also fires for bundled commits.
