### PR TITLE
fix(scope): retry transient remote-fetch failures; fix unhandled rejection in findFirstEnv

### DIFF
--- a/components/legacy/scope/objects-fetcher/objects-fetcher.ts
+++ b/components/legacy/scope/objects-fetcher/objects-fetcher.ts
@@ -169,7 +169,7 @@ the remote scope "${scopeName}" was not found`);
       throw err;
     }
     try {
-      return await remote.fetch(ids, this.getFetchOptionsPerRemote(scopeName), this.context);
+      return await this.fetchFromRemoteWithRetry(remote, ids, scopeName);
     } catch (err: any) {
       if (err instanceof ScopeNotFound && !shouldThrowOnUnavailableScope) {
         logger.error(`failed accessing the scope "${scopeName}". continuing without this scope.`);
@@ -180,6 +180,30 @@ the remote scope "${scopeName}" was not found`);
         throw err;
       }
       return null;
+    }
+  }
+
+  /**
+   * a fetch is read-only and idempotent, so transient server failures (UnexpectedNetworkError,
+   * e.g. a 500 from a remote under load) are worth a couple of retries before failing the whole
+   * command — a single transient 500 used to kill hour-long CI builds (`bit ci pr` on a lane with
+   * hundreds of components). other error types (auth, scope-not-found) still throw immediately.
+   */
+  private async fetchFromRemoteWithRetry(remote: Remote, ids: string[], scopeName: string): Promise<ObjectItemsStream> {
+    const maxAttempts = 3;
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await remote.fetch(ids, this.getFetchOptionsPerRemote(scopeName), this.context);
+      } catch (err: any) {
+        if (!(err instanceof UnexpectedNetworkError) || attempt >= maxAttempts) throw err;
+        const delayMs = 3000 * 4 ** (attempt - 1); // 3s, then 12s
+        logger.warn(
+          `fetch from "${scopeName}" failed with a network error (attempt ${attempt}/${maxAttempts}), retrying in ${
+            delayMs / 1000
+          }s. error: ${err.message}`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
     }
   }
 

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -975,11 +975,21 @@ if needed, use "bit env set" command to align the env id`;
         isFoundWithoutVersion = true;
         return true;
       }
-      const envComponent = await this.getEnvComponentByEnvId(id);
-      const hasManifest = this.hasEnvManifest(envComponent);
-      if (hasManifest) return true;
-      const isUsingEnvEnv = this.isUsingEnvEnv(envComponent);
-      return !!isUsingEnvEnv;
+      // pLocate runs predicates concurrently; once it settles, a predicate that rejects later has
+      // no handler and crashes the process as an unhandled rejection (observed with a remote
+      // scope-fetch 500 inside getEnvComponentByEnvId during `bit ci pr`). this is a discovery
+      // heuristic — an id whose component cannot be loaded simply cannot be identified as an env
+      // here, so log and move on rather than racing an uncatchable rejection.
+      try {
+        const envComponent = await this.getEnvComponentByEnvId(id);
+        const hasManifest = this.hasEnvManifest(envComponent);
+        if (hasManifest) return true;
+        const isUsingEnvEnv = this.isUsingEnvEnv(envComponent);
+        return !!isUsingEnvEnv;
+      } catch (err: any) {
+        this.logger.warn(`findFirstEnv: failed loading env-component "${id}", skipping it. error: ${err.message}`);
+        return false;
+      }
     });
     let finalEnvId;
     if (envId) {


### PR DESCRIPTION
## Why

While load-testing `bit ci pr` on a full-cascade lane (#10602), a single transient HTTP 500 from one scope fetch (`teambit.dependencies`) killed a 57-minute build — twice over:

1. `objects-fetcher` has no retry: one 500 on an idempotent read fails the whole command.
2. The error also escaped as an **unhandled promise rejection** through `findFirstEnv`'s `pLocate` — concurrent predicates that reject after `pLocate` settles have no handler and crash the process.

## Changes

- **Bounded retry on transient fetch failures**: `UnexpectedNetworkError` (server 5xx / isError payloads) retries up to 3 attempts with 3s/12s backoff, with a warning log per retry. Auth/scope-not-found errors throw immediately as before. Fetch is read-only and idempotent, so retrying is safe.
- **`findFirstEnv` predicate hardened**: load failures inside the discovery heuristic log a warning and return false ("cannot be identified as an env") instead of racing an uncatchable rejection.

## Verification
- `npm run lint` green (oxlint + tsc), `bit compile` on both components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)