### PR TITLE
ci: bit_pr on xlarge instead of 2xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,13 +835,13 @@ jobs:
 
   # ========== Bit CI Jobs ==========
   bit_pr:
-    # uncomment in case this job fails with "Killed".
-    resource_class: 2xlarge
-    # resource_class: xlarge
+    # xlarge validated on a worst-case 98-component cascade (no OOM at 12GB heap, same wall time
+    # as 2xlarge). If this job dies with "Killed", revert to 2xlarge + max-old-space-size=30000.
+    resource_class: xlarge
     <<: *defaults
     environment:
       # BIT_FEATURES: cloud-importer-v2
-      NODE_OPTIONS: --max-old-space-size=30000
+      NODE_OPTIONS: --max-old-space-size=12288
     steps:
       - attach_workspace:
           at: ./
@@ -866,7 +866,7 @@ jobs:
           command: 'cd bit && bit ci pr --build --keep-lane --skip-cleanup'
           no_output_timeout: '50m'
           environment:
-            NODE_OPTIONS: --max-old-space-size=30000
+            NODE_OPTIONS: --max-old-space-size=12288
             # NOTE: parallel builds (BIT_BUILD_CONCURRENCY>1) were measured here and did NOT help —
             # this build is CPU-bound and dominated by one env, so concurrency only added contention.
             # See tasks-parallel-scheduler.ts header for the numbers. Left serial on purpose.


### PR DESCRIPTION
## Proposed Changes

- Run the bit_pr job on xlarge instead of 2xlarge, halving its credit rate (80 to 40 credits per minute).
- Cap the Node heap at 12GB to fit the 16GB machine (was 30GB).

Validated on live runs at both extremes. A small 2-component lane used 318 credits instead of 661 and finished slightly faster (jobs 438274 vs 438241). A worst-case 98-component auto-snap cascade completed in 25 minutes with no OOM (job 438467). The build is CPU-bound on a single env, so the extra 8 cores were idle at double the rate.

Rollback: if the job ever dies with "Killed", revert to 2xlarge and restore max-old-space-size=30000.

Extracted from #10597 so it can land independently. That PR will rebase.