### PR TITLE
fix(scope): remove deprecated uid-number dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2074,9 +2074,6 @@ importers:
       ua-parser-js:
         specifier: 0.7.40
         version: 0.7.40
-      uid-number:
-        specifier: 0.0.6
-        version: 0.0.6
       uniqid:
         specifier: 5.3.0
         version: 5.3.0
@@ -3077,7 +3074,7 @@ importers:
         version: 0.0.312
       '@teambit/react.react-env':
         specifier: 2.0.3
-        version: 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.0)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)
+        version: 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler':
         specifier: ^5.0.1
         version: 5.0.1(react@19.2.7)
@@ -25718,9 +25715,6 @@ importers:
       tar-stream:
         specifier: 2.2.0
         version: 2.2.0
-      uid-number:
-        specifier: 0.0.6
-        version: 0.0.6
       uuid:
         specifier: 8.3.2
         version: 8.3.2
@@ -48832,9 +48826,6 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  uid-number@0.0.6:
-    resolution: {integrity: sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==}
-
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
@@ -56442,12 +56433,6 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.4
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.4)(react-refresh@0.14.0)':
-    dependencies:
-      react-refresh: 0.14.0
-    optionalDependencies:
-      '@rspack/core': 2.1.4
-
   '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.4)(react-refresh@0.14.2)':
     dependencies:
       react-refresh: 0.14.2
@@ -61908,7 +61893,7 @@ snapshots:
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/legacy.scope': file:components/legacy/scope(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 4.3.0
       chai-fs: 1.0.0(chai@4.3.0)
@@ -62127,7 +62112,7 @@ snapshots:
       '@teambit/legacy.consumer-component': file:components/legacy/consumer-component(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/legacy.scope': file:components/legacy/scope(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 5.2.1
       chai-fs: 1.0.0(chai@5.2.1)
@@ -62483,7 +62468,7 @@ snapshots:
       '@teambit/scope.modules.find-scope-path': file:components/modules/find-scope-path(react-dom@19.2.7)(react@19.2.7)
       '@teambit/scope.network': file:scopes/scope/network(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/scope.remotes': file:components/scope/remotes(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 4.3.0
       chalk: 4.1.2
@@ -62714,7 +62699,7 @@ snapshots:
       '@teambit/scope.modules.find-scope-path': file:components/modules/find-scope-path(react-dom@19.2.7)(react@19.2.7)
       '@teambit/scope.network': file:scopes/scope/network(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/scope.remotes': file:components/scope/remotes(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 5.2.1
       chalk: 4.1.2
@@ -84353,6 +84338,91 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
+  '@teambit/legacy.e2e-helper@file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)':
+    dependencies:
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
+      '@pnpm/network.fetch': 1100.1.11(@pnpm/logger@1100.0.0)
+      '@pnpm/registry-mock': 3.48.0(supports-color@9.4.0)(typanion@3.14.0)
+      '@teambit/component-id': 1.2.4
+      '@teambit/component.modules.merge-helper': file:scopes/component/modules/merge-helper(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/defender.fs.global-bit-temp-dir': 0.0.1
+      '@teambit/defender.mocha-tester': 1.1.1(@babel/core@7.28.3)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/dependencies.pnpm.dep-path': 1.0.1
+      '@teambit/harmony': 0.4.12
+      '@teambit/harmony.modules.feature-toggle': file:scopes/harmony/modules/feature-toggle(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/lane-id': 0.0.312
+      '@teambit/legacy.bit-map': file:components/legacy/bit-map(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(browserslist@4.23.3)(eslint@8.56.0)(less@4.2.1)(react-refresh@0.10.0)(rollup@4.53.3)(supports-color@9.4.0)(webpack@5.97.1)
+      '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
+      '@teambit/workspace.root-components': 1.0.1
+      chai-fs: 1.0.0(chai@4.3.0)
+      chalk: 4.1.2
+      comment-json: 4.2.5
+      execa: 2.1.0
+      fs-extra: 10.0.0
+      glob: 13.0.0
+      ini: 2.0.0
+      lodash: 4.17.21
+      lodash.flatten: 4.4.0
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      pad-right: 0.2.2
+      react: 19.2.7
+      react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
+      resolve-from: 5.0.0
+      tar: 7.4.3
+      yaml: 1.10.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@pnpm/logger'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@types/webpack'
+      - babel-plugin-macros
+      - browserslist
+      - bufferutil
+      - canvas
+      - chai
+      - clean-css
+      - csso
+      - debug
+      - domexception
+      - encoding
+      - esbuild
+      - eslint
+      - fibers
+      - graphql
+      - less
+      - lightningcss
+      - node-notifier
+      - node-sass
+      - react-dom
+      - react-refresh
+      - rollup
+      - sass-embedded
+      - selfsigned
+      - sockjs-client
+      - supports-color
+      - ts-node
+      - typanion
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
   '@teambit/legacy.e2e-helper@file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@18.3.1)(react-refresh@0.10.0)(react@18.3.1)(rollup@4.53.3)(typanion@3.14.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)':
     dependencies:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
@@ -84541,6 +84611,91 @@ snapshots:
       '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(browserslist@4.23.3)(debug@4.3.4)(eslint@8.56.0)(less@4.2.1)(react-refresh@0.10.0)(rollup@4.53.3)(supports-color@9.4.0)(webpack@5.97.1)
+      '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
+      '@teambit/workspace.root-components': 1.0.1
+      chai-fs: 1.0.0(chai@5.2.1)
+      chalk: 4.1.2
+      comment-json: 4.2.5
+      execa: 2.1.0
+      fs-extra: 10.0.0
+      glob: 13.0.0
+      ini: 2.0.0
+      lodash: 4.17.21
+      lodash.flatten: 4.4.0
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      pad-right: 0.2.2
+      react: 19.2.7
+      react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
+      resolve-from: 5.0.0
+      tar: 7.4.3
+      yaml: 1.10.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@pnpm/logger'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@types/webpack'
+      - babel-plugin-macros
+      - browserslist
+      - bufferutil
+      - canvas
+      - chai
+      - clean-css
+      - csso
+      - debug
+      - domexception
+      - encoding
+      - esbuild
+      - eslint
+      - fibers
+      - graphql
+      - less
+      - lightningcss
+      - node-notifier
+      - node-sass
+      - react-dom
+      - react-refresh
+      - rollup
+      - sass-embedded
+      - selfsigned
+      - sockjs-client
+      - supports-color
+      - ts-node
+      - typanion
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/legacy.e2e-helper@file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)':
+    dependencies:
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
+      '@pnpm/network.fetch': 1100.1.11(@pnpm/logger@1100.0.0)
+      '@pnpm/registry-mock': 3.48.0(supports-color@9.4.0)(typanion@3.14.0)
+      '@teambit/component-id': 1.2.4
+      '@teambit/component.modules.merge-helper': file:scopes/component/modules/merge-helper(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/defender.fs.global-bit-temp-dir': 0.0.1
+      '@teambit/defender.mocha-tester': 1.1.1(@babel/core@7.28.3)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/dependencies.pnpm.dep-path': 1.0.1
+      '@teambit/harmony': 0.4.12
+      '@teambit/harmony.modules.feature-toggle': file:scopes/harmony/modules/feature-toggle(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/lane-id': 0.0.312
+      '@teambit/legacy.bit-map': file:components/legacy/bit-map(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(browserslist@4.23.3)(eslint@8.56.0)(less@4.2.1)(react-refresh@0.10.0)(rollup@4.53.3)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/toolbox.string.random': file:scopes/toolbox/string/random(react-dom@19.2.7)(react@19.2.7)
       '@teambit/typescript.typescript-compiler': 5.0.2(react@19.2.7)
       '@teambit/workspace.root-components': 1.0.1
@@ -87160,7 +87315,6 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
       semver: 7.7.1
       tar-stream: 2.2.0
-      uid-number: 0.0.6
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@types/react'
@@ -87214,7 +87368,6 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@18.3.1)(react@18.3.1)
       semver: 7.7.1
       tar-stream: 2.2.0
-      uid-number: 0.0.6
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@types/react'
@@ -87268,7 +87421,6 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
       semver: 7.7.1
       tar-stream: 2.2.0
-      uid-number: 0.0.6
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@types/react'
@@ -87322,7 +87474,6 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
       semver: 7.7.1
       tar-stream: 2.2.0
-      uid-number: 0.0.6
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@types/react'
@@ -90637,14 +90788,14 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/react.react-env@2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.14.0)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)':
+  '@teambit/react.react-env@2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.7)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(less@4.2.1)(lightningcss@1.28.2)(react-refresh@0.10.0)(rollup@4.53.3)(sass-embedded@1.100.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
       '@rspack/core': 2.1.4
       '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.14.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.10.0)
       '@teambit/defender.jest-tester': 2.1.3(@babel/traverse@7.29.7)(jest@29.3.1)(supports-color@9.4.0)
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/dependencies.modules.packages-excluder': 1.0.8(react@19.2.7)
@@ -90655,8 +90806,8 @@ snapshots:
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
-      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.0)(react@19.2.7)(webpack@5.97.1)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
       '@testing-library/jest-dom': 6.5.0
@@ -90967,7 +91118,7 @@ snapshots:
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -91123,7 +91274,7 @@ snapshots:
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
       '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -91214,6 +91365,84 @@ snapshots:
       core-js: 3.13.0
       graphql: 15.8.0
       jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      sass: 1.72.0
+      sass-loader: 16.0.8(@rspack/core@2.1.4)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@types/webpack'
+      - babel-plugin-macros
+      - browserslist
+      - bufferutil
+      - canvas
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - fibers
+      - less
+      - lightningcss
+      - node-notifier
+      - node-sass
+      - react-refresh
+      - rollup
+      - sass-embedded
+      - selfsigned
+      - sockjs-client
+      - supports-color
+      - ts-node
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/react.react-env@2.0.3(@babel/core@7.28.3)(browserslist@4.23.3)(eslint@8.56.0)(less@4.2.1)(react-refresh@0.10.0)(rollup@4.53.3)(supports-color@9.4.0)(webpack@5.97.1)':
+    dependencies:
+      '@babel/runtime': 7.20.0
+      '@bitdev/react.preview.react-docs-template': 1.0.13(react-dom@19.2.7)(react@19.2.7)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
+      '@rspack/core': 2.1.4
+      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.10.0)
+      '@teambit/defender.jest-tester': 2.1.3(@babel/traverse@7.29.7)(jest@29.3.1)(supports-color@9.4.0)
+      '@teambit/defender.prettier-formatter': 1.0.24
+      '@teambit/dependencies.modules.packages-excluder': 1.0.8(react@19.2.7)
+      '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
+      '@teambit/oxc.linter.oxlint-linter': 2.0.5
+      '@teambit/react.apps.react-app-types': 2.1.0(@babel/core@7.28.3)(@rspack/core@2.1.4)(@testing-library/react@16.3.2)(@types/react@19.2.14)(browserslist@4.23.3)(eslint@8.56.0)(less@4.2.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)
+      '@teambit/react.generator.react-starters': 1.0.9
+      '@teambit/react.generator.react-templates': 1.0.13
+      '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.7)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
+      '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
+      '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/jest-dom': 6.5.0
+      '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
+      '@types/jest': 29.5.14
+      '@types/node': 22.10.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      core-js: 3.13.0
+      graphql: 15.8.0
+      jest: 29.3.1(@types/node@22.10.5)(babel-plugin-macros@3.1.0)(supports-color@9.4.0)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
       oxlint-tsgolint: 0.17.0
       react: 19.2.7
@@ -94453,7 +94682,7 @@ snapshots:
       '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/legacy-bit-id': 1.1.3
       '@teambit/workspace.modules.node-modules-linker': file:scopes/workspace/modules/node-modules-linker(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 4.3.0
       chai-fs: 1.0.0(chai@4.3.0)
@@ -94657,7 +94886,7 @@ snapshots:
       '@teambit/harmony.testing.load-aspect': file:scopes/harmony/testing/load-aspect(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/legacy-bit-id': 1.1.3
       '@teambit/workspace.modules.node-modules-linker': file:scopes/workspace/modules/node-modules-linker(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 5.2.1
       chai-fs: 1.0.0(chai@5.2.1)
@@ -94979,6 +95208,41 @@ snapshots:
       - vue-template-compiler
       - webpack
 
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)':
+    dependencies:
+      '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
+      '@rspack/core': 2.1.4
+      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
+      '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
+      '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)
+      '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
+      '@teambit/ui-foundation.ui.rendering.html': 0.0.95(react-dom@19.2.7)(react@19.2.7)
+      object-hash: 3.0.0
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
+      - '@types/node'
+      - '@types/react'
+      - babel-plugin-macros
+      - eslint
+      - fibers
+      - node-notifier
+      - node-sass
+      - react-dom
+      - react-refresh
+      - rollup
+      - sass
+      - sass-embedded
+      - selfsigned
+      - supports-color
+      - ts-node
+      - typescript
+      - vue-template-compiler
+      - webpack
+
   '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
@@ -95014,49 +95278,14 @@ snapshots:
       - vue-template-compiler
       - webpack
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.4
       '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
       '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
-      '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)
-      '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
-      '@teambit/ui-foundation.ui.rendering.html': 0.0.95(react-dom@19.2.7)(react@19.2.7)
-      object-hash: 3.0.0
-      react: 19.2.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
-      - '@types/node'
-      - '@types/react'
-      - babel-plugin-macros
-      - eslint
-      - fibers
-      - node-notifier
-      - node-sass
-      - react-dom
-      - react-refresh
-      - rollup
-      - sass
-      - sass-embedded
-      - selfsigned
-      - supports-color
-      - ts-node
-      - typescript
-      - vue-template-compiler
-      - webpack
-
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.14.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)':
-    dependencies:
-      '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
-      '@rspack/core': 2.1.4
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@teambit/react.mounter': 1.1.9(@types/node@22.10.5)(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.0)(react@19.2.7)(webpack@5.97.1)
-      '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.14.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)
+      '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.97.1)
       '@teambit/ui-foundation.ui.rendering.html': 0.0.95(react-dom@19.2.7)(react@19.2.7)
       object-hash: 3.0.0
@@ -95400,25 +95629,6 @@ snapshots:
       - selfsigned
       - webpack
 
-  '@teambit/rspack.modules.rspack-config-mutator@1.0.23(react-refresh@0.14.0)(react@19.2.7)(webpack@5.97.1)':
-    dependencies:
-      '@rspack/core': 2.1.4
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.14.0)
-      '@teambit/html.modules.inject-html-element': 0.0.6(react@19.2.7)
-      '@teambit/webpack.modules.generate-externals': 0.0.21
-      camelcase: 6.2.0
-      enhanced-resolve: 5.24.3
-      find-root: 1.1.0
-      html-webpack-plugin: 5.6.3(@rspack/core@2.1.4)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
-      - react
-      - react-refresh
-      - selfsigned
-      - webpack
-
   '@teambit/rspack.modules.rspack-config-mutator@1.0.23(react-refresh@0.14.2)(react@18.3.1)(webpack@5.97.1)':
     dependencies:
       '@rspack/core': 2.1.4
@@ -95725,6 +95935,44 @@ snapshots:
       - supports-color
       - webpack
 
+  '@teambit/rspack.rspack-bundler@1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)':
+    dependencies:
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
+      '@mdx-js/loader': 3.1.1(supports-color@9.4.0)(webpack@5.97.1)
+      '@rspack/core': 2.1.4
+      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.10.0)
+      '@teambit/bit-error': 0.0.404
+      '@teambit/component-id': 1.2.4
+      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
+      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)(supports-color@9.4.0)
+      '@teambit/react.babel.bit-react-transformer': 1.0.34(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
+      babel-loader: 9.1.3(@babel/core@7.28.3)(webpack@5.97.1)
+      compression-webpack-plugin: 11.1.0(webpack@5.97.1)
+      lodash: 4.17.21
+      node-polyfill-webpack-plugin: 4.1.0(webpack@5.97.1)
+      p-map-series: 2.1.0
+      process: 0.11.10
+      rspack-manifest-plugin: 5.2.1(@rspack/core@2.1.4)
+      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
+      - fibers
+      - node-sass
+      - react
+      - react-dom
+      - react-refresh
+      - rollup
+      - sass
+      - sass-embedded
+      - selfsigned
+      - supports-color
+      - webpack
+
   '@teambit/rspack.rspack-bundler@1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)':
     dependencies:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
@@ -95739,82 +95987,6 @@ snapshots:
       '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)(supports-color@9.4.0)
       '@teambit/react.babel.bit-react-transformer': 1.0.34(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
-      babel-loader: 9.1.3(@babel/core@7.28.3)(webpack@5.97.1)
-      compression-webpack-plugin: 11.1.0(webpack@5.97.1)
-      lodash: 4.17.21
-      node-polyfill-webpack-plugin: 4.1.0(webpack@5.97.1)
-      p-map-series: 2.1.0
-      process: 0.11.10
-      rspack-manifest-plugin: 5.2.1(@rspack/core@2.1.4)
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
-      - fibers
-      - node-sass
-      - react
-      - react-dom
-      - react-refresh
-      - rollup
-      - sass
-      - sass-embedded
-      - selfsigned
-      - supports-color
-      - webpack
-
-  '@teambit/rspack.rspack-bundler@1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)':
-    dependencies:
-      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
-      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
-      '@mdx-js/loader': 3.1.1(supports-color@9.4.0)(webpack@5.97.1)
-      '@rspack/core': 2.1.4
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.10.0)
-      '@teambit/bit-error': 0.0.404
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)(supports-color@9.4.0)
-      '@teambit/react.babel.bit-react-transformer': 1.0.34(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.97.1)
-      babel-loader: 9.1.3(@babel/core@7.28.3)(webpack@5.97.1)
-      compression-webpack-plugin: 11.1.0(webpack@5.97.1)
-      lodash: 4.17.21
-      node-polyfill-webpack-plugin: 4.1.0(webpack@5.97.1)
-      p-map-series: 2.1.0
-      process: 0.11.10
-      rspack-manifest-plugin: 5.2.1(@rspack/core@2.1.4)
-      sass-loader: 13.3.2(sass-embedded@1.100.0)(sass@1.72.0)(webpack@5.97.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
-      - fibers
-      - node-sass
-      - react
-      - react-dom
-      - react-refresh
-      - rollup
-      - sass
-      - sass-embedded
-      - selfsigned
-      - supports-color
-      - webpack
-
-  '@teambit/rspack.rspack-bundler@1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.14.0)(react@19.2.7)(rollup@4.53.3)(sass-embedded@1.100.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.97.1)':
-    dependencies:
-      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
-      '@babel/preset-react': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
-      '@mdx-js/loader': 3.1.1(supports-color@9.4.0)(webpack@5.97.1)
-      '@rspack/core': 2.1.4
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.14.0)
-      '@teambit/bit-error': 0.0.404
-      '@teambit/component-id': 1.2.4
-      '@teambit/mdx.modules.mdx-pre-loader': 0.0.1
-      '@teambit/mdx.modules.mdx-v3-options': 0.0.3(rollup@4.53.3)(supports-color@9.4.0)
-      '@teambit/react.babel.bit-react-transformer': 1.0.34(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.14.0)(react@19.2.7)(webpack@5.97.1)
       babel-loader: 9.1.3(@babel/core@7.28.3)(webpack@5.97.1)
       compression-webpack-plugin: 11.1.0(webpack@5.97.1)
       lodash: 4.17.21
@@ -96116,7 +96288,7 @@ snapshots:
       '@teambit/scope.network': file:scopes/scope/network(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema(react-dom@19.2.7)(react@19.2.7)
       '@teambit/semantics.entities.semantic-schema-diff': file:components/entities/semantic-schema-diff(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 4.3.0
       chalk: 4.1.2
@@ -96323,7 +96495,7 @@ snapshots:
       '@teambit/scope.network': file:scopes/scope/network(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/semantics.entities.semantic-schema': file:components/entities/semantic-schema(react-dom@19.2.7)(react@19.2.7)
       '@teambit/semantics.entities.semantic-schema-diff': file:components/entities/semantic-schema-diff(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 5.2.1
       chalk: 4.1.2
@@ -97890,7 +98062,7 @@ snapshots:
       '@teambit/toolbox.crypto.sha1': file:components/crypto/sha1(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.promise.map-pool': file:scopes/toolbox/promise/map-pool(react-dom@19.2.7)(react@19.2.7)
       '@teambit/workspace.modules.node-modules-linker': file:scopes/workspace/modules/node-modules-linker(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 4.3.0
       chalk: 4.1.2
@@ -98175,7 +98347,7 @@ snapshots:
       '@teambit/toolbox.crypto.sha1': file:components/crypto/sha1(react-dom@19.2.7)(react@19.2.7)
       '@teambit/toolbox.promise.map-pool': file:scopes/toolbox/promise/map-pool(react-dom@19.2.7)(react@19.2.7)
       '@teambit/workspace.modules.node-modules-linker': file:scopes/workspace/modules/node-modules-linker(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
-      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      '@teambit/workspace.testing.mock-workspace': file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.14)(react-dom@19.2.7)(react@19.2.7)
       chai: 5.2.1
       chalk: 4.1.2
@@ -105237,6 +105409,62 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
+  '@teambit/workspace.testing.mock-workspace@file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)':
+    dependencies:
+      '@teambit/legacy.e2e-helper': file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      comment-json: 4.2.5
+      fs-extra: 10.0.0
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@pnpm/logger'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@types/webpack'
+      - babel-plugin-macros
+      - browserslist
+      - bufferutil
+      - canvas
+      - chai
+      - clean-css
+      - csso
+      - debug
+      - domexception
+      - encoding
+      - esbuild
+      - eslint
+      - fibers
+      - graphql
+      - less
+      - lightningcss
+      - node-notifier
+      - node-sass
+      - react
+      - react-dom
+      - react-refresh
+      - rollup
+      - sass-embedded
+      - selfsigned
+      - sockjs-client
+      - supports-color
+      - ts-node
+      - typanion
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
   '@teambit/workspace.testing.mock-workspace@file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@18.3.1)(react-refresh@0.10.0)(react@18.3.1)(rollup@4.53.3)(typanion@3.14.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)':
     dependencies:
       '@teambit/legacy.e2e-helper': file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@4.3.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@18.3.1)(react-refresh@0.10.0)(react@18.3.1)(rollup@4.53.3)(typanion@3.14.0)(webpack-hot-middleware@2.26.1)(webpack@5.97.1)
@@ -105352,6 +105580,62 @@ snapshots:
   '@teambit/workspace.testing.mock-workspace@file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(debug@4.3.4)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)':
     dependencies:
       '@teambit/legacy.e2e-helper': file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(debug@4.3.4)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
+      comment-json: 4.2.5
+      fs-extra: 10.0.0
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      react-router-dom: 6.30.1(react-dom@19.2.7)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/traverse'
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@pnpm/logger'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@types/webpack'
+      - babel-plugin-macros
+      - browserslist
+      - bufferutil
+      - canvas
+      - chai
+      - clean-css
+      - csso
+      - debug
+      - domexception
+      - encoding
+      - esbuild
+      - eslint
+      - fibers
+      - graphql
+      - less
+      - lightningcss
+      - node-notifier
+      - node-sass
+      - react
+      - react-dom
+      - react-refresh
+      - rollup
+      - sass-embedded
+      - selfsigned
+      - sockjs-client
+      - supports-color
+      - ts-node
+      - typanion
+      - type-fest
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@teambit/workspace.testing.mock-workspace@file:scopes/workspace/testing/mock-workspace(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)':
+    dependencies:
+      '@teambit/legacy.e2e-helper': file:components/legacy/e2e-helper(@babel/core@7.28.3)(@pnpm/logger@1100.0.0)(browserslist@4.23.3)(chai@5.2.1)(domexception@4.0.0)(eslint@8.56.0)(graphql@15.8.0)(less@4.2.1)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@4.53.3)(supports-color@9.4.0)(typanion@3.14.0)(webpack@5.97.1)
       comment-json: 4.2.5
       fs-extra: 10.0.0
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -121290,8 +121574,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  uid-number@0.0.6: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/scopes/scope/objects/objects/repository.ts
+++ b/scopes/scope/objects/objects/repository.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import uidNumber from 'uid-number';
 import { Mutex } from 'async-mutex';
 import { compact, uniqBy, differenceWith, isEqual } from 'lodash';
 import { BitError } from '@teambit/bit-error';
@@ -756,25 +755,23 @@ async function removeFile(filePath: string, propagateDirs = false): Promise<bool
   return true;
 }
 
-function resolveGroupId(groupName: string): Promise<number | null | undefined> {
-  return new Promise((resolve, reject) => {
-    uidNumber(null, groupName, (err, uid, gid) => {
-      if (err) {
-        logger.error('resolveGroupId', err);
-        if (err.message.includes('EPERM')) {
-          return reject(
-            new BitError(
-              `unable to resolve group id of "${groupName}", current user does not have sufficient permissions`
-            )
-          );
-        }
-        if (err.message.includes('group id does not exist')) {
-          return reject(new BitError(`unable to resolve group id of "${groupName}", the group does not exist`));
-        }
-        return reject(new BitError(`unable to resolve group id of "${groupName}", got an error ${err.message}`));
-      }
-      // on Windows it'll always be null
-      return resolve(gid);
-    });
-  });
+async function resolveGroupId(groupName: string): Promise<number | null | undefined> {
+  // unix group ids are meaningless on Windows, which has no /etc/group and no process.getgid
+  if (!process.getgid) return null;
+  let groupFileContent: string;
+  try {
+    groupFileContent = await fs.readFile('/etc/group', 'utf8');
+  } catch (err: any) {
+    logger.error('resolveGroupId', err);
+    throw new BitError(`unable to resolve group id of "${groupName}", got an error ${err.message}`);
+  }
+  const groupLine = groupFileContent.split('\n').find((line) => line.split(':')[0] === groupName);
+  if (!groupLine) {
+    throw new BitError(`unable to resolve group id of "${groupName}", the group does not exist`);
+  }
+  const gid = Number(groupLine.split(':')[2]);
+  if (Number.isNaN(gid)) {
+    throw new BitError(`unable to resolve group id of "${groupName}", got an error parsing /etc/group`);
+  }
+  return gid;
 }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -643,7 +643,6 @@
         "type-coverage": "2.15.1",
         "typescript": "5.9.2",
         "ua-parser-js": "0.7.40",
-        "uid-number": "0.0.6",
         "uniqid": "5.3.0",
         "url": "^0.11.3",
         "url-join": "4.0.1",


### PR DESCRIPTION
## Summary
- `uid-number` is unmaintained and resolves a group name to a gid by spawning a subprocess (forking node with a helper script that calls `setuid`/`setgid`).
- Replaced with a direct, in-process read/parse of `/etc/group`, no subprocess involved.
- Removed the dependency from `workspace.jsonc` and the lockfile.

## Test plan
- [x] `npm run lint` (tsc + oxlint) passes
- [x] `bit install` regenerates the lockfile without `uid-number`