### PR TITLE
fix(ci): bump bit_merge --increment-by 3 to skip stuck npm versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,8 +923,8 @@ jobs:
       - run: cd bit && npm run generate-core-aspects-ids
       - run:
           name: 'bit ci merge'
-          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual ${BIT_CI_MERGE_EXTRA_FLAGS}'
-          # command: 'cd bit && bit ci merge --build --auto-merge-resolve manual --increment-by 2 ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          # command: 'cd bit && bit ci merge --build --auto-merge-resolve manual ${BIT_CI_MERGE_EXTRA_FLAGS}'
+          command: 'cd bit && bit ci merge --build --auto-merge-resolve manual --increment-by 3 ${BIT_CI_MERGE_EXTRA_FLAGS}'
           no_output_timeout: '50m'
           environment:
             NODE_OPTIONS: --max-old-space-size=30000


### PR DESCRIPTION
The master version-bump job (\`bit_merge\`) has been failing on every merge since 2026-08-11: the original tag (2.0.75-generation) partially published to npm but failed to export to hub.bit.dev (\`Forbidden: teambit.harmony\`, fixed now by rotating \`BIT_CLOUD_PROD_TOKEN\`). Since the git commit never landed, every retry recomputes the same version numbers and hits npm 403 "already published" for the packages that did get through, blocking every merge to master.

Switches \`bit ci merge\` to \`--increment-by 3\`, jumping past the colliding versions so the next tag succeeds. This flag already existed as a commented-out fallback in the config from a past occurrence of this same issue.

Once merged and normal, this should probably be reverted back to the default increment.