### PR TITLE
perf(ui): bundle both ui roots in one compilation, 24MB to 16MB

### DIFF
--- a/components/modules/generate-asset-manifest/generate-asset-manifest.ts
+++ b/components/modules/generate-asset-manifest/generate-asset-manifest.ts
@@ -2,8 +2,20 @@ import type { Compilation } from '@rspack/core';
 
 export type ManifestResult = {
   files: Record<string, string>;
+  /**
+   * assets of the `main` entry, kept for compilations that have exactly one entry.
+   * empty when the compilation has no entry named `main` - read `entrypointsByName` instead.
+   */
   entrypoints: string[];
+  /** assets of every entry, keyed by entry name. */
+  entrypointsByName: Record<string, string[]>;
 };
+
+function assetNames(entry: any): string[] {
+  return (entry?.assets || [])
+    .map((asset: any) => asset.name || asset)
+    .filter((name: string) => !name.endsWith('.map'));
+}
 
 /**
  * Generate a CRA-compatible manifest object from an rspack compilation.
@@ -12,6 +24,10 @@ export type ManifestResult = {
  * ```ts
  * new RspackManifestPlugin({ fileName: 'asset-manifest.json', generate: generateAssetManifest })
  * ```
+ *
+ * A multi-entry compilation cannot describe itself with a single `entrypoints` list, so every
+ * entry is also reported under `entrypointsByName`. Consumers that serve one entry of a
+ * multi-entry build (the UI bundle's ssr middleware) pick their entry from there.
  */
 export function generateAssetManifest(
   _seed: Record<string, any>,
@@ -25,9 +41,10 @@ export function generateAssetManifest(
     if (asset.name) files[asset.name] = `/${asset.name}`;
   }
   const stats = compilation.getStats().toJson({ all: false, entrypoints: true });
-  const mainEntry = (stats as any).entrypoints?.main;
-  const entrypoints = (mainEntry?.assets || [])
-    .map((a: any) => a.name || a)
-    .filter((name: string) => !name.endsWith('.map'));
-  return { files, entrypoints };
+  const statsEntrypoints = ((stats as any).entrypoints || {}) as Record<string, any>;
+  const entrypointsByName: Record<string, string[]> = {};
+  for (const [name, entry] of Object.entries(statsEntrypoints)) {
+    entrypointsByName[name] = assetNames(entry);
+  }
+  return { files, entrypoints: entrypointsByName.main || [], entrypointsByName };
 }

--- a/e2e/harmony/ui-ssr.e2e.ts
+++ b/e2e/harmony/ui-ssr.e2e.ts
@@ -17,6 +17,8 @@ const PORT = 3025;
   let helper: Helper;
   let httpHelper: HttpHelper;
   let html: string;
+  let clientRenderedResponse: Response;
+  let clientRenderedHtml: string;
 
   before(async () => {
     helper = new Helper();
@@ -31,6 +33,10 @@ const PORT = 3025;
     await httpHelper.start();
     const response = await fetch(`http://localhost:${PORT}/`);
     html = await response.text();
+    // `rendering=client` makes the ssr middleware call `next()`, which is the only way to reach the
+    // history-api fallback - the document every client-side route is served from.
+    clientRenderedResponse = await fetch(`http://localhost:${PORT}/some/client/route?rendering=client`);
+    clientRenderedHtml = await clientRenderedResponse.text();
   });
 
   after(async () => {
@@ -51,6 +57,16 @@ const PORT = 3025;
   it('should not emit a module as an asset url where a component is expected', () => {
     // the "Invalid tag" symptom: an emitted asset path reaching react as a tag name.
     expect(html).to.not.match(/<\/?"?\/public\/ssr\//);
+  });
+
+  it("should serve this root's html for a client-side route", () => {
+    // both UI roots are entries of one bundle, so there is no shared `index.html` and the server
+    // falls back to `<root>.html`. get that name wrong and every client-side route 404s while the
+    // ssr-rendered ones keep working, so this asserts the fallback specifically.
+    expect(clientRenderedResponse.status).to.equal(200);
+    expect(clientRenderedHtml).to.have.string('<div id="root">');
+    // and it is this root's document: it must load the scope entry, not another root's
+    expect(clientRenderedHtml).to.match(/src="[^"]*\/scope\.[a-f0-9]+\.js"/);
   });
 
   it('should render the scope name into the markup, not just the document title', () => {

--- a/scopes/ui-foundation/ui/bundle-ui.task.ts
+++ b/scopes/ui-foundation/ui/bundle-ui.task.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import pMapSeries from 'p-map-series';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import type { BuildContext, BuildTask, BuiltTaskResult, TaskLocation } from '@teambit/builder';
 import type { Capsule } from '@teambit/isolator';
@@ -18,6 +19,20 @@ export const BUNDLE_UIROOT_DIR = {
 };
 export const BUNDLE_UI_HASH_FILENAME = '.hash';
 
+/**
+ * Both UI roots are bundled by a single rspack compilation, one entry each, so the roots share
+ * every chunk they have in common instead of each shipping a full copy of the app. The entry name
+ * is the root's short name, and each entry gets its own html naming the chunks only it needs.
+ */
+export function getUiRootEntryName(uiRootAspectId: string): string {
+  // a root outside the two bit ships still gets a usable entry name rather than failing the build.
+  return BUNDLE_UIROOT_DIR[uiRootAspectId] || uiRootAspectId.replace(/[^a-zA-Z0-9-]+/g, '-');
+}
+
+export function getUiRootHtmlFilename(uiRootAspectId: string): string {
+  return `${getUiRootEntryName(uiRootAspectId)}.html`;
+}
+
 export class BundleUiTask implements BuildTask {
   aspectId = 'teambit.ui-foundation/ui';
   name = BUNDLE_UI_TASK_NAME;
@@ -36,75 +51,47 @@ export class BundleUiTask implements BuildTask {
       return { componentsResults: [] };
     }
 
-    const uiRootAspectIds = Object.values(UIROOT_ASPECT_IDS);
-    try {
-      // allSettled, not all: `all` rejects as soon as one root fails, and the `finally` below would
-      // then close compilers while the other root is still bundling. Wait for both, then report.
-      const outcomes = await Promise.allSettled(
-        uiRootAspectIds.map(async (uiRootAspectId) => {
-          const outputPath = join(capsule.path, BundleUiTask.getArtifactDirectory(uiRootAspectId));
-          this.logger.info(`Generating UI bundle at ${outputPath}...`);
-          await this.ui.build(uiRootAspectId, outputPath, { deferClose: true });
-          await this.generateHash(outputPath);
-        })
-      );
-      const failures = outcomes.flatMap((outcome, index) =>
-        outcome.status === 'rejected' ? [{ uiRootAspectId: uiRootAspectIds[index], reason: outcome.reason }] : []
-      );
-      if (failures.length) {
-        // Log every root that failed, not only the one that ends the task. The reason itself is
-        // usually rspack's entire stats output - megabytes - so it goes to the log and to `cause`,
-        // and the thrown message names the roots, which is what the build pipeline prints.
-        failures.forEach(({ uiRootAspectId, reason }) =>
-          this.logger.error(`Generating UI bundle failed for ${uiRootAspectId}`, reason)
-        );
-        const error: any = new Error(
-          `Generating UI bundle failed for ${failures.map((failure) => failure.uiRootAspectId).join(', ')}`
-        );
-        // not `new Error(msg, { cause })`: this project targets es2015, whose lib has no ErrorOptions
-        error.cause = failures[0].reason;
-        throw error;
-      }
-    } finally {
-      // Free both UI module graphs before the build moves on. Every remaining task - a preview
-      // bundle per env among them - runs in this same process, and holding these two graphs is what
-      // pushed it into the OOM killer. `deferClose` above is what leaves them for this call, so a
-      // compiler is never closed while the other root is still bundling.
-      await this.ui.closeBuildCompilers();
-    }
-    const artifacts = BundleUiTask.getArtifactDef();
+    const outputPath = join(capsule.path, BundleUiTask.getArtifactDirectory());
+    this.logger.info(`Generating UI bundle at ${outputPath}...`);
+    // one call, one compilation: `build()` turns every registered UI root into an entry of the same
+    // rspack build, so the chunks the roots share are emitted once. there is no second compilation
+    // to keep alive, so nothing here has to defer closing it.
+    await this.ui.build(undefined, outputPath);
+    await this.generateHash(outputPath);
+
     return {
       componentsResults: [],
-      artifacts,
+      artifacts: BundleUiTask.getArtifactDef(),
     };
   }
 
+  /**
+   * One hash file for the whole bundle, mapping each root aspect id to the hash of the aspects that
+   * root resolved. `bit start` looks up the root it is about to serve; a root missing from the map
+   * (or a bundle built before this layout) reads as "no pre-bundle" and falls back to a local build.
+   */
   private async generateHash(outputPath: string): Promise<void> {
-    const maybeUiRoot = this.ui.getUi();
-    if (!maybeUiRoot) throw new Error('no uiRoot found');
+    const hashes: Record<string, string> = {};
+    await pMapSeries(Object.values(UIROOT_ASPECT_IDS), async (uiRootAspectId) => {
+      const maybeUiRoot = this.ui.getUi(uiRootAspectId);
+      if (!maybeUiRoot) throw new Error(`no uiRoot found for ${uiRootAspectId}`);
+      const [, uiRoot] = maybeUiRoot;
+      hashes[uiRootAspectId] = await this.ui.createBundleUiHash(uiRoot);
+    });
 
-    const [, uiRoot] = maybeUiRoot;
-    const hash = await this.ui.createBundleUiHash(uiRoot);
-
-    if (!existsSync(outputPath)) mkdirSync(outputPath);
-    writeFileSync(join(outputPath, BUNDLE_UI_HASH_FILENAME), hash);
+    if (!existsSync(outputPath)) mkdirSync(outputPath, { recursive: true });
+    writeFileSync(join(outputPath, BUNDLE_UI_HASH_FILENAME), JSON.stringify(hashes, null, 2));
   }
 
-  static getArtifactDirectory(uiRootAspectId) {
-    return join('artifacts', BUNDLE_UI_DIR, BUNDLE_UIROOT_DIR[uiRootAspectId]);
+  static getArtifactDirectory() {
+    return join('artifacts', BUNDLE_UI_DIR);
   }
 
   static getArtifactDef() {
-    const scopeRootDir = BundleUiTask.getArtifactDirectory(UIROOT_ASPECT_IDS.SCOPE);
-    const workspaceRootDir = BundleUiTask.getArtifactDirectory(UIROOT_ASPECT_IDS.WORKSPACE);
     return [
       {
-        name: `${BUNDLE_UI_DIR}-${BUNDLE_UIROOT_DIR[UIROOT_ASPECT_IDS.SCOPE]}`,
-        globPatterns: [`${scopeRootDir}/**`],
-      },
-      {
-        name: `${BUNDLE_UI_DIR}-${BUNDLE_UIROOT_DIR[UIROOT_ASPECT_IDS.WORKSPACE]}`,
-        globPatterns: [`${workspaceRootDir}/**`],
+        name: BUNDLE_UI_DIR,
+        globPatterns: [`${BundleUiTask.getArtifactDirectory()}/**`],
       },
     ];
   }

--- a/scopes/ui-foundation/ui/rspack/rspack.browser.config.ts
+++ b/scopes/ui-foundation/ui/rspack/rspack.browser.config.ts
@@ -25,10 +25,16 @@ import {
  * i.e. `bit build`, `bit start` (non-dev mode)
  */
 
+export type BrowserEntry = {
+  /** entry name; also names the emitted html (`<name>.html`) */
+  name: string;
+  files: string[];
+  title: string;
+};
+
 export default function createRspackBrowserConfig(
   outputDir: string,
-  entryFiles: string[],
-  title: string,
+  entries: BrowserEntry[],
   publicDir: string
 ): Configuration {
   const isEnvProductionProfile = process.argv.includes('--profile');
@@ -45,9 +51,7 @@ export default function createRspackBrowserConfig(
       css: true,
     },
 
-    entry: {
-      main: entryFiles,
-    },
+    entry: Object.fromEntries(entries.map((entry) => [entry.name, entry.files])),
 
     output: {
       path: path.resolve(outputDir, publicDir),
@@ -107,11 +111,19 @@ export default function createRspackBrowserConfig(
     },
 
     plugins: [
-      new rspack.HtmlRspackPlugin({
-        inject: true,
-        templateContent: html(title)(),
-        minify: true,
-      }),
+      // one html per entry, each injecting only its own entry's chunks. `index.html` is no longer
+      // emitted: with two roots in one compilation there is no single default document, so the ui
+      // server falls back to `<entry>.html` for the root it is serving.
+      ...entries.map(
+        (entry) =>
+          new rspack.HtmlRspackPlugin({
+            filename: `${entry.name}.html`,
+            chunks: [entry.name],
+            inject: true,
+            templateContent: html(entry.title)(),
+            minify: true,
+          })
+      ),
 
       new rspack.ProvidePlugin({ process: fallbacksProvidePluginConfig.process }),
 

--- a/scopes/ui-foundation/ui/ssr-middleware/ssr-middleware.ts
+++ b/scopes/ui-foundation/ui/ssr-middleware/ssr-middleware.ts
@@ -11,16 +11,20 @@ type ssrRenderProps = {
   root: string;
   port: number;
   title: string;
+  /** entry of the ui bundle whose assets this root serves */
+  entryName: string;
   logger: Logger;
 };
 
 type ManifestFile = {
   files?: Record<string, string>;
+  /** assets of the `main` entry; empty for a multi-entry bundle - see `entrypointsByName` */
   entrypoints?: string[];
+  entrypointsByName?: Record<string, string[]>;
 };
 
-export async function createSsrMiddleware({ root, port, title, logger }: ssrRenderProps) {
-  const runtime = await loadRuntime(root, { logger });
+export async function createSsrMiddleware({ root, port, title, entryName, logger }: ssrRenderProps) {
+  const runtime = await loadRuntime(root, { entryName, logger });
   if (!runtime) return undefined;
 
   const { render } = runtime;
@@ -58,7 +62,7 @@ export async function createSsrMiddleware({ root, port, title, logger }: ssrRend
   };
 }
 
-async function loadRuntime(root: string, { logger }: { logger: Logger }) {
+async function loadRuntime(root: string, { entryName, logger }: { entryName: string; logger: Logger }) {
   let render: (...arg: any[]) => any;
   let assets: HtmlAssets | undefined;
 
@@ -75,7 +79,7 @@ async function loadRuntime(root: string, { logger }: { logger: Logger }) {
       return undefined;
     }
 
-    assets = await parseManifest(manifestFilepath);
+    assets = await parseManifest(manifestFilepath, entryName);
     if (!assets) {
       logger.warn('[ssr] - Skipping setup (failed parsing assets manifest)');
       return undefined;
@@ -99,14 +103,14 @@ async function loadRuntime(root: string, { logger }: { logger: Logger }) {
   };
 }
 
-async function parseManifest(filepath: string, logger?: Logger) {
+async function parseManifest(filepath: string, entryName: string, logger?: Logger) {
   try {
     const file = await fs.readFile(filepath);
     logger?.debug('[ssr] - ✓ aread manifest file');
     const contents = file.toString();
     const parsed: ManifestFile = JSON.parse(contents);
     logger?.debug('[ssr] - ✓ prased manifest file', parsed);
-    const assets = getAssets(parsed);
+    const assets = getAssets(parsed, entryName);
     logger?.debug('[ssr] - ✓ extracted data from manifest file', assets);
 
     return assets;
@@ -117,11 +121,14 @@ async function parseManifest(filepath: string, logger?: Logger) {
   }
 }
 
-function getAssets(manifest: ManifestFile) {
+function getAssets(manifest: ManifestFile, entryName: string) {
   const assets: HtmlAssets = { css: [], js: [] };
+  // a multi-entry bundle has no single `entrypoints` list - take this root's entry, and fall back
+  // to `entrypoints` for a single-entry manifest.
+  const entrypoints = manifest.entrypointsByName?.[entryName] ?? manifest.entrypoints;
 
-  assets.css = manifest.entrypoints?.filter((x) => x.endsWith('css')).map((x) => path.join('/', x));
-  assets.js = manifest.entrypoints?.filter((x) => x.endsWith('js')).map((x) => path.join('/', x));
+  assets.css = entrypoints?.filter((x) => x.endsWith('css')).map((x) => path.join('/', x));
+  assets.js = entrypoints?.filter((x) => x.endsWith('js')).map((x) => path.join('/', x));
 
   return assets;
 }

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -14,6 +14,7 @@ import type { Configuration as WdsConfiguration } from '@rspack/dev-server';
 import { RspackDevServer } from '@rspack/dev-server';
 import type { ComponentServer } from '@teambit/bundler';
 import { createSsrMiddleware } from './ssr-middleware';
+import { getUiRootEntryName, getUiRootHtmlFilename } from './bundle-ui.task';
 import type { StartPlugin } from './start-plugin';
 import type { ProxyEntry, UIRoot } from './ui-root';
 import { UIRuntime } from './ui.aspect';
@@ -285,7 +286,9 @@ export class UIServer {
     app.use(express.static(root, { index: false }));
     const port = await Port.getPortFromRange(portRange || [3100, 3200]);
     await this.setupServerSideRendering({ root, port, app });
-    app.use(fallback('index.html', { root }));
+    // the bundle covers every UI root in one compilation, so there is no single `index.html` - each
+    // root gets its own document naming only the chunks that root's entry needs.
+    app.use(fallback(getUiRootHtmlFilename(this.uiRootExtension), { root }));
     server.listen(port);
     this._port = port;
 
@@ -303,6 +306,8 @@ export class UIServer {
       root,
       port,
       title: this.uiRoot.name,
+      // which entry of the (multi-entry) bundle this root's assets belong to
+      entryName: getUiRootEntryName(this.uiRootExtension),
       logger: this.logger,
     });
 

--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -37,7 +37,7 @@ import createRspackBrowserConfig from './rspack/rspack.browser.config';
 import createRspackSsrConfig from './rspack/rspack.ssr.config';
 import { writeBundleStats } from './rspack/bundle-stats';
 import type { StartPlugin, StartPluginOptions } from './start-plugin';
-import { BundleUiTask, BUNDLE_UI_HASH_FILENAME } from './bundle-ui.task';
+import { BundleUiTask, BUNDLE_UI_HASH_FILENAME, getUiRootEntryName } from './bundle-ui.task';
 
 export type UIDeps = [PubsubMain, CLIMain, GraphqlMain, ExpressMain, ComponentMain, CacheMain, LoggerMain];
 
@@ -145,9 +145,6 @@ export type RuntimeOptions = {
 export class UiMain {
   private _isBundleUiServed = false;
   private currentUIServer: UIServer | undefined;
-  /** compilers `build()` created, freed by `closeBuildCompilers()` once the caller is done */
-  private openBuildCompilers: any[] = [];
-
   constructor(
     /**
      * Pubsub extension.
@@ -236,30 +233,37 @@ export class UiMain {
   }
 
   /**
-   * create a build of the given UI root.
+   * Build the UI. Every registered UI root becomes one entry of a *single* rspack compilation, so
+   * the chunks they share - which is nearly all of them, the roots differ only by the generated
+   * root module naming the root aspect - are emitted once instead of once per root.
+   *
+   * `uiRootAspectIdOrName` therefore only selects the default output location; it does not narrow
+   * what gets built. Each entry emits its own `<entry>.html`, and the ssr build (scope only) is a
+   * second compilation over that root's entry.
    */
-  async build(
-    uiRootAspectIdOrName?: string,
-    customOutputPath?: string,
-    options?: { deferClose?: boolean }
-  ): Promise<any> {
+  async build(uiRootAspectIdOrName?: string, customOutputPath?: string): Promise<any> {
     this.logger.debug(`build, uiRootAspectIdOrName: "${uiRootAspectIdOrName}"`);
     const maybeUiRoot = this.getUi(uiRootAspectIdOrName);
 
     if (!maybeUiRoot) throw new UnknownUI(uiRootAspectIdOrName, this.possibleUis());
-    const [uiRootAspectId, uiRoot] = maybeUiRoot;
+    const [, uiRoot] = maybeUiRoot;
 
-    // TODO: @uri refactor all dev server related code to use the bundler extension instead.
-    const ssr = uiRoot.buildOptions?.ssr || false;
-    const mainEntry = await this.generateRoot(await uiRoot.resolveAspects(UIRuntime.name), uiRootAspectId);
     const outputPath = customOutputPath || uiRoot.path;
     const publicDir = await this.publicDir(uiRoot);
 
-    const browserConfig = createRspackBrowserConfig(outputPath, [mainEntry], uiRoot.name, publicDir);
+    const entries = await pMapSeries(this.uiRootSlot.toArray(), async ([rootAspectId, root]) => ({
+      name: getUiRootEntryName(rootAspectId),
+      // sequentially: `resolveAspects` imports and isolates, which is not safe to run in parallel.
+      files: [await this.generateRoot(await root.resolveAspects(UIRuntime.name), rootAspectId)],
+      title: root.name,
+      root,
+    }));
+
+    const browserConfig = createRspackBrowserConfig(outputPath, entries, publicDir);
     const compiler = rspack(browserConfig as any);
     const compilers: any[] = [compiler];
     try {
-      this.logger.debug(`rspack (build): running for browser`);
+      this.logger.debug(`rspack (build): running for browser, entries: ${entries.map((e) => e.name).join(', ')}`);
       const [results, errors] = await this.runRspackPromise(compiler);
       this.logger.debug(`rspack (build): completed browser`);
       if (!results) throw new UnknownBuildError();
@@ -271,13 +275,20 @@ export class UiMain {
         this.clearConsole();
         throw new Error(results?.toString());
       }
-      this.writeStats(results, `${uiRoot.name}-browser`);
+      this.writeStats(results, 'browser');
 
-      if (ssr) {
-        const ssrConfig = createRspackSsrConfig(outputPath, [mainEntry], publicDir);
+      // TODO: @uri refactor all dev server related code to use the bundler extension instead.
+      const ssrEntries = entries.filter((entry) => entry.root.buildOptions?.ssr);
+      if (ssrEntries.length > 1) {
+        // they would all write to the same `ssr/` directory. only the scope root sets `ssr: true`.
+        throw new Error(`only one UI root can enable ssr, got: ${ssrEntries.map((entry) => entry.name).join(', ')}`);
+      }
+      for (const ssrEntry of ssrEntries) {
+        const ssrConfig = createRspackSsrConfig(outputPath, ssrEntry.files, publicDir);
         const ssrCompiler = rspack(ssrConfig as any);
         compilers.push(ssrCompiler);
-        this.logger.debug(`rspack (build): running for SSR`);
+        this.logger.debug(`rspack (build): running for SSR (${ssrEntry.name})`);
+        // eslint-disable-next-line no-await-in-loop
         const [ssrResults, ssrErrors] = await this.runRspackPromise(ssrCompiler);
         this.logger.debug(`rspack (build): completed SSR build`);
         if (ssrErrors) {
@@ -288,17 +299,16 @@ export class UiMain {
           this.clearConsole();
           throw new Error(ssrResults?.toString());
         }
-        this.writeStats(ssrResults, `${uiRoot.name}-ssr`);
+        this.writeStats(ssrResults, `${ssrEntry.name}-ssr`);
       }
 
       return results;
     } finally {
-      // `deferClose` hands the compilers to the caller, which must call `closeBuildCompilers()` -
-      // BundleUiTask does, once both of its UI roots are done. Every other caller (bit start's
-      // pre-bundle, a watch rebuild) gets them closed right here: leaving them tracked would keep
-      // one module graph per build alive for the life of a long-running process.
-      if (options?.deferClose) this.openBuildCompilers.push(...compilers);
-      else await this.closeCompilers(compilers);
+      // a compiler holds its whole module graph (and rspack's native side of it) alive, and
+      // `bit build` runs every bundling task in one process - a preview bundle per env follows this
+      // one - so a compiler left open stays resident for all of them. now that both roots share a
+      // single compilation there is no concurrent sibling to wait for, and it closes right here.
+      await this.closeCompilers(compilers);
     }
   }
 
@@ -318,23 +328,6 @@ export class UiMain {
   registerStartPlugin(startPlugin: StartPlugin) {
     this.startPluginSlot.register(startPlugin);
     return this;
-  }
-
-  /**
-   * Release the compilers `build()` created. A compiler keeps its whole module graph (and rspack's
-   * native side of it) alive, and `bit build` runs every bundling task in one process - the UI
-   * bundle first, then a preview bundle per env - so compilers left open stay resident for all of
-   * them and the process gets OOM-killed partway through. The webpack bundler closes its compiler
-   * the same way after each run.
-   *
-   * Deliberately NOT called from inside `build()`: closing one compiler while another UI root is
-   * still bundling in the same process is untested and a run that did so failed to resolve modules
-   * in the second root. Callers close once every root is done - see BundleUiTask.
-   */
-  async closeBuildCompilers(): Promise<void> {
-    const compilers = this.openBuildCompilers;
-    this.openBuildCompilers = [];
-    await this.closeCompilers(compilers);
   }
 
   /**
@@ -421,7 +414,7 @@ export class UiMain {
       await uiServer.dev({ portRange: port || this.config.portRange });
     } else {
       if (!skipUiBuild) await this.buildUI(uiRootAspectId, uiRoot, rebuild);
-      const bundleUiPath = this.getBundleUiPath(uiRootAspectId);
+      const bundleUiPath = this.getBundleUiPath();
       const bundleUiPublicPath = bundleUiPath ? join(bundleUiPath, publicDir) : undefined;
       const bundleUiRoot =
         this._isBundleUiServed && bundleUiPublicPath && existsSync(bundleUiPublicPath || '')
@@ -687,22 +680,32 @@ export class UiMain {
     return sha1(aspectIds.join(''));
   }
 
+  /**
+   * The bundle is one compilation covering every root, so its `.hash` holds one hash per root
+   * keyed by root aspect id, rather than a bare hash per directory.
+   */
   private readBundleUiHash(uiRootAspectId: string) {
-    const bundleUiPathFromBvm = this.getBundleUiPath(uiRootAspectId);
+    const bundleUiPathFromBvm = this.getBundleUiPath();
     if (!bundleUiPathFromBvm) {
       return '';
     }
     const hashFilePath = join(bundleUiPathFromBvm, BUNDLE_UI_HASH_FILENAME);
-    if (existsSync(hashFilePath)) {
-      return readFileSync(hashFilePath).toString();
+    if (!existsSync(hashFilePath)) return '';
+    try {
+      const hashes = JSON.parse(readFileSync(hashFilePath).toString());
+      return hashes[uiRootAspectId] || '';
+    } catch (err) {
+      // an unreadable hash file only means "no usable pre-bundle" - fall through to a local build
+      // rather than failing the command.
+      this.logger.debug(`readBundleUiHash, failed reading ${hashFilePath}: ${err}`);
+      return '';
     }
-    return '';
   }
 
-  private getBundleUiPath(uiRootAspectId: string): string | undefined {
+  private getBundleUiPath(): string | undefined {
     try {
       const uiPathFromBvm = getAspectDirFromBvm(UIAspect.id);
-      return join(uiPathFromBvm, BundleUiTask.getArtifactDirectory(uiRootAspectId));
+      return join(uiPathFromBvm, BundleUiTask.getArtifactDirectory());
     } catch (err) {
       this.logger.error(`getBundleUiPath, getAspectDirFromBvm failed with err: ${err}`);
       return undefined;
@@ -712,13 +715,10 @@ export class UiMain {
   private async buildIfNoBundle(uiRootAspectId: string, uiRoot: UIRoot): Promise<boolean> {
     if (this._isBundleUiServed) return false;
 
-    const config = createRspackBrowserConfig(
-      uiRoot.path,
-      [await this.generateRoot(await uiRoot.resolveAspects(UIRuntime.name), uiRootAspectId)],
-      uiRoot.name,
-      await this.publicDir(uiRoot)
-    );
-    if (config.output?.path && fs.pathExistsSync(config.output.path as string)) return false;
+    // the same path `createRspackBrowserConfig` derives for `output.path`. computed directly rather
+    // than by building a config, which would resolve every root's aspects just to read a path.
+    const outputPath = pathResolve(uiRoot.path, await this.publicDir(uiRoot));
+    if (fs.pathExistsSync(outputPath)) return false;
     const hash = await this.createBuildUiHash(uiRoot);
     await this.build(uiRootAspectId);
     await this.cache.set(uiRoot.path, hash);


### PR DESCRIPTION
Part 2 of #10596 — the workspace/scope dedupe. Builds both UI roots in **one** rspack compilation with an entry each, so the chunks they share are emitted once. Takes the shipped `@teambit/ui` pre-bundle from **24 MB to 16 MB**.

> Rebased onto `master` now that #10628 has merged; targets `master` directly.

## The roots are the same app

The issue estimated a small win from file-level comparison ("only 25 files / 1.9 MB byte-identical"). At the *module* level they are all but identical:

| | modules | bytes |
| --- | --- | --- |
| workspace root | 3,403 | 16.00 MB |
| scope root | 3,403 | 16.00 MB |
| **shared by both** | **3,402** | **15.96 MB** |
| workspace-only | 1 | 40 KB |
| scope-only | 1 | 40 KB |

The one differing module is the generated root entry (`ui.root<hash>.js`) — same aspect graph, different root aspect id baked in. Both the `workspace` and `scope` aspects are already in *both* bundles; the root id only selects which one renders. So the duplicate is essentially total, and so is the saving.

| | before | after |
| --- | --- | --- |
| browser chunks | 16.4 MB (2 copies) | **8.2 MB** (1 copy) |
| ssr | 7.9 MB | 7.9 MB |
| **artifact total** | **24 MB** | **16 MB** |

The 6.53 MB vendor chunk and 0.53 MB CSS are now shared; each root adds ~40 KB of its own. Combined with #10628 this is 58 MB → 16 MB.

It also lowers peak memory during `bit build` — the concern raised on #10612 — since there is one module graph instead of two, and the `BundleUI` task got slightly faster (17s vs 18-19s).

## Layout

```
artifacts/ui-bundle/
  .hash                     JSON: { "<rootAspectId>": "<sha1>", … }
  public/bit/
    workspace.html          only the chunks the workspace entry needs
    scope.html              only the chunks the scope entry needs
    asset-manifest.json
    static/js|css/…         shared chunks, emitted once
    ssr/index.js            scope only
```

Three things had to change to support it:

1. **`.hash` is now a map.** `shouldServeBundleUi` compares a *per-root* hash, but there is now one bundle. `.hash` holds one hash per root aspect id and `readBundleUiHash` looks up the root being served. A root missing from the map — or a bundle in the old layout — reads as "no pre-bundle" and falls back to a local build.
2. **No more `index.html`.** With two roots in one compilation there is no single default document, so the server falls back to `<root>.html`. This is the sharpest edge in the PR: get the name wrong and every *client-side* route 404s while the SSR-rendered ones keep working. There is a test for exactly that (below).
3. **The asset manifest is entry-aware.** `generateAssetManifest` hardcoded `entrypoints.main`, and it is shared with the preview aspect's rspack config, so renaming was not an option. It now also emits `entrypointsByName`; `entrypoints` keeps its old meaning for single-entry compilations, so the preview side is untouched. The SSR middleware prefers its root's entry and falls back to `entrypoints`.

`build()` now builds every registered root rather than one, so `uiRootAspectIdOrName` only selects the output location. That is nearly free — the module graph is shared — and it keeps one layout everywhere instead of one for the build task and another for `bit start`. A bare scope registers only the scope root, so it emits just `scope.html`.

`bit start --dev` is unaffected; the dev config is separate and still single-entry.

## Deletes machinery

Because the two roots bundled concurrently, #10612 had to defer closing the compilers (`openBuildCompilers` + a `deferClose` option on `UiMain.build`) instead of closing inside `build()`. With one compiler there is no concurrent sibling, and it collapses into a single close in `build()`'s `finally`. `buildIfNoBundle` also stopped constructing a whole rspack config — resolving every root's aspects — just to read `output.path`.

## Testing

Both roots verified in a real browser, on **both** paths that can serve them:

- *local build* (`bit start --rebuild`): bare scope emits `scope.html` and SSRs every route; workspace emits both htmls with the 6.53 MB vendor chunk present once.
- *pre-bundle* (the production path): built artifact placed in the bvm install, `bit start` logged `returned from ui bundle cache` and `bundle will be served from …/ui-bundle/public/bit`, with no local build directory created. Scope SSR renders (`/` 27 KB, `/ui/button` 52 KB); workspace serves `workspace.html` through the fallback for client-side routes.

Workspace and scope home pages, component page, code tab and API reference all render with no console errors.

New e2e assertion covers change 2 — `?rendering=client` makes the SSR middleware call `next()`, which is the only way to reach the history-api fallback. Verified it catches the bug: pointing the fallback back at `index.html` fails that test and only that test, which is precisely the failure mode described above.

