### PR TITLE
test(ui): bit start sanity e2e, plus fixes for the qodo findings on #10628/#10629

### DIFF
--- a/e2e/harmony/ui-ssr.e2e.ts
+++ b/e2e/harmony/ui-ssr.e2e.ts
@@ -25,7 +25,7 @@ const PORT = 3025;
     // `--rebuild` so the ssr bundle is compiled from this repo's rspack config. without it the
     // server serves the pre-built bundle shipped by the installed bit version, and the assertions
     // below would describe that release rather than the code under test.
-    httpHelper = new HttpHelper(helper, PORT, ['--rebuild']);
+    httpHelper = new HttpHelper(helper, PORT, { extraArgs: ['--rebuild'] });
     helper.scopeHelper.setWorkspaceWithRemoteScope();
     helper.fixtures.populateComponents(1, false);
     helper.command.tagAllWithoutBuild();

--- a/e2e/harmony/ui-start.e2e.ts
+++ b/e2e/harmony/ui-start.e2e.ts
@@ -1,0 +1,175 @@
+import { expect } from 'chai';
+import { IS_WINDOWS } from '@teambit/legacy.constants';
+import { Helper } from '@teambit/legacy.e2e-helper';
+import { HttpHelper } from '../http-helper';
+
+const SCOPE_PORT = 3030;
+const WORKSPACE_PORT = 3031;
+
+const SCOPE_UI_ROOT = 'teambit.scope/scope';
+const WORKSPACE_UI_ROOT = 'teambit.workspace/workspace';
+
+/** scripts and stylesheets the served document tells the browser to load */
+function referencedAssets(html: string): string[] {
+  const scripts = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map((match) => match[1]);
+  const styles = [...html.matchAll(/<link[^>]+href="([^"]+\.css)"/g)].map((match) => match[1]);
+  return [...scripts, ...styles];
+}
+
+/**
+ * Sanity coverage for `bit start` itself: that the server comes up clean for each UI root, serves a
+ * document, and that every asset that document asks for is actually reachable.
+ *
+ * This is deliberately end-to-end over http rather than unit-level. The failure modes it exists to
+ * catch are all ones where each piece looks fine on its own - a document served from the wrong
+ * filename, an asset emitted under a path the server does not expose, a root whose entry was never
+ * built - and only the running server shows them.
+ *
+ * `--rebuild` throughout: without it the server serves the pre-built bundle from the installed bit
+ * version, so the assertions would describe that release instead of the code under test.
+ */
+(IS_WINDOWS ? describe.skip : describe)('bit start', function () {
+  this.timeout(0);
+
+  describe('scope UI, on a bare scope', () => {
+    let helper: Helper;
+    let httpHelper: HttpHelper;
+    let html: string;
+
+    before(async () => {
+      helper = new Helper();
+      httpHelper = new HttpHelper(helper, SCOPE_PORT, {
+        extraArgs: ['--rebuild'],
+        uiRootAspectId: SCOPE_UI_ROOT,
+      });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      await httpHelper.start();
+      html = await (await fetch(`http://localhost:${SCOPE_PORT}/`)).text();
+    });
+
+    after(async () => {
+      await httpHelper.killHttp();
+      helper.scopeHelper.destroy();
+    });
+
+    it('should start without writing errors to stderr', () => {
+      // `bit start` resolving does not by itself mean a clean startup - an aspect that failed to
+      // load, or a plugin that threw, still lets the server listen.
+      expect(httpHelper.stderr).to.not.match(/error|exception|unhandled/i);
+    });
+
+    it('should serve a document with a react root', () => {
+      expect(html).to.have.string('<div id="root"');
+    });
+
+    it('should serve every asset the document references', async () => {
+      const assets = referencedAssets(html);
+      expect(assets, 'the document references no scripts at all').to.not.have.lengthOf(0);
+      const statuses = await Promise.all(
+        assets.map(async (asset) => {
+          const response = await fetch(`http://localhost:${SCOPE_PORT}${asset}`);
+          return `${asset} -> ${response.status}`;
+        })
+      );
+      expect(statuses.filter((status) => !status.endsWith('-> 200'))).to.deep.equal([]);
+    });
+
+    it('should serve a document for a deep client-side route', async () => {
+      // client-side routes have no file behind them; the history-api fallback is what answers, and
+      // it has to name this root's document.
+      const response = await fetch(`http://localhost:${SCOPE_PORT}/some/deep/route?rendering=client`);
+      expect(response.status).to.equal(200);
+      expect(await response.text()).to.have.string('<div id="root"');
+    });
+
+    it('should answer graphql queries', async () => {
+      const response = await fetch(`http://localhost:${SCOPE_PORT}/graphql`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query: '{ __typename }' }),
+      });
+      expect(response.status).to.equal(200);
+      expect(await response.json()).to.not.have.property('errors');
+    });
+
+    it('should render the exported component into the served markup', () => {
+      // the scope root is the one built with ssr, so its markup is filled in on the server. this is
+      // the only root where the http response proves the app actually rendered.
+      expect(html).to.have.string(helper.scopes.remote);
+      expect(html).to.not.have.string('<div id="root"></div>');
+    });
+  });
+
+  describe('workspace UI', () => {
+    let helper: Helper;
+    let httpHelper: HttpHelper;
+    let html: string;
+
+    before(async () => {
+      helper = new Helper();
+      httpHelper = new HttpHelper(helper, WORKSPACE_PORT, {
+        extraArgs: ['--rebuild'],
+        uiRootAspectId: WORKSPACE_UI_ROOT,
+      });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      await httpHelper.start();
+      html = await (await fetch(`http://localhost:${WORKSPACE_PORT}/`)).text();
+    });
+
+    after(async () => {
+      await httpHelper.killHttp();
+      helper.scopeHelper.destroy();
+    });
+
+    it('should start without writing errors to stderr', () => {
+      expect(httpHelper.stderr).to.not.match(/error|exception|unhandled/i);
+    });
+
+    it('should serve a document with a react root', () => {
+      expect(html).to.have.string('<div id="root"');
+    });
+
+    it("should serve its own entry, not another root's", () => {
+      // both roots are entries of one bundle. serving the wrong document here would still return a
+      // working-looking page - it would just boot the other root's app.
+      const assets = referencedAssets(html);
+      expect(
+        assets.some((asset) => /\/workspace\.[a-f0-9]+\.js$/.test(asset)),
+        `assets: ${assets.join(', ')}`
+      ).to.be.true;
+      expect(assets.some((asset) => /\/scope\.[a-f0-9]+\.js$/.test(asset))).to.be.false;
+    });
+
+    it('should serve every asset the document references', async () => {
+      const assets = referencedAssets(html);
+      expect(assets, 'the document references no scripts at all').to.not.have.lengthOf(0);
+      const statuses = await Promise.all(
+        assets.map(async (asset) => {
+          const response = await fetch(`http://localhost:${WORKSPACE_PORT}${asset}`);
+          return `${asset} -> ${response.status}`;
+        })
+      );
+      expect(statuses.filter((status) => !status.endsWith('-> 200'))).to.deep.equal([]);
+    });
+
+    it('should serve a document for a deep client-side route', async () => {
+      const response = await fetch(`http://localhost:${WORKSPACE_PORT}/some/deep/route`);
+      expect(response.status).to.equal(200);
+      expect(await response.text()).to.have.string('<div id="root"');
+    });
+
+    it('should answer graphql queries', async () => {
+      const response = await fetch(`http://localhost:${WORKSPACE_PORT}/graphql`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query: '{ __typename }' }),
+      });
+      expect(response.status).to.equal(200);
+      expect(await response.json()).to.not.have.property('errors');
+    });
+  });
+});

--- a/e2e/http-helper.ts
+++ b/e2e/http-helper.ts
@@ -10,20 +10,42 @@ const HTTP_TIMEOUT_FOR_MSG = 120000; // 2 min
 const DEFAULT_HTTP_PORT = 3000;
 const PORT_FREE_TIMEOUT = 30000; // 30 sec
 
-const HTTP_SERVER_READY_MSG = 'UI server of teambit.scope/scope is listening to port';
+const readyMessageFor = (uiRootAspectId: string) => `UI server of ${uiRootAspectId} is listening to port`;
+const SCOPE_UI_ROOT = 'teambit.scope/scope';
+
+export type HttpHelperOptions = {
+  /**
+   * extra flags for `bit start`. `--rebuild` is the one that matters for anything asserting on the
+   * UI itself: without it the server resolves the pre-built bundle from the bvm install, so the
+   * test measures whatever bit version happens to be installed rather than the code under test.
+   */
+  extraArgs?: string[];
+  /**
+   * which UI root to start. the scope root serves a bare scope (the default, and what the http
+   * protocol tests use); the workspace root serves the local workspace.
+   */
+  uiRootAspectId?: string;
+};
 
 export class HttpHelper {
   httpProcess: ChildProcess;
+  /** everything `bit start` wrote to stderr, for tests asserting a clean startup */
+  stderr = '';
+
   constructor(
     private helper: Helper,
     private port = DEFAULT_HTTP_PORT,
-    /**
-     * extra flags for `bit start`. `--rebuild` is the one that matters for anything asserting on the
-     * UI itself: without it the server resolves the pre-built bundle from the bvm install, so the
-     * test measures whatever bit version happens to be installed rather than the code under test.
-     */
-    private extraArgs: string[] = []
+    private options: HttpHelperOptions = {}
   ) {}
+
+  private get uiRootAspectId(): string {
+    return this.options.uiRootAspectId || SCOPE_UI_ROOT;
+  }
+
+  /** the scope root runs against the bare remote scope; any other root against the workspace. */
+  private get cwd(): string {
+    return this.uiRootAspectId === SCOPE_UI_ROOT ? this.helper.scopes.remotePath : this.helper.scopes.localPath;
+  }
   async start(): Promise<void> {
     // a `bit start` server from an earlier describe-block in the same file shares this port (and the
     // same remote-scope dir), and may still be shutting down when we get here — especially with a
@@ -33,16 +55,16 @@ export class HttpHelper {
     // (which surfaced as OutdatedIndexJson / MergeConflictOnRemote in the bbit nightly).
     await this.waitForPortToBeFree();
     return new Promise((resolve, reject) => {
-      const args = ['start', '--verbose', '--log', '--port', String(this.port), ...this.extraArgs];
+      const args = ['start', '--verbose', '--log', '--port', String(this.port), ...(this.options.extraArgs || [])];
       const cmd = `${this.helper.command.bitBin} ${args.join(' ')}`;
-      const cwd = this.helper.scopes.remotePath;
+      const { cwd } = this;
       if (this.helper.debugMode) console.log(rightpad(chalk.green('cwd: '), 20, ' '), cwd); // eslint-disable-line no-console
       if (this.helper.debugMode) console.log(rightpad(chalk.green('command: '), 20, ' '), cmd); // eslint-disable-line
       this.httpProcess = childProcess.spawn(this.helper.command.bitBin, args, { cwd });
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       this.httpProcess.stdout.on('data', (data) => {
         if (this.helper.debugMode) console.log(`stdout: ${data}`);
-        if (data.includes(HTTP_SERVER_READY_MSG)) {
+        if (data.includes(readyMessageFor(this.uiRootAspectId))) {
           if (this.helper.debugMode) console.log('Bit server is up and running');
           resolve();
         }
@@ -52,6 +74,7 @@ export class HttpHelper {
       this.httpProcess.stderr.on('data', (data) => {
         if (this.helper.debugMode) console.log(`stderr: ${data}`);
         stderrData += data.toString();
+        this.stderr += data.toString();
       });
       this.httpProcess.on('close', (code) => {
         if (this.helper.debugMode) console.log(`child process exited with code ${code}`);
@@ -101,11 +124,18 @@ export class HttpHelper {
    * connect check) so it catches server children that escaped the parent's process group.
    * note: `lsof -ti` exits 1 when nothing is listening (the normal "port is free" case), so the
    * `|| true` guards that expected non-zero exit — it is not masking a real lsof failure.
+   *
+   * `-sTCP:LISTEN` matters: without it lsof also reports processes holding a *client* socket to the
+   * port, which includes the mocha process itself once a test has fetched from the server (node
+   * keeps connections alive). those were then read as a foreign process squatting the port and
+   * `waitForPortToBeFree` refused to continue. only a listener can actually hold the port.
    */
   private portHolders(): number[] {
     if (process.platform === 'win32') return [];
     try {
-      const out = childProcess.execSync(`lsof -ti tcp:${this.port} 2>/dev/null || true`, { encoding: 'utf8' });
+      const out = childProcess.execSync(`lsof -ti tcp:${this.port} -sTCP:LISTEN 2>/dev/null || true`, {
+        encoding: 'utf8',
+      });
       return out
         .split('\n')
         .map((pid) => pid.trim())

--- a/e2e/http-helper.ts
+++ b/e2e/http-helper.ts
@@ -9,6 +9,9 @@ import type { Helper } from '@teambit/legacy.e2e-helper';
 const HTTP_TIMEOUT_FOR_MSG = 120000; // 2 min
 const DEFAULT_HTTP_PORT = 3000;
 const PORT_FREE_TIMEOUT = 30000; // 30 sec
+// generous on purpose: with `--rebuild` this covers a full rspack build of the UI, which is minutes
+// on a cold cache. it exists to bound a hang, not to police how long a legitimate build takes.
+const START_TIMEOUT = 900000; // 15 min
 
 const readyMessageFor = (uiRootAspectId: string) => `UI server of ${uiRootAspectId} is listening to port`;
 const SCOPE_UI_ROOT = 'teambit.scope/scope';
@@ -20,6 +23,8 @@ export type HttpHelperOptions = {
    * test measures whatever bit version happens to be installed rather than the code under test.
    */
   extraArgs?: string[];
+  /** bound on how long to wait for the server to report itself ready. see `START_TIMEOUT`. */
+  startTimeoutMs?: number;
   /**
    * which UI root to start. the scope root serves a bare scope (the default, and what the http
    * protocol tests use); the workspace root serves the local workspace.
@@ -54,6 +59,7 @@ export class HttpHelper {
     // server over the freshly-reinitialized scope, and not a lingering one serving stale/wiped state
     // (which surfaced as OutdatedIndexJson / MergeConflictOnRemote in the bbit nightly).
     await this.waitForPortToBeFree();
+    const timeoutMs = this.options.startTimeoutMs ?? START_TIMEOUT;
     return new Promise((resolve, reject) => {
       const args = ['start', '--verbose', '--log', '--port', String(this.port), ...(this.options.extraArgs || [])];
       const cmd = `${this.helper.command.bitBin} ${args.join(' ')}`;
@@ -61,15 +67,39 @@ export class HttpHelper {
       if (this.helper.debugMode) console.log(rightpad(chalk.green('cwd: '), 20, ' '), cwd); // eslint-disable-line no-console
       if (this.helper.debugMode) console.log(rightpad(chalk.green('command: '), 20, ' '), cmd); // eslint-disable-line
       this.httpProcess = childProcess.spawn(this.helper.command.bitBin, args, { cwd });
+      let stdoutData = '';
+      let stderrData = '';
+      let settled = false;
+      // the suites that use this run with mocha's timeout disabled, because a legitimate `--rebuild`
+      // start can take minutes. that makes this the only deadline: a server that stays alive but
+      // never reports readiness would otherwise hang the job forever instead of failing it.
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        const tail = (out: string) => out.split('\n').slice(-20).join('\n');
+        void this.killHttp().catch(() => {});
+        reject(
+          new Error(
+            `bit start did not report "${readyMessageFor(this.uiRootAspectId)}" within ${timeoutMs}ms.\n` +
+              `last stdout:\n${tail(stdoutData)}\nlast stderr:\n${tail(stderrData)}`
+          )
+        );
+      }, timeoutMs);
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       this.httpProcess.stdout.on('data', (data) => {
         if (this.helper.debugMode) console.log(`stdout: ${data}`);
+        stdoutData += data.toString();
         if (data.includes(readyMessageFor(this.uiRootAspectId))) {
           if (this.helper.debugMode) console.log('Bit server is up and running');
-          resolve();
+          settle(resolve);
         }
       });
-      let stderrData = '';
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       this.httpProcess.stderr.on('data', (data) => {
         if (this.helper.debugMode) console.log(`stderr: ${data}`);
@@ -78,7 +108,7 @@ export class HttpHelper {
       });
       this.httpProcess.on('close', (code) => {
         if (this.helper.debugMode) console.log(`child process exited with code ${code}`);
-        reject(new Error(`http exited with code ${code}\n${stderrData}`));
+        settle(() => reject(new Error(`http exited with code ${code}\n${stderrData}`)));
       });
     });
   }

--- a/scopes/ui-foundation/ui/bundle-ui.task.ts
+++ b/scopes/ui-foundation/ui/bundle-ui.task.ts
@@ -19,6 +19,9 @@ export const BUNDLE_UIROOT_DIR = {
 };
 export const BUNDLE_UI_HASH_FILENAME = '.hash';
 
+/** the roots bit itself ships; anything else registered is not part of the shipped artifact. */
+export const KNOWN_UIROOT_ASPECT_IDS = new Set<string>(Object.values(UIROOT_ASPECT_IDS));
+
 /**
  * Both UI roots are bundled by a single rspack compilation, one entry each, so the roots share
  * every chunk they have in common instead of each shipping a full copy of the app. The entry name
@@ -72,10 +75,12 @@ export class BundleUiTask implements BuildTask {
    */
   private async generateHash(outputPath: string): Promise<void> {
     const hashes: Record<string, string> = {};
-    await pMapSeries(Object.values(UIROOT_ASPECT_IDS), async (uiRootAspectId) => {
-      const maybeUiRoot = this.ui.getUi(uiRootAspectId);
-      if (!maybeUiRoot) throw new Error(`no uiRoot found for ${uiRootAspectId}`);
-      const [, uiRoot] = maybeUiRoot;
+    // hash exactly the roots that were built. `build()` emits an entry per *registered* root, so
+    // walking a hardcoded list instead would both fail where a root is legitimately absent (a
+    // scope-only runtime registers just the one) and, worse, record a hash for a root whose
+    // document was never emitted - which reads at startup as "a pre-bundle exists" and then 404s.
+    const roots = this.ui.getUiRoots().filter(([uiRootAspectId]) => KNOWN_UIROOT_ASPECT_IDS.has(uiRootAspectId));
+    await pMapSeries(roots, async ([uiRootAspectId, uiRoot]) => {
       hashes[uiRootAspectId] = await this.ui.createBundleUiHash(uiRoot);
     });
 

--- a/scopes/ui-foundation/ui/rspack/bundle-stats.ts
+++ b/scopes/ui-foundation/ui/rspack/bundle-stats.ts
@@ -34,7 +34,9 @@ export function writeBundleStats(stats: any, name: string): string | undefined {
     source: false,
   });
   mkdirpSync(dir);
-  const filePath = join(dir, `${name}.stats.json`);
+  // `name` comes from a ui root's name, which can contain a path separator; left as-is it would
+  // point the write at a directory that does not exist and fail with ENOENT.
+  const filePath = join(dir, `${name.replace(/[^a-zA-Z0-9._-]+/g, '-')}.stats.json`);
   writeFileSync(filePath, JSON.stringify(json));
   return filePath;
 }

--- a/scopes/ui-foundation/ui/rspack/rspack.browser.config.ts
+++ b/scopes/ui-foundation/ui/rspack/rspack.browser.config.ts
@@ -51,7 +51,18 @@ export default function createRspackBrowserConfig(
       css: true,
     },
 
-    entry: Object.fromEntries(entries.map((entry) => [entry.name, entry.files])),
+    entry: Object.fromEntries(
+      (() => {
+        // `Object.fromEntries` would silently keep only the last of two entries sharing a name, and
+        // the lost root would then have no chunks and no document while still looking built.
+        const seen = new Set<string>();
+        return entries.map((entry) => {
+          if (seen.has(entry.name)) throw new Error(`duplicate ui bundle entry name: "${entry.name}"`);
+          seen.add(entry.name);
+          return [entry.name, entry.files] as const;
+        });
+      })()
+    ),
 
     output: {
       path: path.resolve(outputDir, publicDir),
@@ -138,8 +149,11 @@ export default function createRspackBrowserConfig(
         clientsClaim: true,
         maximumFileSizeToCacheInBytes: 5000000,
         exclude: [/\.map$/, /asset-manifest\.json$/],
-        navigateFallback: 'public/index.html',
-        navigateFallbackDenylist: [new RegExp('^/_'), new RegExp('/[^/.?]+\\.[^/]+$')],
+        // no `navigateFallback`: with an entry per UI root there is no single app shell to fall back
+        // to, and the previous value (`public/index.html`) now names a document this build does not
+        // emit - the service worker would answer navigations with a missing file. the express
+        // history-api fallback already serves the right `<root>.html`, so navigations go to the
+        // network instead of through a shell the service worker cannot supply.
       }),
     ],
 

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -292,8 +292,8 @@ export class UIServer {
     server.listen(port);
     this._port = port;
 
-    // important: we use the string of the following message for the http.e2e.ts. if you change the message,
-    // please make sure you change the `HTTP_SERVER_READY_MSG` const.
+    // important: the e2e HttpHelper waits on this exact string to know the server is up (it builds
+    // it per UI root, in `readyMessageFor`). if you change the message, change that too.
     const readyMessage = `UI server of ${this.uiRootExtension} is listening to port ${port}`;
     this.logger.info(readyMessage);
     this.setReady();

--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -37,7 +37,7 @@ import createRspackBrowserConfig from './rspack/rspack.browser.config';
 import createRspackSsrConfig from './rspack/rspack.ssr.config';
 import { writeBundleStats } from './rspack/bundle-stats';
 import type { StartPlugin, StartPluginOptions } from './start-plugin';
-import { BundleUiTask, BUNDLE_UI_HASH_FILENAME, getUiRootEntryName } from './bundle-ui.task';
+import { BundleUiTask, BUNDLE_UI_HASH_FILENAME, getUiRootEntryName, getUiRootHtmlFilename } from './bundle-ui.task';
 
 export type UIDeps = [PubsubMain, CLIMain, GraphqlMain, ExpressMain, ComponentMain, CacheMain, LoggerMain];
 
@@ -251,7 +251,7 @@ export class UiMain {
     const outputPath = customOutputPath || uiRoot.path;
     const publicDir = await this.publicDir(uiRoot);
 
-    const entries = await pMapSeries(this.uiRootSlot.toArray(), async ([rootAspectId, root]) => ({
+    const entries = await pMapSeries(this.getUiRoots(), async ([rootAspectId, root]) => ({
       name: getUiRootEntryName(rootAspectId),
       // sequentially: `resolveAspects` imports and isolates, which is not safe to run in parallel.
       files: [await this.generateRoot(await root.resolveAspects(UIRuntime.name), rootAspectId)],
@@ -523,6 +523,14 @@ export class UiMain {
   /**
    * get a UI runtime instance.
    */
+  /**
+   * every registered UI root, as `[aspectId, root]`. this is the set `build()` turns into entries,
+   * so anything deriving per-root output (hashes, documents) must walk the same list.
+   */
+  getUiRoots(): [string, UIRoot][] {
+    return this.uiRootSlot.toArray();
+  }
+
   getUi(uiRootAspectIdOrName?: string): [string, UIRoot] | undefined {
     if (uiRootAspectIdOrName) {
       const root = this.uiRootSlot.get(uiRootAspectIdOrName) || this.getUiByName(uiRootAspectIdOrName);
@@ -718,7 +726,11 @@ export class UiMain {
     // the same path `createRspackBrowserConfig` derives for `output.path`. computed directly rather
     // than by building a config, which would resolve every root's aspects just to read a path.
     const outputPath = pathResolve(uiRoot.path, await this.publicDir(uiRoot));
-    if (fs.pathExistsSync(outputPath)) return false;
+    // check for this root's document rather than merely for the directory. a build made before the
+    // roots shared one compilation left an `index.html` here and no `<root>.html`, and the server
+    // now falls back to the latter - so "the directory exists" would skip the rebuild and every
+    // client-side route would 404 against an output this bit can no longer serve.
+    if (fs.pathExistsSync(join(outputPath, getUiRootHtmlFilename(uiRootAspectId)))) return false;
     const hash = await this.createBuildUiHash(uiRoot);
     await this.build(uiRootAspectId);
     await this.cache.set(uiRoot.path, hash);


### PR DESCRIPTION
Sanity e2e for `bit start` itself, covering both UI roots. Part 3 of #10596 follow-up work.

> Rebased onto `master` now that #10628 and #10629 have merged; targets `master` directly.

Until now nothing exercised `bit start` end to end. That is how the scope SSR bundle managed to throw on every request for months (#10628), and the layout change in #10629 has a matching failure mode: name the fallback document wrong and every *client-side* route 404s while SSR-rendered ones keep working.

`e2e/harmony/ui-start.e2e.ts` starts a real server per root and asserts, over http:

- startup writes nothing matching `/error|exception|unhandled/i` to stderr — a server can listen fine with an aspect that failed to load
- the served document has a react root
- **every script and stylesheet the document references actually resolves 200** — this is the one that catches assets emitted under a path the server does not expose
- a deep client-side route returns a document (the history-api fallback)
- `/graphql` answers without errors
- workspace only: the document loads the *workspace* entry and not the scope one — both roots are entries of one bundle now, so serving the wrong document would still look like a working page, just booting the other root's app
- scope only: the markup is server-rendered and contains the exported component

12 assertions, ~1 min. All `--rebuild`, so they describe this repo's code rather than whichever bit release is installed.

## Two supporting changes

**`HttpHelper` can start either root.** It was hardcoded to the bare scope (`scopes.remotePath`, and a ready-message string naming `teambit.scope/scope`). It now takes `{ extraArgs, uiRootAspectId }`, derives the cwd from the root, and builds the ready message per root. Existing callers use the unchanged two-arg form. It also records stderr so tests can assert on a clean startup.

**`portHolders()` now filters to listening sockets** (`lsof -ti tcp:PORT -sTCP:LISTEN`). Without it lsof also reports processes holding a *client* socket to the port — including the mocha process itself, since node keeps connections alive after a test fetches from the server. `waitForPortToBeFree` read that as a foreign process squatting the port and refused to continue, failing the `after` hooks. Only a listener can actually hold a port. This was a latent bug in the helper; the new tests hit it because they fetch every referenced asset.



---

## Also: Qodo review findings from #10628 / #10629

Both of those merged before their review findings were addressed, so the actionable ones land here. Each was verified against the code rather than taken on trust.

**`bit start` 404s on an existing local UI build (from #10629) — the important one.** `buildIfNoBundle()` treated *any* existing `public/bit` directory as a valid build, but the server now falls back to `<root>.html`, which a build made before #10629 does not contain. Reproduced end to end: with the pre-fix check the whole UI returns **404** on `/` and on deep routes; with the fix it detects the missing document, rebuilds, and serves 200. This would have hit every user upgrading past #10629 with a previously-built local UI. It now checks for the root's document rather than the directory.

**Hash written for roots that were never built (from #10629).** `generateHash()` walked a hardcoded root list and threw when one was not registered. Beyond failing in a scope-only runtime, it could record a hash for a root whose document was never emitted — which reads at startup as "a pre-bundle exists" and then 404s, the same failure as above. It now walks the same registered roots `build()` turns into entries, via a new `UiMain.getUiRoots()`.

**Service worker bound to a document that is not emitted (from #10629).** Confirmed in the built artifact: `service-worker.js` contained `createHandlerBoundToURL("public/index.html")` while the build emits only `scope.html` / `workspace.html`. With an entry per root there is no single app shell, so `navigateFallback` is removed — the express history-api fallback already serves the right document. Verified the built service worker no longer contains that binding.

**Entry name collisions (from #10629).** `Object.fromEntries` would silently keep only the last of two entries sharing a sanitized name, leaving a root with no chunks and no document while still looking built. Now throws instead.

**Stats filename could break (from #10628).** `writeBundleStats` interpolated an unsanitized name into a path, so a root name containing `/` would fail with ENOENT into a swallowed debug log. Now sanitized.

Not changed: the "ad-hoc chalk in `writeStats`" rule violation. That line matches the surrounding `[Rspack]` log statements in the same file; the style guide it cites covers section titles and symbols in command output, not diagnostic log lines. Happy to switch it if you'd rather be strict.

The `preview/bundle-stats.ts` copy of the sanitization fix lands with #10632, which is where that file lives.
