### PR TITLE
fix(ui): provide the ssr browser context above ClientContext

### DIFF
--- a/scopes/ui-foundation/ui/ui.ui.runtime.tsx
+++ b/scopes/ui-foundation/ui/ui.ui.runtime.tsx
@@ -68,12 +68,20 @@ export class UiUI {
 
     const reactSsr = new ServerRenderer(lifecyclePlugins);
     const fullHtml = await reactSsr.render(
-      <ClientContext>
-        <SSRBrowserProvider value={ssrContent.browser}>
+      // `SSRBrowserProvider` wraps `ClientContext`, not the other way round. `useUserAgent` reads
+      // this context and, finding nothing, falls back to `window.navigator` - which on the server
+      // throws `ReferenceError: window is not defined` and takes the whole render down (the ssr
+      // middleware then silently serves the empty client shell). Anything rendered outside this
+      // provider is therefore a latent server crash, and `ClientContext` renders real UI of its
+      // own - icons, the theme switcher, the loader ribbon, the tooltip mount point - so it has to
+      // be inside. Nesting it the other way only appeared to work while nothing in that subtree
+      // happened to call `useIsMobile`.
+      <SSRBrowserProvider value={ssrContent.browser}>
+        <ClientContext>
           {hudItems}
           {routes}
-        </SSRBrowserProvider>
-      </ClientContext>,
+        </ClientContext>
+      </SSRBrowserProvider>,
       ssrContent
     );
 


### PR DESCRIPTION
`useUserAgent` reads `ssrBrowserContext`, and that context is provided in exactly one place — wrapping only `{hudItems}` and `{routes}`, *inside* `ClientContext`. Everything rendered outside that subtree therefore gets `undefined`, falls back to `window.navigator`, and throws `ReferenceError: window is not defined` on the server. The ssr middleware swallows it and serves the empty client shell, so the page still looks fine in a browser.

`ClientContext` is not a bare provider: it renders icons, the theme switcher, the loader ribbon and the tooltip mount point. Any of those growing a `useIsMobile` call — directly or through a dependency bump — takes scope SSR down. Swapping the nesting so `SSRBrowserProvider` wraps `ClientContext` closes the whole class.

## Why this surfaced now

Reported from a branch that removes core envs from the manifest, where the crash reproduces deterministically:

```
[ssr] failed at '/'
ReferenceError: window is not defined
    at useUserAgent → useIsMobile → Tooltip
```

That branch already has all of #10628's fixes, so this is not a regression of them — it is a second, independent gap that #10628 did not cover. It was latent on `master` only because nothing inside `ClientContext` currently happens to call `useIsMobile`; changing which aspects load changes what renders there.

Worth being explicit that the `.cjs` fix and the `use-user-agent` alias from #10628 are still doing their jobs. This is a tree-position bug, not a duplicate-context one — the alias pins the module to a single copy, so provider and consumer share the context object; the consumer is simply rendered where no provider is above it.

## Proof

Rendering a `Tooltip` inside `ClientContext` — what the reporting branch effectively does — and changing nothing else:

| nesting | `ui-ssr.e2e.ts` |
| --- | --- |
| `ClientContext` > `SSRBrowserProvider` (before) | **2 failing** — `#root` empty, ssr fell back to the client shell |
| `SSRBrowserProvider` > `ClientContext` (after) | **4 passing** |

The synthetic `Tooltip` was then removed; both UI suites pass on the final diff (16 assertions).

## Residual gap

Render-plugin `reactContext`s (pubsub, lanes, notifications, user-agent) are applied by `ServerRenderer` *outside* the JSX this file passes, so they remain above the provider. A component rendered by one of those contexts — as opposed to inside its children — would still hit this. Covering that needs `ssrBrowserContext` supplied as a render plugin rather than as JSX, which is a larger change and not what the reported failure needs.

Also worth noting separately: `scopes/ui-foundation/user-agent` provides `userAgentContext`, which `useUserAgent` never reads — it only reads `ssrBrowserContext`. That aspect looks vestigial for this purpose.
