### PR TITLE
ci: remove the CircleCI merge-queue heartbeat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -734,27 +734,6 @@ jobs:
           name: 'check @teambit/harmony version synchronization'
           command: './scripts/check-harmony-version-sync.sh'
 
-  # Runs the same reconcile script the merge-queue GitHub workflow runs — see the
-  # merge_queue_reconcile workflow below for why it also lives here.
-  merge_queue_reconcile:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          name: 'reconcile the merge queue'
-          # no CIRCLE_TOKEN needed: the project is public, so the script's CircleCI reads work
-          # unauthenticated (it uses the token only when one is present in the environment).
-          # A hung API call would otherwise let a run outlive the 10m schedule interval — the
-          # tight no_output_timeout bounds it (the script normally finishes in seconds).
-          no_output_timeout: 5m
-          command: |
-            if [ -z "$GH_RELEASE_GITHUB_API_TOKEN" ]; then
-              echo "The GH_RELEASE_GITHUB_API_TOKEN project env var is not set — the reconcile"
-              echo "script needs it as GITHUB_TOKEN (statuses+issues write)."
-              exit 1
-            fi
-            GITHUB_TOKEN=$GH_RELEASE_GITHUB_API_TOKEN node .github/scripts/merge-queue.js
-
   generate_and_check_types:
     <<: *defaults
     steps:
@@ -1624,30 +1603,6 @@ workflows:
                 - master
     jobs:
       - update_e2e_timings
-
-  # Independent heartbeat for the merge queue. The GitHub Actions side of the queue is
-  # event-driven, but its only time-based fallback is the Actions cron — which GitHub throttles
-  # far beyond its 5m spec (20-40m silent gaps), and which vanishes entirely when Actions itself
-  # is down (2026-08-06 outage: the queue froze and only admins could bypass the gate). CircleCI
-  # is independent infrastructure that kept working through that outage, so this schedule runs the
-  # very same reconcile script from here. The script is stateless and idempotent — concurrent runs
-  # with the Actions-side reconciles are harmless. It can also be run from any laptop as a
-  # break-glass: GITHUB_TOKEN=<pat> node .github/scripts/merge-queue.js
-  merge_queue_heartbeat:
-    triggers:
-      - schedule:
-          # CircleCI's config-level cron rejects step syntax (*/10) — list the minutes explicitly
-          cron: '4,14,24,34,44,54 * * * *'
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - merge_queue_reconcile:
-          # serialize heartbeat runs against each other (same mechanism bit_merge uses) so a
-          # slow run can't overlap the next tick; overlap with the Actions-side reconciles
-          # remains possible and harmless — the script is stateless and idempotent
-          serial-group: 'merge-queue-reconcile'
 
   # Windows nightly workflow
   # windows-nightly:

--- a/.github/scripts/merge-queue.js
+++ b/.github/scripts/merge-queue.js
@@ -33,11 +33,11 @@
  *   "Merge Queue Dashboard" issue (label: merge-queue) is kept up to date.
  *
  * The loop is stateless and idempotent: every run re-derives the queue from the GitHub + CircleCI
- * APIs, so a skipped or crashed run costs nothing. It runs from three places for redundancy:
- * the GitHub Actions workflow (event-driven + cron), a CircleCI scheduled workflow
- * (merge_queue_heartbeat, every 10m — survives Actions outages on independent infrastructure),
- * and, as a break-glass, any machine: GITHUB_TOKEN=<pat> node .github/scripts/merge-queue.js
- * (add MERGE_QUEUE_DRY_RUN=true to observe without mutating).
+ * APIs, so a skipped or crashed run costs nothing. It normally runs from the GitHub Actions
+ * workflow (event-driven + cron) and, as a break-glass (e.g. during an Actions outage), from any
+ * machine: GITHUB_TOKEN=<pat> node .github/scripts/merge-queue.js
+ * (add MERGE_QUEUE_DRY_RUN=true to observe without mutating). A CircleCI heartbeat used to run
+ * it every 10m as outage insurance; removed 2026-08 — it flooded the CircleCI pipeline views.
  *
  * Required env: GITHUB_TOKEN (statuses+issues write). Optional: CIRCLE_TOKEN (CircleCI API,
  * read) — the project is public so unauthenticated reads work; set it only to avoid shared-IP
@@ -131,7 +131,7 @@ async function githubGraphql(query) {
 
 // transient CircleCI failures get bounded retries: the reconcile is this queue's outage
 // fallback, and (especially unauthenticated) reads can hit rate limits or blips — one 429/5xx
-// must not abort a whole heartbeat run. Hard failures (401/404/...) still throw immediately,
+// must not abort a whole reconcile run. Hard failures (401/404/...) still throw immediately,
 // and exhausting retries throws too: "couldn't check bit_merge" is never treated as settled.
 const RETRYABLE_CIRCLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -29,10 +29,13 @@
 #   pull_request_review runs the PR merge commit's workflow copy, which must never see
 #   CIRCLE_TOKEN; the secret-less ping workflow absorbs that context, and its completion lands
 #   here on master's trusted copy.
-# - schedule: safety net for missed events. Not the only one: a CircleCI scheduled workflow
-#   (merge_queue_heartbeat in .circleci/config.yml) runs the same script every 10m from
-#   independent infrastructure — GitHub's cron is heavily throttled, and an Actions outage
-#   (2026-08-06) froze this workflow entirely, blocking every non-admin merge.
+# - schedule: safety net for missed events. GitHub throttles it far beyond its 5m spec (20-40m
+#   silent gaps observed), which is tolerable now that the event triggers above cover the common
+#   transitions. A CircleCI heartbeat (merge_queue_heartbeat) used to run the same script every
+#   10m as outage insurance — removed 2026-08 for flooding the CircleCI pipeline views (~144
+#   runs/day); if Actions goes down again (2026-08-06 froze every non-admin merge), run the
+#   script from any machine as a break-glass:
+#   GITHUB_TOKEN=<pat> node .github/scripts/merge-queue.js
 name: merge-queue
 
 on:


### PR DESCRIPTION
The heartbeat ran the reconcile script every 10 minutes on master, flooding the CircleCI pipeline views with ~144 runs/day. It was added as outage insurance, but it's now third-line defense: event triggers (including commit-status events from #10630) cover the common transitions, and the GitHub Actions cron remains as the timed safety net.

Removing it to declutter; we'll monitor the queue and revisit if Actions reliability makes it necessary again. Break-glass for an Actions outage stays documented in the workflow/script comments: run the script from any machine with a token.