### PR TITLE
chore: checkout head and resolve workspace.jsonc conflict after ci merge failure

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1102,7 +1102,7 @@
     "modules/config-mutator": {
         "name": "modules/config-mutator",
         "scope": "teambit.webpack",
-        "version": "0.0.182",
+        "version": "0.0.183",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/config-mutator"
     },
@@ -1385,7 +1385,7 @@
     "overview/renderers/grouped-schema-nodes-overview-summary": {
         "name": "overview/renderers/grouped-schema-nodes-overview-summary",
         "scope": "teambit.api-reference",
-        "version": "0.0.71",
+        "version": "0.0.73",
         "mainFile": "index.ts",
         "rootDir": "components/overview/renderers/grouped-schema-nodes-overview-summary"
     },

--- a/components/overview/renderers/grouped-schema-nodes-overview-summary/grouped-schema-nodes-overview-summary.tsx
+++ b/components/overview/renderers/grouped-schema-nodes-overview-summary/grouped-schema-nodes-overview-summary.tsx
@@ -12,13 +12,30 @@ import type { APINodeRenderProps } from '@teambit/api-reference.models.api-node-
 import { nodeStyles } from '@teambit/api-reference.models.api-node-renderer';
 import { VariableNodeSummary, EnumMemberSummary } from '@teambit/api-reference.renderers.schema-node-member-summary';
 import { parameterRenderer as defaultParamRenderer } from '@teambit/api-reference.renderers.parameter';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+// deep import on purpose: the package root re-exports `default-highlight` (highlight.js with every
+// language) and `prism` (refractor with every language) alongside the light builds, so importing
+// anything from the root pulls ~2.3 MB into every consumer's bundle.
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
+import tsSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+import tsxSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
+import jsSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import jsxSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
+import cssSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/css';
+import mdSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/markdown';
 import defaultTheme from '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme';
 import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 import pluralize from 'pluralize';
 import classnames from 'classnames';
 
 import styles from './grouped-schema-nodes-overview-summary.module.scss';
+
+// `lang` below is the source file's ending: ts/tsx/js/jsx, with scss/sass mapped to css and mdx to md.
+SyntaxHighlighter.registerLanguage('ts', tsSyntax);
+SyntaxHighlighter.registerLanguage('tsx', tsxSyntax);
+SyntaxHighlighter.registerLanguage('js', jsSyntax);
+SyntaxHighlighter.registerLanguage('jsx', jsxSyntax);
+SyntaxHighlighter.registerLanguage('css', cssSyntax);
+SyntaxHighlighter.registerLanguage('md', mdSyntax);
 
 // @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
 const Link = BaseLink as any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,8 +275,8 @@ importers:
         specifier: ^0.0.69
         version: 0.0.69(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
       '@teambit/api-reference.renderers.schema-node-member-summary':
-        specifier: ^0.0.80
-        version: 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
+        specifier: ^0.0.82
+        version: 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
       '@teambit/api-reference.renderers.schema-nodes-index':
         specifier: ^0.0.72
         version: 0.0.72(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(react-dom@19.2.7)(react@19.2.7)
@@ -1726,6 +1726,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lodash.flatten:
+        specifier: 4.4.0
+        version: 4.4.0
       lodash.head:
         specifier: 4.0.1
         version: 4.0.1
@@ -2216,9 +2219,6 @@ importers:
       '@types/react-router-dom':
         specifier: 5.3.3
         version: 5.3.3
-      lodash.flatten:
-        specifier: 4.4.0
-        version: 4.4.0
 
   components/bit/get-bit-version:
     dependencies:
@@ -3610,8 +3610,8 @@ importers:
         specifier: ^0.0.69
         version: 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/api-reference.renderers.schema-node-member-summary':
-        specifier: ^0.0.80
-        version: 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
+        specifier: ^0.0.82
+        version: 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
       '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme':
         specifier: ^0.0.16
         version: 0.0.16
@@ -6839,7 +6839,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react-refresh@0.10.0)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -7913,7 +7913,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@5.2.1)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@5.2.1)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -8972,7 +8972,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -9980,7 +9980,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react-refresh@0.10.0)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -11045,7 +11045,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react-refresh@0.10.0)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -12110,7 +12110,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -13151,7 +13151,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -14192,7 +14192,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.26.9)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -15248,7 +15248,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -16295,7 +16295,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -17312,7 +17312,7 @@ importers:
         version: file:scopes/workspace/clear-cache(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli':
         specifier: workspace:*
-        version: file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+        version: file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/cli-mcp-server':
         specifier: workspace:*
         version: file:scopes/mcp/cli-mcp-server(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@pnpm/logger@1100.0.0)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(chai@4.3.0)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(domexception@4.0.0)(esbuild@0.14.29)(eslint@8.56.0)(graphql@15.8.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(typanion@3.14.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
@@ -23593,6 +23593,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.3.1
         version: 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      chai:
+        specifier: 5.2.1
+        version: 5.2.1
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -24427,6 +24430,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
+      '@teambit/ui-foundation.ui.is-browser':
+        specifier: ^0.0.500
+        version: 0.0.500(react-dom@19.2.7)(react@19.2.7)
       '@testing-library/react':
         specifier: ^14.3.1
         version: 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
@@ -24452,9 +24458,6 @@ importers:
       '@teambit/harmony.envs.core-aspect-env':
         specifier: 2.0.1
         version: 2.0.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
-      '@teambit/ui-foundation.ui.is-browser':
-        specifier: ^0.0.500
-        version: 0.0.500(react-dom@19.2.7)(react@19.2.7)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25548,6 +25551,9 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      cross-fetch:
+        specifier: 3.1.5
+        version: 3.1.5
       filenamify:
         specifier: 4.2.0
         version: 4.2.0
@@ -25566,6 +25572,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lru-cache:
+        specifier: 10.4.3
+        version: 10.4.3
       mime:
         specifier: 2.5.2
         version: 2.5.2
@@ -25630,12 +25639,6 @@ importers:
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
-      cross-fetch:
-        specifier: 3.1.5
-        version: 3.1.5
-      lru-cache:
-        specifier: 10.4.3
-        version: 10.4.3
 
   scopes/preview/ui/component-preview:
     dependencies:
@@ -26022,6 +26025,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lodash.flatten:
+        specifier: 4.4.0
+        version: 4.4.0
       mini-css-extract-plugin:
         specifier: 2.2.2
         version: 2.2.2(webpack@5.109.2)
@@ -26155,9 +26161,6 @@ importers:
       '@types/webpack':
         specifier: 5.28.5
         version: 5.28.5(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(uglify-js@3.19.3)
-      lodash.flatten:
-        specifier: 4.4.0
-        version: 4.4.0
 
   scopes/react/ui/compositions-app:
     dependencies:
@@ -33119,6 +33122,13 @@ packages:
       react: 19.2.7
       react-dom: 19.2.7
 
+  '@teambit/api-reference.renderers.schema-node-member-summary@0.0.82':
+    resolution: {integrity: sha512-ZZfxLD8LAds3tRDINFd/2Uxhy3lOS+7qQhNGel3lAUMXpkLuzn89D7hGnfB3mcOnC7psByra1fJLLFTz+0nU9A==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7
+
   '@teambit/api-reference.renderers.schema-nodes-index@0.0.72':
     resolution: {integrity: sha512-OTpCILDwCQsHU8TmKXPQqcjpyqW379I2UwFEsfeXf9c/VghqLUHIBtGGJoLqlp2PaVQdwS+SmG6IxX76foQVnw==}
     engines: {node: '>=12.22.0'}
@@ -33949,6 +33959,7 @@ packages:
   '@teambit/cli@file:scopes/harmony/cli':
     resolution: {directory: scopes/harmony/cli, type: directory}
     peerDependencies:
+      chai: 5.2.1
       react: 19.2.7
 
   '@teambit/cloud.entities.cloud-date@0.0.3':
@@ -57491,7 +57502,7 @@ snapshots:
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@18.3.1)(react@18.3.1)
       '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
-      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@18.3.1)(react-router-dom@6.30.4)(react@18.3.1)
+      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@18.3.1)(react-router-dom@6.30.4)(react@18.3.1)
       '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
       '@teambit/api-reference.utils.group-schema-node-by-signature': 0.0.45
       '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
@@ -57515,7 +57526,7 @@ snapshots:
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.2.7)(react@19.2.7)
       '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
+      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
       '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
       '@teambit/api-reference.utils.group-schema-node-by-signature': 0.0.45
       '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
@@ -57539,7 +57550,7 @@ snapshots:
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.2.7)(react@19.2.7)
       '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
+      '@teambit/api-reference.renderers.schema-node-member-summary': 0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
       '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
       '@teambit/api-reference.utils.group-schema-node-by-signature': 0.0.45
       '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
@@ -58372,6 +58383,78 @@ snapshots:
       - react-router-dom
 
   '@teambit/api-reference.renderers.schema-node-member-summary@0.0.80(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)':
+    dependencies:
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53
+      '@teambit/api-reference.renderers.api-node-details': 0.0.84(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
+      '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
+      '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
+      '@teambit/documenter.ui.table-heading-row': 4.0.11(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/documenter.ui.table-row': 4.1.16(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/semantics.entities.semantic-schema': 0.0.103
+      classnames: 2.5.1
+      core-js: 3.13.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-syntax-highlighter: 15.6.6(react@19.2.7)
+    transitivePeerDependencies:
+      - '@teambit/base-react.navigation.link'
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
+  '@teambit/api-reference.renderers.schema-node-member-summary@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@18.3.1)(react-router-dom@6.30.4)(react@18.3.1)':
+    dependencies:
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53
+      '@teambit/api-reference.renderers.api-node-details': 0.0.84(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react@19.2.18)(react-dom@18.3.1)(react-router-dom@6.30.4)(react@18.3.1)
+      '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
+      '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
+      '@teambit/documenter.ui.table-heading-row': 4.0.11(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/documenter.ui.table-row': 4.1.16(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/semantics.entities.semantic-schema': 0.0.103
+      classnames: 2.5.1
+      core-js: 3.13.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-syntax-highlighter: 15.6.6(react@18.3.1)
+    transitivePeerDependencies:
+      - '@teambit/base-react.navigation.link'
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
+  '@teambit/api-reference.renderers.schema-node-member-summary@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)':
+    dependencies:
+      '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/api-reference.models.api-reference-model': 0.0.53
+      '@teambit/api-reference.renderers.api-node-details': 0.0.84(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@14.3.1)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)
+      '@teambit/api-reference.renderers.parameter': 0.0.69(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme': 0.0.16
+      '@teambit/api-reference.utils.schema-node-signature-transform': 0.0.47
+      '@teambit/documenter.ui.table-heading-row': 4.0.11(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/documenter.ui.table-row': 4.1.16(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/semantics.entities.semantic-schema': 0.0.103
+      classnames: 2.5.1
+      core-js: 3.13.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-syntax-highlighter: 15.6.6(react@19.2.7)
+    transitivePeerDependencies:
+      - '@teambit/base-react.navigation.link'
+      - '@testing-library/react'
+      - '@testing-library/react-hooks'
+      - '@types/react'
+      - '@types/react-dom'
+      - react-router-dom
+
+  '@teambit/api-reference.renderers.schema-node-member-summary@0.0.82(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react-hooks@8.0.1)(@testing-library/react@16.3.2)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.7)(react-router-dom@6.30.4)(react@19.2.7)':
     dependencies:
       '@teambit/api-reference.models.api-node-renderer': 0.0.53(react-dom@19.2.7)(react@19.2.7)
       '@teambit/api-reference.models.api-reference-model': 0.0.53
@@ -62518,7 +62601,7 @@ snapshots:
       - react
       - react-dom
 
-  '@teambit/cli@file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)':
+  '@teambit/cli@file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version(react-dom@18.3.1)(react@18.3.1)
@@ -62531,6 +62614,7 @@ snapshots:
       '@teambit/legacy.logger': file:components/legacy/logger(react-dom@18.3.1)(react@18.3.1)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
+      chai: 4.3.0
       chalk: 4.1.2
       didyoumean: 1.2.1
       fs-extra: 10.0.0
@@ -62550,7 +62634,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@teambit/cli@file:scopes/harmony/cli(@types/react@19.2.18)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)':
+  '@teambit/cli@file:scopes/harmony/cli(@types/react@19.2.18)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
       '@teambit/bit-error': 0.0.404
       '@teambit/bit.get-bit-version': file:components/bit/get-bit-version(react-dom@19.2.7)(react@19.2.7)
@@ -62563,6 +62647,40 @@ snapshots:
       '@teambit/legacy.logger': file:components/legacy/logger(react-dom@19.2.7)(react@19.2.7)
       '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      chai: 4.3.0
+      chalk: 4.1.2
+      didyoumean: 1.2.1
+      fs-extra: 10.0.0
+      lodash: 4.17.21
+      oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
+      oxlint-tsgolint: 0.17.0
+      p-map-series: 2.1.0
+      pad-right: 0.2.2
+      react: 19.2.7
+      react-router-dom: 6.30.4(react-dom@19.2.7)(react@19.2.7)
+      yargs: 17.0.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - domexception
+      - encoding
+      - graphql
+      - react-dom
+      - supports-color
+
+  '@teambit/cli@file:scopes/harmony/cli(@types/react@19.2.18)(chai@5.2.1)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)':
+    dependencies:
+      '@teambit/bit-error': 0.0.404
+      '@teambit/bit.get-bit-version': file:components/bit/get-bit-version(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/harmony': 0.4.12
+      '@teambit/legacy.analytics': file:components/legacy/analytics(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.cli.error': file:components/legacy/cli/error(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.constants': file:components/legacy/constants(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.consumer': file:components/legacy/consumer(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
+      '@teambit/legacy.loader': file:components/legacy/loader(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.logger': file:components/legacy/logger(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/legacy.utils': file:components/legacy/utils(react-dom@19.2.7)(react@19.2.7)
+      '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      chai: 5.2.1
       chalk: 4.1.2
       didyoumean: 1.2.1
       fs-extra: 10.0.0
@@ -84694,12 +84812,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 4.3.0
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -84762,12 +84882,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 4.3.0
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -84830,12 +84952,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 4.3.0
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -84898,12 +85022,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -84940,6 +85066,7 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@teambit/harmony': 0.4.12
+      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       eventemitter2: 6.4.4
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -84954,6 +85081,7 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@teambit/harmony': 0.4.12
+      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.2.7)(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       eventemitter2: 6.4.4
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -88445,6 +88573,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -88595,6 +88724,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -88745,6 +88875,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -88895,6 +89026,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)
@@ -89045,6 +89177,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       oxlint: 1.55.0(oxlint-tsgolint@0.17.0)

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -98,7 +98,7 @@
         "@teambit/api-reference.renderers.interface": "^0.0.84",
         "@teambit/api-reference.renderers.parameter": "^0.0.69",
         "@teambit/api-reference.renderers.react": "^0.0.69",
-        "@teambit/api-reference.renderers.schema-node-member-summary": "^0.0.80",
+        "@teambit/api-reference.renderers.schema-node-member-summary": "^0.0.82",
         "@teambit/api-reference.renderers.schema-nodes-index": "^0.0.72",
         "@teambit/api-reference.renderers.this": "^0.0.71",
         "@teambit/api-reference.renderers.type": "^0.0.82",


### PR DESCRIPTION
The "bit ci merge" step failed on master. The file workspace.jsonc had a version conflict.

This PR applies these changes:
- Set the component range for the conflicting entry in workspace.jsonc to ^0.0.82.
- Move 2 components to their head versions.
- Update .bitmap and pnpm-lock.yaml to match.