### PR TITLE
fix(ci): read version for merge commit message from .bitmap instead of npm

### DIFF
--- a/scripts/generate-merge-commit-message.js
+++ b/scripts/generate-merge-commit-message.js
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
 
-const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 try {
-  // Get the current version of @teambit/bit from npm
-  const version = execSync('npm show @teambit/bit version', { encoding: 'utf8' }).trim();
+  // Read the version of teambit.harmony/bit from .bitmap - at commit time it already
+  // holds the version that was just tagged (and published to npm) by `bit ci merge`.
+  // Querying npm here instead is racy: the registry read endpoints may lag the publish
+  // by seconds to minutes, which used to produce commit messages one release behind.
+  const bitmapRaw = fs.readFileSync(path.join(__dirname, '..', '.bitmap'), 'utf8');
+  const bitmapJson = bitmapRaw.replace(/\/\*[\s\S]*?\*\//g, '');
+  const bitmap = JSON.parse(bitmapJson);
+  const version = bitmap.bit.version;
+  if (!version) throw new Error('bit entry has no version');
 
-  // Generate the commit message with the version
   console.log(`bump teambit version to ${version} [skip ci]`);
 } catch {
   // Fallback to default message if version lookup fails


### PR DESCRIPTION
The merge commit message often showed the version of the previous release.

The script read the version from the npm registry. The registry data can stay old for some minutes after a publish. Because of this delay, the script got the old version.

Now the script reads the version of `teambit.harmony/bit` from the `.bitmap` file. At commit time, this file already contains the new version. Thus the message always agrees with the committed data, and no network call is necessary. If the file read fails, the script uses the fallback message as before.