### PR TITLE
fix(ci): pin Bit version in release bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,9 @@ commands:
               "@pnpm/util.lex-comparator": "3.0.2",
               "@pnpm/config.nerf-dart": "1.0.1"
             }'
-            pnpm add @teambit/bit --os=<<parameters.os>> --cpu=<<parameters.cpu>>
+            # Pin the release selected by setup_bit_version. Without the version, pnpm 12's default
+            # 24-hour minimum release age can select an older Bit release instead of the latest one.
+            pnpm add "@teambit/bit@${BIT_VERSION}" --os=<<parameters.os>> --cpu=<<parameters.cpu>>
 
   verify_pnpm_napi_bundle:
     parameters:


### PR DESCRIPTION
## Summary

- install the exact Bit version selected by `setup_bit_version`
- prevent pnpm 12’s default 24-hour minimum release age from selecting an older Bit release
- keep the minimum-release-age protection enabled for unrelated packages

## Root cause

The bundle command used `pnpm add @teambit/bit` without a version. pnpm 12 therefore selected the newest mature release (`2.0.85`) instead of the newly published `2.2.1`. That older release depends on the unavailable `@teambit/harmony.content.cli-reference@2.0.1193`, causing the CircleCI bundle jobs to fail.

## Verification

- reproduced the unversioned install failure with pnpm `12.0.0-rc.7`
- verified `pnpm add "@teambit/bit@${BIT_VERSION}"` installs `2.2.1` and resolves `cli-reference@2.0.1210`
- verified the Linux pnpm native binary is present
- parsed the CircleCI YAML and ran `git diff --check`