### PR TITLE
fix(lane): "component has config changes" false positive during lane merge

### DIFF
--- a/e2e/harmony/lanes/merge-main-env-policy.e2e.ts
+++ b/e2e/harmony/lanes/merge-main-env-policy.e2e.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/legacy.e2e-helper';
+
+/**
+ * Bug reproduction: "component has config changes" false positive during lane-merge.
+ *
+ * Scenario:
+ * 1. A component uses a custom env whose env.jsonc defines a dependency policy (forced runtime/dev deps).
+ * 2. The component is snapped on a lane. main diverges (the component gets a new tag on main).
+ * 3. A fresh workspace imports the lane. the env is not a workspace component - it's installed as a package.
+ * 4. `bit status` / `bit diff` show no modified components. the workspace is clean.
+ * 5. BUG: `bit lane merge main` failed with "component has config changes, please snap/tag it first".
+ *    the merge flow loaded the component via the legacy loader before its env was loaded into Harmony,
+ *    so the env's dependency-policy was not applied. the recalculated component-hash then differed from
+ *    the model (packageDependencies/overrides missing the env policy) and the component was mistakenly
+ *    marked as config-modified.
+ */
+(supportNpmCiRegistryTesting ? describe : describe.skip)(
+  'lane merge main when the comp env with deps policy is a package and not in the workspace',
+  function () {
+    this.timeout(0);
+    let helper: Helper;
+    let npmCiRegistry: NpmCiRegistry;
+    let mergeOutput: string;
+    before(async () => {
+      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+      await npmCiRegistry.init();
+
+      // create comp1 and an old-style aspect-env that defines a deps policy via getDependencies()
+      helper.fs.outputFile('comp1/index.ts', 'export const comp1 = "v1";');
+      helper.command.addComponent('comp1');
+      const envName = helper.env.setCustomEnv('node-env-dev-dep');
+      helper.command.setEnv('comp1', envName);
+
+      // tag with build so the env package is compiled and published to the local registry
+      helper.command.tagAllComponents();
+      helper.command.export();
+
+      // snap comp1 on a lane
+      helper.command.createLane('dev');
+      helper.fs.outputFile('comp1/index.ts', 'export const comp1 = "v1-lane";');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      // diverge main: add a file to comp1 on main so the later merge auto-resolves
+      helper.command.switchLocalLane('main', '-x');
+      helper.fs.outputFile('comp1/main-change.ts', 'export const mainChange = true;');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      // fresh workspace on the lane. the env is not a workspace component, it gets installed
+      // as a package. this is required for reproducing the bug: the env must be loadable so
+      // the regular status/diff flow applies its policy, while the merge flow used to miss it.
+      helper.scopeHelper.reInitWorkspace();
+      npmCiRegistry.setResolver();
+      helper.command.importLane('dev');
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+      helper.scopeHelper.destroy();
+    });
+    it('bit status should show a clean workspace before the merge', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+    });
+    it('bit lane merge main should not fail with a "config changes" false positive', () => {
+      mergeOutput = helper.command.mergeLaneWithoutBuild('main', '-x');
+      expect(mergeOutput).to.not.have.string('config changes');
+      expect(mergeOutput).to.have.string('successfully merged');
+    });
+    it('the merge should snap the diverged component', () => {
+      expect(mergeOutput).to.have.string('merge-snapped components');
+    });
+  }
+);

--- a/e2e/harmony/lanes/merge-main-env-policy.e2e.ts
+++ b/e2e/harmony/lanes/merge-main-env-policy.e2e.ts
@@ -21,7 +21,6 @@ import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/leg
     this.timeout(0);
     let helper: Helper;
     let npmCiRegistry: NpmCiRegistry;
-    let mergeOutput: string;
     before(async () => {
       helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
       helper.scopeHelper.setWorkspaceWithRemoteScope();
@@ -62,17 +61,22 @@ import { Helper, NpmCiRegistry, supportNpmCiRegistryTesting } from '@teambit/leg
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
-    it('bit status should show a clean workspace before the merge', () => {
+    it('bit status should not show the component as modified before the merge', () => {
       const status = helper.command.statusJson();
       expect(status.modifiedComponents).to.have.lengthOf(0);
     });
-    it('bit lane merge main should not fail with a "config changes" false positive', () => {
-      mergeOutput = helper.command.mergeLaneWithoutBuild('main', '-x');
-      expect(mergeOutput).to.not.have.string('config changes');
-      expect(mergeOutput).to.have.string('successfully merged');
-    });
-    it('the merge should snap the diverged component', () => {
-      expect(mergeOutput).to.have.string('merge-snapped components');
+    describe('bit lane merge main', () => {
+      let mergeOutput: string;
+      before(() => {
+        mergeOutput = helper.command.mergeLaneWithoutBuild('main', '-x');
+      });
+      it('should not fail with a "config changes" false positive', () => {
+        expect(mergeOutput).to.not.have.string('config changes');
+        expect(mergeOutput).to.have.string('successfully merged');
+      });
+      it('should snap the diverged component', () => {
+        expect(mergeOutput).to.have.string('merge-snapped components');
+      });
     });
   }
 );

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -85,8 +85,9 @@ export class CheckoutMain {
     const addedComponents = await this.restoreMissingComponents(checkoutProps);
     const newComponents = await this.addNewComponents(checkoutProps);
     const bitIds = ComponentIdList.fromArray(ids || []);
-    // pre-load the components through the grouped workspace loader (envs first), so the modified-status
-    // calculated per component below works on correctly-built components. see workspace.preloadComponents.
+    // must happen before the per-component flow below, which loads components cold via the legacy loader
+    // and calls consumer.isComponentModified directly, bypassing the component-status-loader.
+    // see workspace.preloadComponents.
     await this.workspace.preloadComponents(bitIds);
     // don't use Promise.all, it loads the components and this operation must be in sequence.
     const allComponentStatusBeforeMerge = await mapSeries(bitIds, (id) =>

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -85,6 +85,9 @@ export class CheckoutMain {
     const addedComponents = await this.restoreMissingComponents(checkoutProps);
     const newComponents = await this.addNewComponents(checkoutProps);
     const bitIds = ComponentIdList.fromArray(ids || []);
+    // pre-load the components through the grouped workspace loader (envs first), so the modified-status
+    // calculated per component below works on correctly-built components. see workspace.preloadComponents.
+    await this.workspace.preloadComponents(bitIds);
     // don't use Promise.all, it loads the components and this operation must be in sequence.
     const allComponentStatusBeforeMerge = await mapSeries(bitIds, (id) =>
       this.getComponentStatusBeforeMergeAttempt(id, checkoutProps)

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -86,8 +86,8 @@ export class CheckoutMain {
     const newComponents = await this.addNewComponents(checkoutProps);
     const bitIds = ComponentIdList.fromArray(ids || []);
     // must happen before the per-component flow below, which loads components cold via the legacy loader
-    // and calls consumer.isComponentModified directly, bypassing the component-status-loader.
-    // see workspace.preloadComponents.
+    // and calls consumer.isComponentModified directly, bypassing the component-status-loader (which would
+    // have preloaded them itself). see workspace.preloadComponents.
     await this.workspace.preloadComponents(bitIds);
     // don't use Promise.all, it loads the components and this operation must be in sequence.
     const allComponentStatusBeforeMerge = await mapSeries(bitIds, (id) =>

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -56,6 +56,7 @@ export class MergeStatusProvider {
     if (!this.currentLane && this.otherLane) {
       await this.importer.importObjectsFromMainIfExist(this.otherLane.toBitIds().toVersionLatest());
     }
+    await this.loadCurrentComponentsIfExistOnWorkspace(bitIds);
     const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
       this.getComponentStatusBeforeMergeAttempt(id)
     );
@@ -113,6 +114,23 @@ export class MergeStatusProvider {
 
     results.push(...compStatusNotNeedMerge);
     return results;
+  }
+
+  /**
+   * load the components that exist in the workspace through the workspace loader, which loads their envs
+   * before loading the components themselves, and populates the loaders caches with correctly-built components.
+   * without this, getComponentStatusBeforeMergeAttempt loads each component individually via the legacy loader,
+   * which can load a component before its env is loaded into Harmony. the env's dependency-policy is then not
+   * applied, the recalculated component-hash differs from the model, and the merge fails with a
+   * "component has config changes" false positive, even though bit-status/bit-diff show no changes.
+   */
+  private async loadCurrentComponentsIfExistOnWorkspace(bitIds: ComponentID[]) {
+    if (!this.workspace) return;
+    const bitMap = this.workspace.consumer.bitMap;
+    const existingIds = compact(bitIds.map((id) => bitMap.getComponentIdIfExist(id, { ignoreVersion: true })));
+    if (!existingIds.length) return;
+    // don't throw. errors during component-load are handled later per-component when calculating its status
+    await this.workspace.getMany(existingIds, undefined, false);
   }
 
   private async getComponentMergeStatus(

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -129,8 +129,16 @@ export class MergeStatusProvider {
     const bitMap = this.workspace.consumer.bitMap;
     const existingIds = compact(bitIds.map((id) => bitMap.getComponentIdIfExist(id, { ignoreVersion: true })));
     if (!existingIds.length) return;
-    // don't throw. errors during component-load are handled later per-component when calculating its status
-    await this.workspace.getMany(existingIds, undefined, false);
+    try {
+      // don't throw on component-load failures. they are handled later per-component when calculating its status
+      await this.workspace.getMany(existingIds, undefined, false);
+    } catch (err: any) {
+      // the loader can still throw for errors it does not classify as invalid-component errors. this pre-load
+      // is a best-effort cache-warming, it should never fail the merge. a component that genuinely fails to
+      // load will surface a proper error later in the per-component flow, and a component that the merge
+      // legitimately skips without loading (e.g. locally-removed) should not fail it here.
+      this.logger.warn(`failed pre-loading components for merge, continuing without the pre-loaded cache`, err);
+    }
   }
 
   private async getComponentMergeStatus(

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -56,7 +56,9 @@ export class MergeStatusProvider {
     if (!this.currentLane && this.otherLane) {
       await this.importer.importObjectsFromMainIfExist(this.otherLane.toBitIds().toVersionLatest());
     }
-    await this.loadCurrentComponentsIfExistOnWorkspace(bitIds);
+    // pre-load in one batch through the grouped workspace loader (envs first), so the modified-status
+    // calculated per component below works on correctly-built components. see workspace.preloadComponents.
+    if (this.workspace) await this.workspace.preloadComponents(bitIds);
     const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
       this.getComponentStatusBeforeMergeAttempt(id)
     );
@@ -114,31 +116,6 @@ export class MergeStatusProvider {
 
     results.push(...compStatusNotNeedMerge);
     return results;
-  }
-
-  /**
-   * load the components that exist in the workspace through the workspace loader, which loads their envs
-   * before loading the components themselves, and populates the loaders caches with correctly-built components.
-   * without this, getComponentStatusBeforeMergeAttempt loads each component individually via the legacy loader,
-   * which can load a component before its env is loaded into Harmony. the env's dependency-policy is then not
-   * applied, the recalculated component-hash differs from the model, and the merge fails with a
-   * "component has config changes" false positive, even though bit-status/bit-diff show no changes.
-   */
-  private async loadCurrentComponentsIfExistOnWorkspace(bitIds: ComponentID[]) {
-    if (!this.workspace) return;
-    const bitMap = this.workspace.consumer.bitMap;
-    const existingIds = compact(bitIds.map((id) => bitMap.getComponentIdIfExist(id, { ignoreVersion: true })));
-    if (!existingIds.length) return;
-    try {
-      // don't throw on component-load failures. they are handled later per-component when calculating its status
-      await this.workspace.getMany(existingIds, undefined, false);
-    } catch (err: any) {
-      // the loader can still throw for errors it does not classify as invalid-component errors. this pre-load
-      // is a best-effort cache-warming, it should never fail the merge. a component that genuinely fails to
-      // load will surface a proper error later in the per-component flow, and a component that the merge
-      // legitimately skips without loading (e.g. locally-removed) should not fail it here.
-      this.logger.warn(`failed pre-loading components for merge, continuing without the pre-loaded cache`, err);
-    }
   }
 
   private async getComponentMergeStatus(

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -56,8 +56,8 @@ export class MergeStatusProvider {
     if (!this.currentLane && this.otherLane) {
       await this.importer.importObjectsFromMainIfExist(this.otherLane.toBitIds().toVersionLatest());
     }
-    // must happen before the per-component flow below, which loads components cold via the legacy loader
-    // (getCurrentComponent) before their modified-status is calculated. see workspace.preloadComponents.
+    // batching optimization: load all components in one grouped load, before the per-component flow below
+    // loads them one by one cold via the legacy loader. see workspace.preloadComponents.
     if (this.workspace) await this.workspace.preloadComponents(bitIds);
     const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
       this.getComponentStatusBeforeMergeAttempt(id)

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -56,8 +56,8 @@ export class MergeStatusProvider {
     if (!this.currentLane && this.otherLane) {
       await this.importer.importObjectsFromMainIfExist(this.otherLane.toBitIds().toVersionLatest());
     }
-    // pre-load in one batch through the grouped workspace loader (envs first), so the modified-status
-    // calculated per component below works on correctly-built components. see workspace.preloadComponents.
+    // must happen before the per-component flow below, which loads components cold via the legacy loader
+    // (getCurrentComponent) before their modified-status is calculated. see workspace.preloadComponents.
     if (this.workspace) await this.workspace.preloadComponents(bitIds);
     const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
       this.getComponentStatusBeforeMergeAttempt(id)

--- a/scopes/workspace/workspace/workspace-component/component-status-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/component-status-loader.ts
@@ -32,6 +32,8 @@ export class ComponentStatusLoader {
   }
 
   async getManyComponentsStatuses(ids: ComponentID[]): Promise<ComponentStatusResult[]> {
+    // pre-load in one batch. otherwise, each getStatus pre-loads its component individually
+    await this.workspace.preloadComponents(ids);
     const results: ComponentStatusResult[] = [];
     await mapSeries(ids, async (id) => {
       const status = await this.getComponentStatusById(id);
@@ -65,9 +67,8 @@ export class ComponentStatusLoader {
 
   private async getStatus(id: ComponentID) {
     // make sure the component is loaded through the grouped workspace loader (envs first), so the
-    // modified-status below is calculated on a correctly-built component. without it, the load from
-    // the file-system below may build the component without its env's dependency-policy applied and
-    // mistakenly mark it as modified. (no-op if the component was already loaded or is not in the workspace)
+    // modified-status below is calculated on a correctly-built component. no-op if the component was
+    // already loaded or is not in the workspace. see workspace.preloadComponents.
     await this.workspace.preloadComponents([id]);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const status: ComponentStatusLegacy = {};

--- a/scopes/workspace/workspace/workspace-component/component-status-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/component-status-loader.ts
@@ -64,6 +64,11 @@ export class ComponentStatusLoader {
   }
 
   private async getStatus(id: ComponentID) {
+    // make sure the component is loaded through the grouped workspace loader (envs first), so the
+    // modified-status below is calculated on a correctly-built component. without it, the load from
+    // the file-system below may build the component without its env's dependency-policy applied and
+    // mistakenly mark it as modified. (no-op if the component was already loaded or is not in the workspace)
+    await this.workspace.preloadComponents([id]);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const status: ComponentStatusLegacy = {};
     const componentFromModel: ModelComponent | undefined = await this.consumer.scope.getModelComponentIfExist(id);

--- a/scopes/workspace/workspace/workspace-component/component-status-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/component-status-loader.ts
@@ -67,8 +67,9 @@ export class ComponentStatusLoader {
 
   private async getStatus(id: ComponentID) {
     // make sure the component is loaded through the grouped workspace loader (envs first), so the
-    // modified-status below is calculated on a correctly-built component. no-op if the component was
-    // already loaded or is not in the workspace. see workspace.preloadComponents.
+    // modified-status below is calculated on a correctly-built component - regardless of whether and how
+    // the component was loaded before. no-op if the component was already loaded through the grouped
+    // loader or is not in the workspace. see workspace.preloadComponents.
     await this.workspace.preloadComponents([id]);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const status: ComponentStatusLegacy = {};

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -897,6 +897,13 @@ export class WorkspaceComponentLoader {
     component.state.issues.getOrCreate(IssuesClasses.MultipleEnvs).data = envIds;
   }
 
+  /**
+   * whether the component exists in the in-memory cache in its fully-loaded form
+   */
+  isLoaded(id: ComponentID): boolean {
+    return Boolean(this.getFromCache(id, { loadExtensions: true, executeLoadSlot: true }));
+  }
+
   clearCache() {
     this.componentsCache.deleteAll();
     this.scopeComponentsCache.deleteAll();

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -123,6 +123,9 @@ export class WorkspaceComponentLoader {
     this.componentLoadedSelfAsAspects = createInMemoryCache({ maxSize: getMaxSizeForComponents() });
   }
 
+  // id-strings of components that were built by the grouped load pipeline. see isLoadedThroughGroupPipeline
+  private idsLoadedThroughGroupPipeline = new Set<string>();
+
   async getMany(ids: Array<ComponentID>, loadOpts?: ComponentLoadOptions, throwOnFailure = true): Promise<GetManyRes> {
     const idsWithoutEmpty = compact(ids);
     if (!idsWithoutEmpty.length) {
@@ -452,6 +455,9 @@ export class WorkspaceComponentLoader {
       concurrency: concurrentComponentsLimit(),
     });
     this.logger.profileTrace('executeLoadSlot');
+    // these components were built with their envs loaded beforehand (the load-groups load envs first),
+    // so their env-derived data (e.g. dependency policies) is reliable. see isLoadedThroughGroupPipeline
+    wsComponentsWithAspects.forEach((component) => this.idsLoadedThroughGroupPipeline.add(component.id.toString()));
     await this.warnAboutMisconfiguredEnvs(wsComponentsWithAspects);
     // }
 
@@ -864,6 +870,9 @@ export class WorkspaceComponentLoader {
     if (storeInCache) {
       this.addMultipleEnvsIssueIfNeeded(component); // it's in storeInCache block, otherwise, it wasn't fully loaded
       this.saveInCache(component, loadOptsWithDefaults);
+      // this single-component load overwrote the cache. if this load is part of a grouped load, the
+      // component gets marked once its group completes (getAndLoadSlot)
+      this.idsLoadedThroughGroupPipeline.delete(component.id.toString());
     }
     return component;
   }
@@ -904,11 +913,24 @@ export class WorkspaceComponentLoader {
     return Boolean(this.getFromCache(id, { loadExtensions: true, executeLoadSlot: true }));
   }
 
+  /**
+   * whether the component exists in the in-memory cache in its fully-loaded form AND was built by the
+   * grouped load pipeline, which loads envs before the components that use them. a cached component that
+   * was built by a cold single-component load is not considered loaded here, as it may have been built
+   * without its env's dependency-policy applied.
+   */
+  isLoadedThroughGroupPipeline(id: ComponentID): boolean {
+    const fromCache = this.getFromCache(id, { loadExtensions: true, executeLoadSlot: true });
+    if (!fromCache) return false;
+    return this.idsLoadedThroughGroupPipeline.has(fromCache.id.toString());
+  }
+
   clearCache() {
     this.componentsCache.deleteAll();
     this.scopeComponentsCache.deleteAll();
     this.componentsExtensionsCache.deleteAll();
     this.componentLoadedSelfAsAspects.deleteAll();
+    this.idsLoadedThroughGroupPipeline.clear();
   }
 
   clearComponentCache(id: ComponentID) {
@@ -936,6 +958,7 @@ export class WorkspaceComponentLoader {
         }
       }
     });
+    idsStr.forEach((idStr) => this.idsLoadedThroughGroupPipeline.delete(idStr));
   }
 
   private async loadOne(id: ComponentID, consumerComponent?: ConsumerComponent, loadOpts?: ComponentLoadOptions) {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { AsyncLocalStorage } from 'async_hooks';
 import { parse } from 'comment-json';
 import semver from 'semver';
 import mapSeries from 'p-map-series';
@@ -182,7 +183,9 @@ const DEFAULT_VENDOR_DIR = 'vendor';
  */
 export class Workspace implements ComponentFactory {
   private warnedAboutMisconfiguredEnvs: string[] = []; // cache env-ids that have been errored about not having "env" type
-  private componentsBeingPreloaded = new Set<string>(); // guard against re-entrance during preloadComponents
+  // ids being preloaded in the current async call-chain. guards against recursive re-entrance during preloadComponents
+  private preloadingContext = new AsyncLocalStorage<Set<string>>();
+  private preloadsInFlight = new Map<string, Promise<void>>(); // id-str => the in-flight preload promise
   priority = true;
   owner?: string;
   componentsScopeDirsMap: ComponentScopeDirMap;
@@ -1243,17 +1246,46 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
     const existingIds = compact(
       ids.map((id) => this.consumer.bitMap.getComponentIdIfExist(id, { ignoreVersion: true }))
     );
-    const idsToLoad = existingIds.filter((id) => !this.componentsBeingPreloaded.has(id.toString()));
-    if (!idsToLoad.length) return;
-    idsToLoad.forEach((id) => this.componentsBeingPreloaded.add(id.toString()));
-    try {
-      await this.getMany(idsToLoad, undefined, false);
-    } catch (err: any) {
-      // the loader can still throw for errors it does not classify as invalid-component errors
-      this.logger.warn(`failed pre-loading components, continuing without the pre-loaded cache`, err);
-    } finally {
-      idsToLoad.forEach((id) => this.componentsBeingPreloaded.delete(id.toString()));
+    // recursive re-entry: ids whose preload is in progress in the current async call-chain (i.e. this
+    // call originated from within their own grouped load). don't load and don't wait, it would deadlock
+    const idsInCurrentContext = this.preloadingContext.getStore();
+    const relevantIds = idsInCurrentContext
+      ? existingIds.filter((id) => !idsInCurrentContext.has(id.toString()))
+      : existingIds;
+    if (!relevantIds.length) return;
+    // ids being preloaded by an independent concurrent caller. don't re-load them, but do wait for
+    // their preload to complete, so the caller won't compute the status on a half-built component
+    const preloadsToWaitFor: Promise<void>[] = [];
+    const idsToLoad: ComponentID[] = [];
+    relevantIds.forEach((id) => {
+      const inFlight = this.preloadsInFlight.get(id.toString());
+      if (inFlight) preloadsToWaitFor.push(inFlight);
+      else idsToLoad.push(id);
+    });
+    if (idsToLoad.length) {
+      const contextIds = new Set([...(idsInCurrentContext || []), ...idsToLoad.map((id) => id.toString())]);
+      // an explicit promise rather than the return value of preloadingContext.run, as some @types/node
+      // versions type the latter as void
+      const loadPromise = new Promise<void>((resolve) => {
+        void this.preloadingContext.run(contextIds, async () => {
+          try {
+            await this.getMany(idsToLoad, undefined, false);
+          } catch (err: any) {
+            // the loader can still throw for errors it does not classify as invalid-component errors
+            this.logger.warn(`failed pre-loading components, continuing without the pre-loaded cache`, err);
+          } finally {
+            resolve();
+          }
+        });
+      });
+      idsToLoad.forEach((id) => this.preloadsInFlight.set(id.toString(), loadPromise));
+      try {
+        await loadPromise;
+      } finally {
+        idsToLoad.forEach((id) => this.preloadsInFlight.delete(id.toString()));
+      }
     }
+    await Promise.all(preloadsToWaitFor);
   }
 
   getManyByLegacy(components: ConsumerComponent[], loadOpts?: ComponentLoadOptions): Promise<Component[]> {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1232,16 +1232,16 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
   }
 
   /**
-   * pre-load the given components (only those that exist in the workspace and were not loaded yet) through
-   * the grouped workspace loader, which loads their envs before the components themselves. this populates
-   * the loaders caches with correctly-built components for subsequent loads, e.g. by the legacy loader when
-   * calculating the modified-status. loading a component cold outside this pipeline (a single-component
-   * load) may miss the env's dependency-policy, in which case the recalculated component hash differs from
-   * the model and the component is mistakenly marked as modified (config changes).
-   * note that this is a cache-warmer. it cannot repair a component that was already loaded incorrectly, so
-   * call it before any cold single-component load. (the deeper fix would be for the single-component load
-   * path to load the component's env first, similarly to the grouped loader. see
-   * workspace-component-loader "getWithSpan").
+   * pre-load the given components (only those that exist in the workspace) through the grouped workspace
+   * loader, which loads their envs before the components themselves. this populates the loaders caches
+   * with correctly-built components for subsequent loads, e.g. by the legacy loader when calculating the
+   * modified-status. loading a component cold outside this pipeline (a single-component load) may miss the
+   * env's dependency-policy, in which case the recalculated component hash differs from the model and the
+   * component is mistakenly marked as modified (config changes). a component that was already loaded that
+   * way gets evicted from the caches and rebuilt through the grouped loader (note that references obtained
+   * before the eviction keep pointing to the old instance). the deeper fix would be for the
+   * single-component load path to load the component's env first, similarly to the grouped loader. see
+   * workspace-component-loader "getWithSpan".
    * this method never throws. a component that fails to load here will surface a proper error when loaded
    * later by the calling flow, and a component the calling flow legitimately skips without loading
    * (e.g. locally-removed) should not fail it here.
@@ -1251,26 +1251,31 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
     // within their own grouped load). loading or even waiting for them here would deadlock
     const chainIds = this.preloadingContext.getStore() ?? new Set<string>();
     const bitmapIds = this.consumer.bitmapIdsFromCurrentLaneIncludeRemoved;
-    const candidates: Array<{ id: ComponentID; idStr: string }> = [];
+    const candidates: Array<{ id: ComponentID; idStr: string; needsEviction?: boolean }> = [];
     ids.forEach((id) => {
       const existingId = bitmapIds.searchWithoutVersion(id);
       if (!existingId) return;
       const idStr = existingId.toString();
       if (chainIds.has(idStr)) return;
-      if (this.componentLoader.isLoaded(existingId)) return; // already warm
-      candidates.push({ id: existingId, idStr });
+      if (this.componentLoader.isLoadedThroughGroupPipeline(existingId)) return; // already correctly built
+      // if cached, it was built by a cold single-component load and its env-derived data may be wrong
+      candidates.push({ id: existingId, idStr, needsEviction: this.componentLoader.isLoaded(existingId) });
     });
     if (!candidates.length) return;
     // ids being preloaded by an independent concurrent caller. don't re-load them, but do wait for
     // their preload to complete, so the caller won't compute the status on a half-built component
     const preloadsToAwait: Promise<void>[] = [];
-    const toLoad: Array<{ id: ComponentID; idStr: string }> = [];
+    const toLoad: Array<{ id: ComponentID; idStr: string; needsEviction?: boolean }> = [];
     candidates.forEach((candidate) => {
       const inFlight = this.preloadsInFlight.get(candidate.idStr);
       if (inFlight) preloadsToAwait.push(inFlight);
       else toLoad.push(candidate);
     });
     if (toLoad.length) {
+      // evict components built by a cold single-component load, so getMany rebuilds them through the
+      // grouped pipeline rather than returning the cached (possibly env-less) instances
+      const toEvict = toLoad.filter((c) => c.needsEviction).map((c) => c.id);
+      this.clearComponentsCache(toEvict);
       const contextIds = new Set([...chainIds, ...toLoad.map((c) => c.idStr)]);
       // assign the promise from within run() rather than using its return value, which some
       // @types/node versions type as void

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -182,6 +182,7 @@ const DEFAULT_VENDOR_DIR = 'vendor';
  */
 export class Workspace implements ComponentFactory {
   private warnedAboutMisconfiguredEnvs: string[] = []; // cache env-ids that have been errored about not having "env" type
+  private componentsBeingPreloaded = new Set<string>(); // guard against re-entrance during preloadComponents
   priority = true;
   owner?: string;
   componentsScopeDirsMap: ComponentScopeDirMap;
@@ -1225,6 +1226,34 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
     const { components } = await this.componentLoader.getMany(ids, loadOpts, throwOnFailure);
     this.logger.debug(`getMany, completed. ${components.length} components`);
     return components;
+  }
+
+  /**
+   * pre-load the given components (only those that exist in the workspace) through the grouped workspace
+   * loader, which loads their envs before the components themselves. this populates the loaders caches with
+   * correctly-built components, making them the single source of truth for subsequent loads, e.g. by the
+   * legacy loader when calculating the modified-status. loading a component cold outside this pipeline (a
+   * single-component load) may miss the env's dependency-policy, in which case the recalculated component
+   * hash differs from the model and the component is mistakenly marked as modified (config changes).
+   * this method never throws. a component that fails to load here will surface a proper error when loaded
+   * later by the calling flow, and a component the calling flow legitimately skips without loading
+   * (e.g. locally-removed) should not fail it here.
+   */
+  async preloadComponents(ids: ComponentID[]): Promise<void> {
+    const existingIds = compact(
+      ids.map((id) => this.consumer.bitMap.getComponentIdIfExist(id, { ignoreVersion: true }))
+    );
+    const idsToLoad = existingIds.filter((id) => !this.componentsBeingPreloaded.has(id.toString()));
+    if (!idsToLoad.length) return;
+    idsToLoad.forEach((id) => this.componentsBeingPreloaded.add(id.toString()));
+    try {
+      await this.getMany(idsToLoad, undefined, false);
+    } catch (err: any) {
+      // the loader can still throw for errors it does not classify as invalid-component errors
+      this.logger.warn(`failed pre-loading components, continuing without the pre-loaded cache`, err);
+    } finally {
+      idsToLoad.forEach((id) => this.componentsBeingPreloaded.delete(id.toString()));
+    }
   }
 
   getManyByLegacy(components: ConsumerComponent[], loadOpts?: ComponentLoadOptions): Promise<Component[]> {
@@ -2710,6 +2739,8 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
   }
 
   async getManyComponentsStatuses(ids: ComponentID[]): Promise<ComponentStatusResult[]> {
+    // pre-load in one batch. otherwise, each getComponentStatusById pre-loads its component individually
+    await this.preloadComponents(ids);
     return this.componentStatusLoader.getManyComponentsStatuses(ids);
   }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1232,60 +1232,66 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
   }
 
   /**
-   * pre-load the given components (only those that exist in the workspace) through the grouped workspace
-   * loader, which loads their envs before the components themselves. this populates the loaders caches with
-   * correctly-built components, making them the single source of truth for subsequent loads, e.g. by the
-   * legacy loader when calculating the modified-status. loading a component cold outside this pipeline (a
-   * single-component load) may miss the env's dependency-policy, in which case the recalculated component
-   * hash differs from the model and the component is mistakenly marked as modified (config changes).
+   * pre-load the given components (only those that exist in the workspace and were not loaded yet) through
+   * the grouped workspace loader, which loads their envs before the components themselves. this populates
+   * the loaders caches with correctly-built components for subsequent loads, e.g. by the legacy loader when
+   * calculating the modified-status. loading a component cold outside this pipeline (a single-component
+   * load) may miss the env's dependency-policy, in which case the recalculated component hash differs from
+   * the model and the component is mistakenly marked as modified (config changes).
+   * note that this is a cache-warmer. it cannot repair a component that was already loaded incorrectly, so
+   * call it before any cold single-component load. (the deeper fix would be for the single-component load
+   * path to load the component's env first, similarly to the grouped loader. see
+   * workspace-component-loader "getWithSpan").
    * this method never throws. a component that fails to load here will surface a proper error when loaded
    * later by the calling flow, and a component the calling flow legitimately skips without loading
    * (e.g. locally-removed) should not fail it here.
    */
   async preloadComponents(ids: ComponentID[]): Promise<void> {
-    const existingIds = compact(
-      ids.map((id) => this.consumer.bitMap.getComponentIdIfExist(id, { ignoreVersion: true }))
-    );
-    // recursive re-entry: ids whose preload is in progress in the current async call-chain (i.e. this
-    // call originated from within their own grouped load). don't load and don't wait, it would deadlock
-    const idsInCurrentContext = this.preloadingContext.getStore();
-    const relevantIds = idsInCurrentContext
-      ? existingIds.filter((id) => !idsInCurrentContext.has(id.toString()))
-      : existingIds;
-    if (!relevantIds.length) return;
+    // ids whose preload is in progress in the current async call-chain (i.e. this call originated from
+    // within their own grouped load). loading or even waiting for them here would deadlock
+    const chainIds = this.preloadingContext.getStore() ?? new Set<string>();
+    const bitmapIds = this.consumer.bitmapIdsFromCurrentLaneIncludeRemoved;
+    const candidates: Array<{ id: ComponentID; idStr: string }> = [];
+    ids.forEach((id) => {
+      const existingId = bitmapIds.searchWithoutVersion(id);
+      if (!existingId) return;
+      const idStr = existingId.toString();
+      if (chainIds.has(idStr)) return;
+      if (this.componentLoader.isLoaded(existingId)) return; // already warm
+      candidates.push({ id: existingId, idStr });
+    });
+    if (!candidates.length) return;
     // ids being preloaded by an independent concurrent caller. don't re-load them, but do wait for
     // their preload to complete, so the caller won't compute the status on a half-built component
-    const preloadsToWaitFor: Promise<void>[] = [];
-    const idsToLoad: ComponentID[] = [];
-    relevantIds.forEach((id) => {
-      const inFlight = this.preloadsInFlight.get(id.toString());
-      if (inFlight) preloadsToWaitFor.push(inFlight);
-      else idsToLoad.push(id);
+    const preloadsToAwait: Promise<void>[] = [];
+    const toLoad: Array<{ id: ComponentID; idStr: string }> = [];
+    candidates.forEach((candidate) => {
+      const inFlight = this.preloadsInFlight.get(candidate.idStr);
+      if (inFlight) preloadsToAwait.push(inFlight);
+      else toLoad.push(candidate);
     });
-    if (idsToLoad.length) {
-      const contextIds = new Set([...(idsInCurrentContext || []), ...idsToLoad.map((id) => id.toString())]);
-      // an explicit promise rather than the return value of preloadingContext.run, as some @types/node
-      // versions type the latter as void
-      const loadPromise = new Promise<void>((resolve) => {
-        void this.preloadingContext.run(contextIds, async () => {
-          try {
-            await this.getMany(idsToLoad, undefined, false);
-          } catch (err: any) {
+    if (toLoad.length) {
+      const contextIds = new Set([...chainIds, ...toLoad.map((c) => c.idStr)]);
+      // assign the promise from within run() rather than using its return value, which some
+      // @types/node versions type as void
+      let loadPromise!: Promise<void>;
+      this.preloadingContext.run(contextIds, () => {
+        loadPromise = this.getMany(
+          toLoad.map((c) => c.id),
+          undefined,
+          false
+        ).then(
+          () => undefined,
+          (err) => {
             // the loader can still throw for errors it does not classify as invalid-component errors
             this.logger.warn(`failed pre-loading components, continuing without the pre-loaded cache`, err);
-          } finally {
-            resolve();
           }
-        });
+        );
       });
-      idsToLoad.forEach((id) => this.preloadsInFlight.set(id.toString(), loadPromise));
-      try {
-        await loadPromise;
-      } finally {
-        idsToLoad.forEach((id) => this.preloadsInFlight.delete(id.toString()));
-      }
+      toLoad.forEach((c) => this.preloadsInFlight.set(c.idStr, loadPromise));
+      preloadsToAwait.push(loadPromise.finally(() => toLoad.forEach((c) => this.preloadsInFlight.delete(c.idStr))));
     }
-    await Promise.all(preloadsToWaitFor);
+    await Promise.all(preloadsToAwait);
   }
 
   getManyByLegacy(components: ConsumerComponent[], loadOpts?: ComponentLoadOptions): Promise<Component[]> {
@@ -2771,8 +2777,6 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
   }
 
   async getManyComponentsStatuses(ids: ComponentID[]): Promise<ComponentStatusResult[]> {
-    // pre-load in one batch. otherwise, each getComponentStatusById pre-loads its component individually
-    await this.preloadComponents(ids);
     return this.componentStatusLoader.getManyComponentsStatuses(ids);
   }
 


### PR DESCRIPTION
A component could be mistakenly reported as modified ("component has config changes, please snap/tag it first" during `bit lane merge main`) even though `bit status` and `bit diff` showed a completely clean workspace.

Root cause: the modified-status is a hash comparison between the model and a Version recomputed from the filesystem, and its correctness depends on *how the component was loaded*. The grouped workspace loader (used by status/diff) loads and registers the component's env before the component itself, so env dependency-policies are applied. A cold single-component load (used by the merge/checkout/import/eject/delete flows) loads the env lazily mid-load, may miss its policy, and produces a component whose recalculated hash differs from the model in the env-policy-derived fields (packageDependencies/devPackageDependencies/overrides) — a false "modified (config changes)".

The fix makes the grouped loader the source of truth for modified-status calculation:
- The loader now tracks which components were built through the grouped pipeline. A new `workspace.preloadComponents()` (never throws, re-entrance guarded via AsyncLocalStorage, concurrent callers await in-flight preloads) loads components through the grouped pipeline, and **evicts and rebuilds** components that were previously built by a cold single-component load — so status is correct regardless of load order.
- `ComponentStatusLoader.getStatus()` pre-loads the component before computing — covering every status caller (import, eject, delete, merge, status, and `workspace.get(id).getStatus()`).
- The merge-status and checkout flows pre-load in one batch before their per-component loops (checkout bypasses the status loader and checks modified directly).

Verified against a real-world workspace that reproduced the failure (merge now completes with a proper merge-snap; status unchanged), plus a new e2e covering a component with an env-defined deps policy going through a diverged lane-merge-main in a fresh workspace. Checkout, import, revert, and lane-merge e2e suites pass.