### PR TITLE
chore: comment out preview maxChunkSize webpack workaround

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -754,8 +754,9 @@
     "capsuleSelfReference": true
   },
   "teambit.preview/preview": {
-    "bundlingStrategy": "component",
-    "maxChunkSize": 5
+    "bundlingStrategy": "component"
+    // "maxChunkSize": 5 — was a workaround for webpack OOM during preview bundling.
+    // the previews are bundled with rspack now; re-enable if memory issues return.
   },
   "teambit.generator/generator": {
     "aspects": [


### PR DESCRIPTION
## Summary

The `maxChunkSize: 5` setting of `teambit.preview/preview` was a workaround. It limited chunk size because webpack consumed too much memory and the CI got OOM errors.

The previews are bundled with rspack now. Rspack does not have this memory problem. This change comments out the setting. If memory issues return, uncomment the line to restore the limit.