### PR TITLE
feat(bundle): pack the bundled cli into a bvm-installable tar

### DIFF
--- a/bundle-plan.md
+++ b/bundle-plan.md
@@ -101,6 +101,10 @@ Full detail in [01-goal-and-results.md](bundle-plan/01-goal-and-results.md).
 - [22 — `mcp-config-writer` inlined into the bundle instead of copied](bundle-plan/22-mcp-config-writer-inlined.md) (§18, 2026-08-11)
 - [23 — `BabelAspect` removed from core, and why `@babel/core` still can't leave externals](bundle-plan/23-babel-aspect-removed.md) (§19, 2026-08-12)
 
+**Shipping the branch**
+
+- [24 — Handing the branch out through bvm](bundle-plan/24-installing-via-bvm.md) (the tar layout bvm expects, `pack-bundle-for-bvm.js`, pre-release versioning and the `dev` release type)
+
 ## Section-number cross-reference
 
 The files above keep the original `§N` numbering from the single-file era (many cross-references in

--- a/bundle-plan/24-installing-via-bvm.md
+++ b/bundle-plan/24-installing-via-bvm.md
@@ -1,0 +1,119 @@
+# 24. Handing the branch out through bvm
+
+[← back to bundle-plan index](../bundle-plan.md)
+
+The goal is to let someone run the bundled bit without merging or releasing anything: no npm
+publish, no `@teambit/bit` version taken, no effect on anyone who is not asking for it.
+
+bvm can already do this. It has two installation methods, and the `tar` one downloads an archive
+from GCS and extracts it — it runs no package manager of its own, so whatever the tar holds *is*
+the installation. That makes the tar the entire deliverable.
+
+## The layout bvm expects
+
+Verified against bvm 3.0.4 by installing hand-made tars into an isolated `BVM_DIR`:
+
+```
+bit-<version>/                            ← the tar's single root directory, named exactly this
+└── node_modules/
+    ├── @teambit/bit/
+    │   ├── package.json                  ← "bvm": { "node": "22.22.0" }, "bin": { "bit": "./bin/bit" }
+    │   ├── bin/bit
+    │   └── dist/…                        ← the bundle, shims, locators, artifacts
+    └── <externals>/…                     ← installed, hoisted
+```
+
+Three hard requirements, each of which bvm reads by an absolute path:
+
+- the tar's root directory is `bit-<version>` and nothing else — `install.ts` extracts to
+  `~/.bvm/versions/<version>/` and every later step joins `bit-<version>` onto it;
+- `node_modules/@teambit/bit/package.json` exists and carries `bvm.node`, which is how bvm picks
+  the Node.js to run bit with (`Config.getWantedNodeVersion` reads that exact path, uncaught);
+- `node_modules/@teambit/bit/bin/bit` exists — `bvm link` hardcodes it as the bin source.
+
+Everything else is free. In particular the externals are ordinary hoisted packages one level up
+from `@teambit/bit`, which is where node's upward `node_modules` walk from
+`dist/core-aspects/bundle/bit.app.js` looks for them anyway — the same resolution §9b relies on for
+the published shape, so no special casing is needed.
+
+## Producing it
+
+`scripts/pack-bundle-for-bvm.js` takes the capsule that `bit build` writes for
+`teambit.harmony/bit` and produces the tar:
+
+```bash
+bd build teambit.harmony/bit --tasks BundleUI,PreBundlePreview,BundleCliApp
+node scripts/pack-bundle-for-bvm.js --capsule <capsule-dir> --version 2.2.18-bundle.1
+```
+
+Since §9e the bundler emits the published package shape **in place**, so the capsule already is
+`@teambit/bit` as it would be published. The script therefore does not rearrange anything:
+
+1. installs the capsule's declared dependencies — the externals, and only the externals — with
+   `pnpm --node-linker=hoisted`, pinned to the target platform via `supportedArchitectures` so a
+   mac can pack a linux tar (the native addons are per-platform optional deps);
+2. `npm pack`s the capsule and unpacks it into `node_modules/@teambit/bit`;
+3. rewrites that package.json's `version` to the version being handed out;
+4. tars it.
+
+The externals are installed **before** `@teambit/bit` is dropped in, because pnpm reconciles
+`node_modules` against the manifest and would prune it otherwise. For the same reason the staging
+`package.json` and lockfile are left out of the tar — the same exclusions CI's `compress_bit` uses.
+
+The script refuses to build a tar that would install but not run. It checks the capsule for
+`bin/bit`, `dist/core-aspects/bundle/bit.app.js` and the UI/preview pre-bundle
+(`@teambit/{ui,preview}/artifacts/ui-bundle/…`, §17), and re-checks them after packing. The
+pre-bundle is the one that is easy to lose: without it `bit start` falls back to rebuilding with
+rspack, which the default build deliberately cannot do. It only exists if `BundleUI` and
+`PreBundlePreview` ran before `BundleCliApp` — hence the task list above.
+
+Verified that `npm pack` keeps `dist/core-aspects/node_modules/@teambit/*` (the shims) while
+stripping the capsule's own root `node_modules`, and that the `.hash` gate files inside `artifacts/`
+survive both the pack and the tar.
+
+## Versioning and who sees it
+
+A pre-release version — `<the real version>-bundle.1`, `.2`, … — keeps the builds ordered next to
+the releases without taking a version anyone else would get.
+
+bvm filters `index.json` by the release type the client asks for, and the entries are independent
+booleans, so listing a build under `dev` makes it invisible on the default (`stable`) and on
+`nightly`, and reachable only by someone who opts in:
+
+```bash
+node scripts/add-bvm-index-entry.js --version 2.2.18-bundle.1 --release-type dev
+# upload index.json, then:
+BVM_RELEASE_TYPE=dev bvm install 2.2.18-bundle.1 --method tar
+```
+
+`BVM_RELEASE_TYPE` is per-invocation; `bvm config set RELEASE_TYPE dev` makes it the default for
+that machine and makes `bvm upgrade` track the bundle builds.
+
+Listing it is optional. `bvm install <version> --file <tar> --method tar` installs a tar directly,
+and an explicit version is never looked up in the index at all, so the tar can also be handed out
+by URL alone.
+
+Pass `--method tar` either way: the default is `package-manager`, which tries to install
+`@teambit/bit@<version>` from the registry first, and for an unpublished version that is a failed
+network round-trip before the fallback.
+
+### One bvm fix is needed
+
+bvm ≤ 3.0.4 cannot install a pre-release from a tar. `FsTarVersion.version` reads the version back
+out of the tar file name with `split('-')[1]`, which returns `2.2.18` for
+`bit-2.2.18-bundle.1-darwin-arm64.tar.gz`. The files extract to the right place and the install
+then fails on the last step with `version 2.2.18 is not installed`.
+
+Fixed in the bvm repo (`fix: support pre-release versions in tar installs`): the file name is
+parsed by stripping the archive extension and the `-<os>-<arch>` suffix, and `installVersion` links
+the version it extracted rather than the one it read back from the name. **That fix has to be
+released before any `-bundle.N` tar is usable.** Plain (non-pre-release) versions work on 3.0.4 as
+is.
+
+## Per platform
+
+The externals include native addons, so there is one tar per platform, exactly as the release
+pipeline already produces: `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`, `win-x64`. The
+uploaded object name is what bvm derives from the index entry, so it has to be
+`bit/versions/<version>/bit-<version>-<os>-<arch>.tar.gz` in `gs://bvm.bit.dev`. The script prints
+the `gsutil` commands.

--- a/scripts/add-bvm-index-entry.js
+++ b/scripts/add-bvm-index-entry.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Add one version to bvm's `index.json` under a chosen release type, and write the result to
+ * `index.json` in the cwd for the caller to upload.
+ *
+ *   node scripts/add-bvm-index-entry.js --version 2.2.18-bundle.1 --release-type dev
+ *   gsutil cp index.json gs://bvm.bit.dev/bit/index.json
+ *   gsutil setmeta -h "Cache-Control:no-cache" gs://bvm.bit.dev/bit/index.json
+ *
+ * This is `update-bit-gcp-index.js` with the release type as an argument rather than always
+ * `nightly`. bvm filters the index by the type the client asked for, so an entry flagged `dev` is
+ * invisible to everyone on the default (`stable`) and on `nightly`, and reachable only by someone
+ * who opts in with `BVM_RELEASE_TYPE=dev` or `bvm config set RELEASE_TYPE dev`. That is what makes
+ * it safe to list a branch build next to the real releases.
+ */
+const fs = require('fs');
+const https = require('https');
+
+const RELEASE_TYPES = ['dev', 'nightly', 'stable'];
+
+const argv = process.argv.slice(2);
+const take = (flag, fallback) => {
+  const i = argv.indexOf(flag);
+  if (i === -1) return fallback;
+  const value = argv[i + 1];
+  argv.splice(i, 2);
+  return value;
+};
+
+const version = take('--version', process.env.BIT_VERSION);
+const releaseType = take('--release-type', 'dev');
+
+function fail(message) {
+  console.error(`[bvm-index] ${message}`);
+  process.exit(1);
+}
+
+if (!version) fail('missing --version <semver> (or the BIT_VERSION env variable)');
+if (!RELEASE_TYPES.includes(releaseType)) fail(`--release-type must be one of ${RELEASE_TYPES.join(', ')}`);
+
+function fetchIndex() {
+  // go straight at the object with a cache-buster; the CDN in front of it serves stale copies
+  const random = Math.floor(Math.random() * 100000);
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        {
+          host: 'bvm.bit.dev',
+          path: `/bit/index.json?random=${random}`,
+          port: 443,
+          headers: { 'Content-Type': 'application/json' },
+        },
+        (response) => {
+          let body = '';
+          response.on('data', (chunk) => {
+            body += chunk;
+          });
+          response.on('end', () => {
+            if (response.statusCode === 404) return resolve([]);
+            if (response.statusCode !== 200) return reject(new Error(`index.json responded ${response.statusCode}`));
+            try {
+              return resolve(JSON.parse(body));
+            } catch (err) {
+              return reject(err);
+            }
+          });
+        }
+      )
+      .on('error', reject);
+  });
+}
+
+(async () => {
+  const index = await fetchIndex();
+  const existing = index.find((release) => release.version === version);
+  if (existing) {
+    existing[releaseType] = true;
+    console.log(`[bvm-index] marked the existing ${version} entry as "${releaseType}"`);
+  } else {
+    index.push({ version, date: new Date().toISOString(), [releaseType]: true });
+    console.log(`[bvm-index] added ${version} as "${releaseType}"`);
+  }
+  fs.writeFileSync('index.json', JSON.stringify(index, null, 2), 'utf8');
+  console.log('[bvm-index] wrote index.json - upload it to gs://bvm.bit.dev/bit/index.json');
+})().catch((err) => fail(err.message));

--- a/scripts/pack-bundle-for-bvm.js
+++ b/scripts/pack-bundle-for-bvm.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Turn the built `@teambit/bit` capsule into a tar file that `bvm install` can consume, so a branch
+ * can be handed out without publishing anything to the registry.
+ *
+ *   node scripts/pack-bundle-for-bvm.js --capsule <dir> --version 2.2.18-bundle.1
+ *
+ * The capsule is the one `bit build` writes for `teambit.harmony/bit`. Since §9e the bundler emits
+ * the published package shape *in place*, so that capsule already is `@teambit/bit` as it would be
+ * published - bundle, shims, locators, UI/preview pre-bundle and a package.json whose dependencies
+ * are the externals alone. Nothing here rebuilds or rearranges it; it is packed, the externals are
+ * installed next to it, and the result is tarred in the layout bvm extracts into `~/.bvm/versions`:
+ *
+ *   bit-<version>/
+ *   └── node_modules/
+ *       ├── @teambit/bit/…      ← `npm pack` of the capsule
+ *       └── <externals>/…       ← `pnpm install`, hoisted
+ *
+ * That layout is the whole contract with bvm: it reads `bvm.node` and `bin` out of
+ * `node_modules/@teambit/bit/package.json` and links `node_modules/@teambit/bit/bin/bit`.
+ *
+ * Note that bvm's tar install runs no package manager of its own - whatever the tar holds is the
+ * installation. So the externals are installed *before* `@teambit/bit` is placed next to them: a
+ * pnpm run afterwards would prune it as extraneous, which is also why the staging `package.json`
+ * and lockfile are excluded from the tar (the same exclusions CI's `compress_bit` uses).
+ */
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const argv = process.argv.slice(2);
+
+const take = (flag, fallback) => {
+  const i = argv.indexOf(flag);
+  if (i === -1) return fallback;
+  const value = argv[i + 1];
+  argv.splice(i, 2);
+  return value;
+};
+const takeBool = (flag) => {
+  const i = argv.indexOf(flag);
+  if (i === -1) return false;
+  argv.splice(i, 1);
+  return true;
+};
+
+/** bvm's own os names, which are not node's - see `OS_TYPES` in `@teambit/bvm.list`. */
+const BVM_OS = { darwin: 'darwin', linux: 'linux', win32: 'win' };
+/** ...and pnpm's, which are node's. */
+const PNPM_OS = { darwin: 'darwin', linux: 'linux', win: 'win32' };
+
+/**
+ * The pre-bundled UI and preview browser assets. `bit start` serves these instead of running a
+ * bundler, so a tar without them produces a bit that installs and runs but cannot start. They are
+ * copied into the shims by the bundler, which is why they only exist after a build that ran
+ * `BundleUI` and `PreBundlePreview` before `BundleCliApp`.
+ */
+const REQUIRED_IN_CAPSULE = [
+  'bin/bit',
+  'dist/core-aspects/bundle/bit.app.js',
+  'dist/core-aspects/node_modules/@teambit/ui/artifacts/ui-bundle/workspace',
+  'dist/core-aspects/node_modules/@teambit/ui/artifacts/ui-bundle/scope',
+  'dist/core-aspects/node_modules/@teambit/preview/artifacts/ui-bundle',
+];
+
+function fail(message) {
+  console.error(`[pack-for-bvm] ${message}`);
+  process.exit(1);
+}
+
+function run(command, args, opts = {}) {
+  return execFileSync(command, args, { stdio: 'inherit', ...opts });
+}
+
+function isValidSemver(version) {
+  // the same shape bvm validates with; kept as a regex so the script has no dependencies
+  return /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/.test(version);
+}
+
+function main() {
+  const capsule = take('--capsule');
+  const version = take('--version');
+  const outDir = path.resolve(take('--out-dir', path.join(os.tmpdir(), 'bit-bvm-tar')));
+  const targetOs = take('--os', BVM_OS[process.platform]);
+  const targetArch = take('--arch', process.arch);
+  const registry = take('--registry');
+  const keepStaging = takeBool('--keep-staging');
+
+  if (argv.length) fail(`unknown argument(s): ${argv.join(' ')}`);
+  if (!capsule) fail('missing --capsule <dir> (the built @teambit/bit capsule)');
+  if (!version) fail('missing --version <semver>');
+  if (!isValidSemver(version)) fail(`--version "${version}" is not a valid semver`);
+  if (!BVM_OS[PNPM_OS[targetOs]]) fail(`--os must be one of ${Object.values(BVM_OS).join(', ')}`);
+  if (!['x64', 'arm64'].includes(targetArch)) fail('--arch must be x64 or arm64');
+
+  const capsuleDir = path.resolve(capsule);
+  const manifestPath = path.join(capsuleDir, 'package.json');
+  if (!fs.existsSync(manifestPath)) fail(`no package.json in ${capsuleDir} - is that the capsule?`);
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (manifest.name !== '@teambit/bit') fail(`${capsuleDir} is "${manifest.name}", expected "@teambit/bit"`);
+  if (!manifest.bvm || !manifest.bvm.node) fail('the capsule package.json has no "bvm.node" - bvm cannot pick a Node.js');
+
+  const missing = REQUIRED_IN_CAPSULE.filter((entry) => !fs.existsSync(path.join(capsuleDir, entry)));
+  if (missing.length) {
+    fail(
+      `the capsule is missing:\n  ${missing.join('\n  ')}\n` +
+        'build it with the UI/preview pre-bundle tasks before BundleCliApp, e.g.\n' +
+        '  bd build teambit.harmony/bit --tasks BundleUI,PreBundlePreview,BundleCliApp'
+    );
+  }
+
+  const externals = manifest.dependencies || {};
+  if (!Object.keys(externals).length) fail('the capsule package.json declares no dependencies - the externals are missing');
+
+  const stagingRoot = path.join(outDir, 'staging');
+  const innerDirName = `bit-${version}`;
+  const innerDir = path.join(stagingRoot, innerDirName);
+  fs.rmSync(stagingRoot, { recursive: true, force: true });
+  fs.mkdirSync(innerDir, { recursive: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`[pack-for-bvm] version ${version}, target ${targetOs}-${targetArch}`);
+  console.log(`[pack-for-bvm] externals: ${Object.keys(externals).join(', ')}`);
+
+  // 1. install the externals. this has to happen first: pnpm reconciles node_modules against the
+  //    manifest, so running it after @teambit/bit is in place would delete it again.
+  const stagingManifest = {
+    name: 'bit-bvm-distribution',
+    version: '0.0.0',
+    private: true,
+    dependencies: externals,
+    pnpm: {
+      // the target platform's native addons, which are optional deps picked by platform. without
+      // this, packing on a mac produces a tar that is missing linux's @pnpm/napi binary.
+      supportedArchitectures: { os: [PNPM_OS[targetOs]], cpu: [targetArch] },
+    },
+  };
+  fs.writeFileSync(path.join(innerDir, 'package.json'), `${JSON.stringify(stagingManifest, null, 2)}\n`);
+  const pnpmArgs = ['install', '--node-linker=hoisted', '--ignore-scripts', '--no-frozen-lockfile'];
+  if (registry) pnpmArgs.push(`--registry=${registry}`);
+  run('pnpm', pnpmArgs, { cwd: innerDir });
+
+  // 2. pack the capsule exactly as it would be published, and unpack it next to the externals.
+  const packDir = path.join(outDir, 'pack');
+  fs.rmSync(packDir, { recursive: true, force: true });
+  fs.mkdirSync(packDir, { recursive: true });
+  run('npm', ['pack', '--ignore-scripts', `--pack-destination=${packDir}`], { cwd: capsuleDir });
+  const [tarball] = fs.readdirSync(packDir).filter((entry) => entry.endsWith('.tgz'));
+  if (!tarball) fail('npm pack produced no tarball');
+
+  const bitPackageDir = path.join(innerDir, 'node_modules', '@teambit', 'bit');
+  fs.mkdirSync(bitPackageDir, { recursive: true });
+  // --strip-components drops npm's "package/" wrapper directory
+  run('tar', ['-xzf', path.join(packDir, tarball), '-C', bitPackageDir, '--strip-components=1']);
+
+  // 3. the version bvm installs and the version `bit --version` reports have to be the same one.
+  const packedManifestPath = path.join(bitPackageDir, 'package.json');
+  const packedManifest = JSON.parse(fs.readFileSync(packedManifestPath, 'utf8'));
+  packedManifest.version = version;
+  fs.writeFileSync(packedManifestPath, `${JSON.stringify(packedManifest, null, 2)}\n`);
+
+  // 4. everything the tar needs is now in place. verify before paying for the compression.
+  const unresolved = Object.keys(externals).filter(
+    (name) => !fs.existsSync(path.join(innerDir, 'node_modules', ...name.split('/')))
+  );
+  if (unresolved.length) fail(`externals not installed: ${unresolved.join(', ')}`);
+  const packedMissing = REQUIRED_IN_CAPSULE.filter((entry) => !fs.existsSync(path.join(bitPackageDir, entry)));
+  if (packedMissing.length) {
+    fail(`npm pack dropped:\n  ${packedMissing.join('\n  ')}\ncheck "files"/.npmignore in the capsule`);
+  }
+
+  // 5. the staging manifest and lockfile stay out of the tar, so nothing can later run a package
+  //    manager inside the installed version and prune it. same exclusions as CI's `compress_bit`.
+  ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc', 'node_modules/.modules.yaml'].forEach((entry) =>
+    fs.rmSync(path.join(innerDir, entry), { force: true })
+  );
+
+  const tarName = `bit-${version}-${targetOs}-${targetArch}.tar.gz`;
+  const tarPath = path.join(outDir, tarName);
+  fs.rmSync(tarPath, { force: true });
+  run('tar', ['-czf', tarPath, innerDirName], {
+    cwd: stagingRoot,
+    // macOS bsdtar otherwise writes an AppleDouble "._" file next to every entry
+    env: { ...process.env, COPYFILE_DISABLE: '1' },
+  });
+
+  if (!keepStaging) fs.rmSync(stagingRoot, { recursive: true, force: true });
+  fs.rmSync(packDir, { recursive: true, force: true });
+
+  const sizeMb = (fs.statSync(tarPath).size / 1024 / 1024).toFixed(1);
+  console.log(`\n[pack-for-bvm] ${tarPath} (${sizeMb} MB)`);
+  console.log(`\ntry it without uploading anything:\n  bvm install ${version} --file ${tarPath} --method tar\n`);
+  console.log(`then upload it:
+  gsutil cp ${tarPath} gs://bvm.bit.dev/bit/versions/${version}/${tarName}
+  shasum -a 256 ${tarPath} > checksum.txt
+  gsutil cp checksum.txt gs://bvm.bit.dev/bit/versions/${version}/bit-${version}-${targetOs}-${targetArch}.checksum.txt
+
+and list it for the "dev" release type only:
+  node scripts/add-bvm-index-entry.js --version ${version} --release-type dev
+  gsutil cp index.json gs://bvm.bit.dev/bit/index.json
+  gsutil setmeta -h "Cache-Control:no-cache" gs://bvm.bit.dev/bit/index.json
+`);
+}
+
+main();


### PR DESCRIPTION
Lets the bundled CLI be handed out through bvm without merging or releasing anything — no npm publish, no `@teambit/bit` version taken, no effect on anyone who is not asking for it.

`scripts/pack-bundle-for-bvm.js` turns the built `@teambit/bit` capsule into a tar that `bvm install --method tar` extracts. Since §9e the bundler emits the published package shape in place, so the script rearranges nothing: it installs the capsule's declared dependencies (the externals, and only those) hoisted, `npm pack`s the capsule next to them, pins the version, and tars it in the `bit-<version>/node_modules/…` layout bvm expects.

It refuses to produce a tar that would install but not run — it checks the capsule, and re-checks after packing, for `bin/bit`, the bundle, and the UI/preview pre-bundle, which only exists if `BundleUI` and `PreBundlePreview` ran before `BundleCliApp`.

`scripts/add-bvm-index-entry.js` lists a version under a chosen release type. bvm filters `index.json` by type, so a build flagged `dev` is invisible on the default (`stable`) and on `nightly`, and reachable only via `BVM_RELEASE_TYPE=dev`. Nothing in the live index uses `dev` today.

`bundle-plan/24-installing-via-bvm.md` documents the layout contract, the versioning, and one bvm-side fix that has to ship before a `-bundle.N` tar is usable (https://github.com/teambit/bvm/pull/123).

Verified end to end against a stand-in capsule: `npm pack` keeps the nested shim `node_modules` and the `.hash` gate files while stripping the capsule's own root `node_modules`; the resulting tar installs into an isolated `BVM_DIR` and the launcher runs and resolves a hoisted external. Not yet run against a real build — the task list in the doc is the part to try first.
