### PR TITLE
chore(envs): update core-aspect-env to 2.0.8

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -24,21 +24,30 @@
         "scope": "teambit.api-reference",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.1172",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "array/duplications-finder": {
         "name": "array/duplications-finder",
@@ -55,7 +64,10 @@
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -256,14 +268,20 @@
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
@@ -280,7 +298,10 @@
         "scope": "teambit.harmony",
         "version": "2.2.18",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "bit-map": {
         "name": "bit-map",
@@ -294,7 +315,10 @@
         "scope": "teambit.pipelines",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
@@ -311,56 +335,80 @@
         "scope": "teambit.compilation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.1471",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.1141",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
         "version": "1.0.537",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/ci"
+        "rootDir": "scopes/git/ci",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.587",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.1378",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "cli-mcp-server": {
         "name": "cli-mcp-server",
         "scope": "teambit.mcp",
         "version": "0.0.243",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mcp/cli-mcp-server"
+        "rootDir": "scopes/mcp/cli-mcp-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
@@ -397,49 +445,70 @@
         "scope": "teambit.cloud",
         "version": "0.0.1439",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.806",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
@@ -448,7 +517,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-descriptor",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@2.0.7": {}
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
         }
     },
     "component-diff": {
@@ -480,7 +549,10 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
@@ -497,21 +569,30 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -525,28 +606,40 @@
         "scope": "teambit.compositions",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.1553",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.1006",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "config-store": {
         "name": "config-store",
         "scope": "teambit.harmony",
         "version": "0.0.259",
         "mainFile": "index.ts",
-        "rootDir": "components/config-store"
+        "rootDir": "components/config-store",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "constants": {
         "name": "constants",
@@ -598,7 +691,10 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "dependency-graph": {
         "name": "dependency-graph",
@@ -612,14 +708,20 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "deps-detectors/detective-mdx": {
         "name": "deps-detectors/detective-mdx",
@@ -633,14 +735,20 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "doc-parser": {
         "name": "doc-parser",
@@ -654,14 +762,20 @@
         "scope": "teambit.docs",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "doctor": {
         "name": "doctor",
         "scope": "teambit.harmony",
         "version": "0.0.824",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/doctor"
+        "rootDir": "scopes/harmony/doctor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "e2e-helper": {
         "name": "e2e-helper",
@@ -675,14 +789,20 @@
         "scope": "teambit.workspace",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "empty-env": {
         "name": "empty-env",
         "scope": "teambit.harmony",
         "version": "0.0.54",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/empty-env"
+        "rootDir": "scopes/harmony/empty-env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
@@ -719,21 +839,30 @@
         "scope": "teambit.envs",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "eslint": {
         "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint"
+        "rootDir": "scopes/defender/eslint",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "eslint-config-bit-react": {
         "name": "eslint-config-bit-react",
@@ -760,14 +889,20 @@
         "scope": "teambit.scope",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.1477",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "extension-data": {
         "name": "extension-data",
@@ -781,14 +916,20 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "fs/extension-getter": {
         "name": "fs/extension-getter",
@@ -850,7 +991,10 @@
         "scope": "teambit.generator",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "get-bit-version": {
         "name": "get-bit-version",
@@ -867,35 +1011,50 @@
         "scope": "teambit.git",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.1382",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "hooks/use-cloud-scopes": {
         "name": "hooks/use-cloud-scopes",
@@ -961,63 +1120,90 @@
         "scope": "teambit.harmony",
         "version": "0.0.852",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/host-initializer"
+        "rootDir": "scopes/harmony/host-initializer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "importer": {
         "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "internalize": {
         "name": "internalize",
         "scope": "teambit.component",
         "version": "0.0.138",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/internalize"
+        "rootDir": "scopes/component/internalize",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "json/jsonc-utils": {
         "name": "json/jsonc-utils",
@@ -1034,7 +1220,10 @@
         "scope": "teambit.lanes",
         "version": "1.0.1161",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "legacy-component-log": {
         "name": "legacy-component-log",
@@ -1051,14 +1240,20 @@
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "loader": {
         "name": "loader",
@@ -1085,28 +1280,40 @@
         "scope": "teambit.mdx",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/mdx"
+        "rootDir": "scopes/mdx/mdx",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "merge-lanes": {
         "name": "merge-lanes",
         "scope": "teambit.lanes",
         "version": "1.0.1161",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.1143",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.896",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -1480,21 +1687,30 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "network": {
         "name": "network",
@@ -1515,35 +1731,50 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "node": {
         "name": "node",
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/node"
+        "rootDir": "scopes/harmony/node",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "notifications": {
         "name": "notifications",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "objects": {
         "name": "objects",
         "scope": "teambit.scope",
         "version": "0.0.646",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/objects"
+        "rootDir": "scopes/scope/objects",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "panels": {
         "name": "panels",
         "scope": "teambit.ui-foundation",
         "version": "0.0.1381",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1585,7 +1816,10 @@
         "scope": "teambit.pkg",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
@@ -1609,14 +1843,20 @@
         "scope": "teambit.dependencies",
         "version": "1.0.1179",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
@@ -1633,7 +1873,10 @@
         "scope": "teambit.preview",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "promise/map-pool": {
         "name": "promise/map-pool",
@@ -1647,35 +1890,50 @@
         "scope": "teambit.harmony",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "react": {
         "name": "react",
         "scope": "teambit.react",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/react"
+        "rootDir": "scopes/react/react",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "react-router": {
         "name": "react-router",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "readme": {
         "name": "readme",
         "scope": "teambit.mdx",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/mdx/readme"
+        "rootDir": "scopes/mdx/readme",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "refactoring": {
         "name": "refactoring",
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "remote-actions": {
         "name": "remote-actions",
@@ -1696,14 +1954,20 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "renderers/default-node-renderers": {
         "name": "renderers/default-node-renderers",
@@ -1717,14 +1981,20 @@
         "scope": "teambit.cloud",
         "version": "0.0.226",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/ripple"
+        "rootDir": "scopes/cloud/ripple",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "schema": {
         "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "scope-api": {
         "name": "scope-api",
@@ -1738,14 +2008,20 @@
         "scope": "teambit.workspace",
         "version": "0.0.358",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/scripts"
+        "rootDir": "scopes/workspace/scripts",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "sidebar": {
         "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "snap-distance": {
         "name": "snap-distance",
@@ -1759,7 +2035,10 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "sources": {
         "name": "sources",
@@ -1773,14 +2052,20 @@
         "scope": "teambit.component",
         "version": "1.0.1141",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.1165",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
@@ -1836,7 +2121,10 @@
         "scope": "teambit.harmony",
         "version": "0.0.1471",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
@@ -1860,14 +2148,20 @@
         "scope": "teambit.scope",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "tester": {
         "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
@@ -1902,7 +2196,10 @@
         "scope": "teambit.component",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
@@ -1926,14 +2223,20 @@
         "scope": "teambit.typescript",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "ui": {
         "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/ui"
+        "rootDir": "scopes/ui-foundation/ui",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "ui/api-diff-view": {
         "name": "ui/api-diff-view",
@@ -2465,7 +2768,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "utils": {
         "name": "utils",
@@ -2482,70 +2788,100 @@
         "scope": "teambit.defender",
         "version": "0.0.376",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/validator"
+        "rootDir": "scopes/defender/validator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "variants": {
         "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.1646",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "version-history": {
         "name": "version-history",
         "scope": "teambit.scope",
         "version": "0.0.931",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/version-history"
+        "rootDir": "scopes/scope/version-history",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "vue-aspect": {
         "name": "vue-aspect",
         "scope": "teambit.vue",
         "version": "0.0.505",
         "mainFile": "index.ts",
-        "rootDir": "scopes/vue/vue"
+        "rootDir": "scopes/vue/vue",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1682",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.1139",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.1140",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@2.0.8": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -821,8 +821,8 @@ importers:
         specifier: 0.4.12
         version: 0.4.12
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/html.modules.inject-html-element':
         specifier: 0.0.6
         version: 0.0.6(react@19.2.7)
@@ -894,7 +894,7 @@ importers:
         version: 1.0.3
       '@teambit/preview.react-preview':
         specifier: ^1.1.13
-        version: 1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@5.9.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+        version: 1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@5.9.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.content.react-overview':
         specifier: 1.96.6
         version: 1.96.6(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -1702,6 +1702,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lodash.flatten:
+        specifier: 4.4.0
+        version: 4.4.0
       lodash.head:
         specifier: 4.0.1
         version: 4.0.1
@@ -2161,16 +2164,16 @@ importers:
         version: 0.0.2(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@teambit/node.envs.node-typescript-mocha':
         specifier: 2.0.2
         version: 2.0.2(@babel/core@7.28.3)(supports-color@9.4.0)
       '@teambit/node.node':
         specifier: 4.0.1
-        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/babel__core':
         specifier: 7.20.0
         version: 7.20.0
@@ -2183,9 +2186,6 @@ importers:
       '@types/react-router-dom':
         specifier: 5.3.3
         version: 5.3.3
-      lodash.flatten:
-        specifier: 4.4.0
-        version: 4.4.0
 
   components/bit/get-bit-version:
     dependencies:
@@ -2210,7 +2210,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
 
   components/component-issues:
     dependencies:
@@ -2241,7 +2241,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2289,8 +2289,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -2361,7 +2361,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2395,7 +2395,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2580,7 +2580,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -2608,7 +2608,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
 
   components/legacy/analytics:
     dependencies:
@@ -2654,7 +2654,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2724,7 +2724,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2776,7 +2776,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -2840,7 +2840,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -2886,7 +2886,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -2920,7 +2920,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
 
   components/legacy/consumer:
     dependencies:
@@ -2972,7 +2972,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3036,7 +3036,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3097,7 +3097,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3155,7 +3155,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3313,7 +3313,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3356,7 +3356,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/pretty-time':
         specifier: ^1.1.5
         version: 1.1.5
@@ -3408,7 +3408,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3490,7 +3490,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3554,7 +3554,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3612,7 +3612,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3655,7 +3655,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -3695,7 +3695,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -3726,7 +3726,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -3794,7 +3794,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -3962,7 +3962,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -4005,7 +4005,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -6662,7 +6662,7 @@ importers:
         specifier: 9.1.0
         version: 9.1.0
 
-  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.7:
+  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@2.0.8:
     dependencies:
       '@mdx-js/react':
         specifier: 3.1.1
@@ -7067,8 +7067,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/cli-reference(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/harmony.modules.concurrency':
         specifier: workspace:*
         version: file:scopes/harmony/modules/concurrency
@@ -9369,7 +9369,7 @@ importers:
         version: file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
         version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
@@ -10428,7 +10428,7 @@ importers:
         version: file:scopes/mdx/deps-detectors/detective-mdx
       '@teambit/mdx.mdx-env':
         specifier: 3.2.0
-        version: 3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.14
         version: 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
@@ -11511,7 +11511,7 @@ importers:
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(react-router-dom@6.30.4)(react@19.2.7)
@@ -13581,7 +13581,7 @@ importers:
         version: file:scopes/harmony/node(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)
       '@teambit/node.node':
         specifier: 4.0.1
-        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/notifications':
         specifier: workspace:*
         version: file:scopes/ui-foundation/notifications/aspect(react-router-dom@6.30.4)(react@19.2.7)
@@ -14058,8 +14058,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14131,8 +14131,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -14178,7 +14178,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14209,7 +14209,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14240,7 +14240,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14271,7 +14271,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14299,7 +14299,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14327,7 +14327,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14369,8 +14369,8 @@ importers:
         version: 6.0.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -14511,8 +14511,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14543,7 +14543,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14580,7 +14580,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14617,7 +14617,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14662,8 +14662,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14711,8 +14711,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14781,8 +14781,8 @@ importers:
         specifier: 1.96.22
         version: 1.96.22(@apollo/client@3.12.11)(@teambit/base-react.navigation.link@2.0.33)(@teambit/community.ui.bit-cli.commands-provider@0.0.51)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@14.3.1)(@types/react@19.2.18)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -14822,7 +14822,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/babel__core':
         specifier: 7.20.0
         version: 7.20.0
@@ -14864,8 +14864,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -14896,7 +14896,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -14956,8 +14956,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15014,8 +15014,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15069,8 +15069,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15223,8 +15223,8 @@ importers:
         specifier: ^1.96.10
         version: 1.96.10(@apollo/client@3.12.11)(@teambit/base-react.navigation.link@2.0.33)(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(@testing-library/react@14.3.1)(@types/react@19.2.18)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15320,8 +15320,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15369,8 +15369,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15430,8 +15430,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -15471,7 +15471,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
 
   scopes/component/component-sizer:
     dependencies:
@@ -15516,8 +15516,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15550,8 +15550,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -15588,7 +15588,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -15645,8 +15645,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -15706,8 +15706,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15758,8 +15758,8 @@ importers:
         specifier: 1.96.6
         version: 1.96.6(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15819,8 +15819,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15928,8 +15928,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -15986,8 +15986,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16074,8 +16074,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16132,8 +16132,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -16184,8 +16184,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -16245,8 +16245,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16295,7 +16295,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16343,8 +16343,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16398,8 +16398,8 @@ importers:
         version: 2.2.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16450,8 +16450,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16517,8 +16517,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16587,8 +16587,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16634,7 +16634,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16724,8 +16724,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16804,7 +16804,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16861,8 +16861,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16919,8 +16919,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16960,7 +16960,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17029,8 +17029,8 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17067,7 +17067,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -17138,6 +17138,9 @@ importers:
       '@teambit/base-ui.surfaces.split-pane.split-pane':
         specifier: 1.0.0
         version: 1.0.0(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/component-id':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@teambit/compositions.ui.composition-live-controls':
         specifier: ~0.0.6
         version: 0.0.6(react@19.2.7)
@@ -17247,12 +17250,9 @@ importers:
         specifier: ^6.30.1
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
-      '@teambit/component-id':
-        specifier: ^1.2.4
-        version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -17326,7 +17326,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17423,8 +17423,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -17470,7 +17470,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/eslint':
         specifier: 8.56.6
         version: 8.56.6
@@ -17524,8 +17524,8 @@ importers:
         specifier: 1.96.11
         version: 1.96.11(@teambit/community.ui.bit-cli.commands-provider@0.0.52)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@14.3.1)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17594,8 +17594,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17655,8 +17655,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.51)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@14.3.1)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17701,8 +17701,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17747,8 +17747,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.51)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@14.3.1)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17790,8 +17790,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -17828,7 +17828,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17924,8 +17924,8 @@ importers:
         specifier: 1.96.12
         version: 1.96.12(@teambit/community.ui.bit-cli.commands-provider@0.0.51)(@teambit/community.ui.community-highlighter@1.96.7)(@testing-library/react@14.3.1)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -17970,8 +17970,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
 
   scopes/dependencies/aspect-docs/dependency-resolver:
     dependencies:
@@ -17999,7 +17999,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18036,7 +18036,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18073,7 +18073,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18208,8 +18208,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -18338,8 +18338,8 @@ importers:
         version: 0.3.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18379,7 +18379,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -18466,8 +18466,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18560,8 +18560,8 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -18577,6 +18577,9 @@ importers:
       '@teambit/base-ui.loaders.skeleton':
         specifier: 1.0.2
         version: 1.0.2(react@19.2.7)
+      '@teambit/component-id':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@teambit/design.ui.surfaces.status-message-card':
         specifier: 0.0.18
         version: 0.0.18(@testing-library/react@14.3.1)(react-dom@19.2.7)(react@19.2.7)
@@ -18623,15 +18626,12 @@ importers:
         specifier: ^6.30.1
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
-      '@teambit/component-id':
-        specifier: ^1.2.4
-        version: 1.2.4
       '@teambit/docs.content.docs-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18699,7 +18699,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -18765,8 +18765,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
 
   scopes/envs/envs:
     dependencies:
@@ -18820,8 +18820,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18918,8 +18918,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -18979,8 +18979,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19017,7 +19017,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19092,8 +19092,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19162,8 +19162,8 @@ importers:
         version: 3.36.0(supports-color@9.4.0)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19217,8 +19217,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19252,7 +19252,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -19286,7 +19286,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19355,8 +19355,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -19425,8 +19425,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -19537,8 +19537,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -19572,7 +19572,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19609,7 +19609,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -19687,8 +19687,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -19832,8 +19832,8 @@ importers:
         specifier: 1.96.13
         version: 1.96.13(@testing-library/react@14.3.1)(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/eventsource':
         specifier: ^1.1.15
         version: 1.1.15
@@ -19884,8 +19884,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -19954,8 +19954,8 @@ importers:
         version: 17.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/didyoumean':
         specifier: 1.2.0
         version: 1.2.0
@@ -19992,7 +19992,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -20049,8 +20049,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20092,8 +20092,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20165,8 +20165,8 @@ importers:
         version: 2.2.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20205,8 +20205,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
 
   scopes/harmony/express:
     dependencies:
@@ -20245,8 +20245,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -20303,8 +20303,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -20418,8 +20418,8 @@ importers:
         version: 7.5.10(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
@@ -20485,8 +20485,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20528,8 +20528,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -20574,8 +20574,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20606,7 +20606,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20634,7 +20634,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -20671,7 +20671,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20702,7 +20702,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20730,7 +20730,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -20764,7 +20764,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20792,7 +20792,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20820,7 +20820,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20898,8 +20898,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20909,6 +20909,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.12
         version: 0.4.12
+      '@teambit/ui-foundation.ui.is-browser':
+        specifier: ~0.0.500
+        version: 0.0.500(react-dom@19.2.7)(react@19.2.7)
       '@testing-library/react':
         specifier: ^14.3.1
         version: 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
@@ -20938,11 +20941,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
-      '@teambit/ui-foundation.ui.is-browser':
-        specifier: ~0.0.500
-        version: 0.0.500(react-dom@19.2.7)(react@19.2.7)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -20973,7 +20973,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21061,8 +21061,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21093,7 +21093,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21127,7 +21127,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21155,7 +21155,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21204,7 +21204,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21250,7 +21250,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21349,8 +21349,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21419,8 +21419,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21469,7 +21469,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21535,8 +21535,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -21579,7 +21579,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.2.0
-        version: 3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21676,8 +21676,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21710,8 +21710,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -21742,7 +21742,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21832,8 +21832,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/archiver':
         specifier: 5.3.1
         version: 5.3.1
@@ -21879,7 +21879,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -21916,7 +21916,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -21950,7 +21950,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -21990,7 +21990,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -22077,8 +22077,8 @@ importers:
         version: 10.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.96.9
         version: 1.96.9(@apollo/client@3.12.11)(@teambit/base-react.navigation.link@2.0.33)(@testing-library/react@14.3.1)(@types/react@19.2.18)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)
@@ -22124,7 +22124,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22158,7 +22158,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -22213,6 +22213,9 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      cross-fetch:
+        specifier: 3.1.5
+        version: 3.1.5
       filenamify:
         specifier: 4.2.0
         version: 4.2.0
@@ -22231,6 +22234,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lru-cache:
+        specifier: 10.4.3
+        version: 10.4.3
       mime:
         specifier: 2.5.2
         version: 2.5.2
@@ -22266,8 +22272,8 @@ importers:
         version: 13.3.2(sass-embedded@1.102.0)(sass@1.63.6)(webpack@5.109.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -22289,12 +22295,6 @@ importers:
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
-      cross-fetch:
-        specifier: 3.1.5
-        version: 3.1.5
-      lru-cache:
-        specifier: 10.4.3
-        version: 10.4.3
 
   scopes/preview/ui/component-preview:
     dependencies:
@@ -22408,7 +22408,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -22463,7 +22463,7 @@ importers:
         version: 7.22.3
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.19.6)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.19.6)(supports-color@9.4.0)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -22521,7 +22521,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
 
   scopes/react/react:
     dependencies:
@@ -22702,6 +22702,9 @@ importers:
       lodash.compact:
         specifier: 3.0.1
         version: 3.0.1
+      lodash.flatten:
+        specifier: 4.4.0
+        version: 4.4.0
       mini-css-extract-plugin:
         specifier: 2.2.2
         version: 2.2.2(webpack@5.109.2)
@@ -22776,8 +22779,8 @@ importers:
         version: 5.1.0(webpack@5.109.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/react.content.react-overview':
         specifier: 1.96.6
         version: 1.96.6(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -22820,9 +22823,6 @@ importers:
       '@types/webpack':
         specifier: 5.28.5
         version: 5.28.5(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(uglify-js@3.19.3)
-      lodash.flatten:
-        specifier: 4.4.0
-        version: 4.4.0
 
   scopes/react/ui/compositions-app:
     dependencies:
@@ -23224,8 +23224,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23294,8 +23294,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23329,7 +23329,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -23399,7 +23399,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/http-proxy-agent':
         specifier: 2.0.2
         version: 2.0.2
@@ -23486,8 +23486,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -23533,7 +23533,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
 
   scopes/scope/scope:
     dependencies:
@@ -23674,8 +23674,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/scope.content.scope-overview':
         specifier: 1.96.8
         version: 1.96.8(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -23738,8 +23738,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23796,8 +23796,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/chai-subset':
         specifier: 1.3.5
         version: 1.3.5
@@ -23837,7 +23837,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -23914,7 +23914,7 @@ importers:
         version: 0.0.1
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24114,7 +24114,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24560,7 +24560,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
@@ -24709,7 +24709,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -24749,7 +24749,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24807,7 +24807,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24867,8 +24867,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -24910,8 +24910,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24956,8 +24956,8 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -24999,8 +24999,8 @@ importers:
         version: 3.2.0(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -25045,8 +25045,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25091,8 +25091,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -25257,8 +25257,8 @@ importers:
         version: 7.1.0(@types/babel__core@7.20.0)(supports-color@9.4.0)(webpack@5.109.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -25312,8 +25312,8 @@ importers:
         version: 0.7.40
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25367,8 +25367,8 @@ importers:
         version: 2.2.12(typescript@5.9.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
 
   scopes/webpack/config-mutator:
     dependencies:
@@ -25405,7 +25405,7 @@ importers:
     devDependencies:
       '@teambit/node.node':
         specifier: 4.0.1
-        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -25445,7 +25445,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25476,7 +25476,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25504,7 +25504,7 @@ importers:
     devDependencies:
       '@teambit/node.node':
         specifier: 4.0.1
-        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25541,7 +25541,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25569,7 +25569,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -25719,8 +25719,8 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
@@ -25760,7 +25760,7 @@ importers:
     devDependencies:
       '@teambit/mdx.mdx-env':
         specifier: 3.1.1
-        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
+        version: 3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@types/jest':
         specifier: ^29.2.2
         version: 29.5.14
@@ -25802,8 +25802,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25863,8 +25863,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -25909,8 +25909,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
@@ -26000,8 +26000,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26050,7 +26050,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/cacache':
         specifier: 19.0.0
         version: 19.0.0
@@ -26093,7 +26093,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -26148,7 +26148,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26185,7 +26185,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26230,8 +26230,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -26265,7 +26265,7 @@ importers:
     devDependencies:
       '@teambit/node.envs.node-babel-mocha':
         specifier: 2.0.5
-        version: 2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)
+        version: 2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26310,8 +26310,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/workspace.content.variants':
         specifier: 1.96.7
         version: 1.96.7(react@19.2.7)
@@ -26377,8 +26377,8 @@ importers:
         version: 6.30.4(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -26543,8 +26543,8 @@ importers:
         version: 7.7.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/workspace.content.workspace-overview':
         specifier: 1.96.7
         version: 1.96.7(@apollo/client@3.12.11)(@testing-library/react@14.3.1)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)
@@ -26634,8 +26634,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 2.0.7
-        version: 2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
+        specifier: 2.0.8
+        version: 2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -33177,8 +33177,8 @@ packages:
     peerDependencies:
       react: 19.1.0
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.7':
-    resolution: {integrity: sha512-/D1UIlNhccvYHZeEpFzp71T/qMZPlC/1ykjsUTrji51RAmrtpQ6pJgqRTO5IaFrz7+Dl/oAghvmNSjmCoNLtrw==}
+  '@teambit/harmony.envs.core-aspect-env@2.0.8':
+    resolution: {integrity: sha512-Sc6Km0qA9WUkzoMDYqx9Kk3POFNrPS1ZQnADwWaR0aUdzo9mZ+G0yjiMPT0ZSiuarsqDhzjPUBfH/baNS8+f6A==}
 
   '@teambit/harmony.envs.core-react-env@0.0.2':
     resolution: {integrity: sha512-HDaTKMSodbisvRqLDPGkdoblGZM5F8AOy7qJZs5gRIQ8xeewXj7L5m8ZwtwEMUVZlyYqQMWDbbEFkkxBUnY4HQ==}
@@ -34099,6 +34099,11 @@ packages:
 
   '@teambit/react.ui.error-fallback@file:scopes/react/ui/error-fallback':
     resolution: {directory: scopes/react/ui/error-fallback, type: directory}
+    peerDependencies:
+      react: 19.2.7
+
+  '@teambit/react.ui.highlighter-provider@0.0.228':
+    resolution: {integrity: sha512-TUgzdPnQjRye4p6vU3H1sxXSSdOC8d5cihpn8YF51iHQCzlfPgUPP4Y+e+ZAqcXCpW1wMTkJfJeVwrt+KEQcJQ==}
     peerDependencies:
       react: 19.2.7
 
@@ -49904,6 +49909,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@floating-ui/react-dom@0.7.2(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 0.5.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.18)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@floating-ui/react-dom@0.7.2(@types/react@19.2.18)(react-dom@19.2.7)(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 0.5.4
@@ -61166,6 +61180,7 @@ snapshots:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@18.3.1)(react@18.3.1)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(domexception@4.0.0)(graphql@15.8.0)(supports-color@9.4.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@18.3.1)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(@testing-library/dom@10.4.1)
@@ -61235,6 +61250,7 @@ snapshots:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.2.7)
       '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.1(react-dom@19.2.7)(react@19.2.7)
       '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(domexception@4.0.0)(graphql@15.8.0)(supports-color@9.4.0)
       '@teambit/compositions.aspect-docs.compositions': file:scopes/compositions/aspect-docs/compositions(@teambit/documenter.theme.theme-compositions@4.1.5)(@teambit/mdx.ui.mdx-layout@1.0.14)(react@19.2.7)
       '@teambit/compositions.model.composition-id': file:scopes/compositions/model/composition-id(@testing-library/dom@10.4.1)
@@ -65801,6 +65817,7 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/dom@10.4.1)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@18.3.1)(react@18.3.1)(supports-color@9.4.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@18.3.1)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(domexception@4.0.0)(graphql@15.8.0)(supports-color@9.4.0)
       '@teambit/component.ui.component-meta': file:components/ui/component-meta(@testing-library/dom@10.4.1)(chai@4.3.0)(react@18.3.1)(supports-color@9.4.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(@testing-library/dom@10.4.1)(react@18.3.1)
@@ -65834,6 +65851,7 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/dom@10.4.1)(chai@4.3.0)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.2.7)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(domexception@4.0.0)(graphql@15.8.0)(supports-color@9.4.0)
       '@teambit/component.ui.component-meta': file:components/ui/component-meta(@testing-library/dom@10.4.1)(chai@4.3.0)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(@testing-library/dom@10.4.1)(react@19.2.7)
@@ -65867,6 +65885,7 @@ snapshots:
   '@teambit/docs@file:scopes/docs/docs(@teambit/base-react.navigation.link@2.0.33)(@testing-library/dom@10.4.1)(chai@5.2.1)(domexception@4.0.0)(graphql@15.8.0)(react-dom@19.2.7)(react@19.2.7)(supports-color@9.4.0)':
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.2(react@19.2.7)
+      '@teambit/component-id': 1.2.4
       '@teambit/component.sources': file:scopes/component/sources(domexception@4.0.0)(graphql@15.8.0)(supports-color@9.4.0)
       '@teambit/component.ui.component-meta': file:components/ui/component-meta(@testing-library/dom@10.4.1)(chai@5.2.1)(react@19.2.7)(supports-color@9.4.0)
       '@teambit/compositions.panels.composition-gallery': file:scopes/compositions/panels/composition-gallery(@teambit/base-react.navigation.link@2.0.33)(@testing-library/dom@10.4.1)(react@19.2.7)
@@ -68762,7 +68781,7 @@ snapshots:
       react-dom: 18.3.1(react@19.2.7)
       react-router-dom: 6.30.4(react-dom@18.3.1)(react@19.2.7)
 
-  '@teambit/harmony.envs.core-aspect-env@2.0.7(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)':
+  '@teambit/harmony.envs.core-aspect-env@2.0.8(@babel/core@7.28.3)(@babel/traverse@7.29.8)(eslint@8.56.0)(react-refresh@0.10.0)(react-test-renderer@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(webpack@5.109.2)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
@@ -68779,8 +68798,8 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.15(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@7.0.2)(webpack@5.109.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.15(@babel/core@7.28.3)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@7.0.2)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 5.0.3(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@testing-library/react-hooks': 8.0.1(@types/react@19.2.18)(react-dom@19.2.7)(react-test-renderer@19.2.7)(react@19.2.7)
@@ -68809,7 +68828,6 @@ snapshots:
       - '@babel/traverse'
       - '@module-federation/runtime-tools'
       - '@swc/helpers'
-      - '@testing-library/dom'
       - eslint
       - fibers
       - node-sass
@@ -72311,7 +72329,7 @@ snapshots:
 
   '@teambit/mdx.generator.mdx-templates@1.0.14': {}
 
-  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@18.3.1)
@@ -72325,9 +72343,9 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.18
@@ -72359,7 +72377,6 @@ snapshots:
       - '@swc/css'
       - '@swc/helpers'
       - '@swc/html'
-      - '@testing-library/dom'
       - '@testing-library/react'
       - '@types/node'
       - '@types/react-syntax-highlighter'
@@ -72401,7 +72418,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
+  '@teambit/mdx.mdx-env@3.1.1(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@18.3.1)
@@ -72415,9 +72432,9 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.18
@@ -72449,7 +72466,6 @@ snapshots:
       - '@swc/css'
       - '@swc/helpers'
       - '@swc/html'
-      - '@testing-library/dom'
       - '@testing-library/react'
       - '@types/node'
       - '@types/react-syntax-highlighter'
@@ -72491,7 +72507,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
+  '@teambit/mdx.mdx-env@3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@18.3.1)
@@ -72505,9 +72521,9 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+      '@teambit/preview.react-preview': 1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.18
@@ -72539,7 +72555,6 @@ snapshots:
       - '@swc/css'
       - '@swc/helpers'
       - '@swc/html'
-      - '@testing-library/dom'
       - '@testing-library/react'
       - '@types/node'
       - '@types/react-syntax-highlighter'
@@ -72581,7 +72596,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/mdx.mdx-env@3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
+  '@teambit/mdx.mdx-env@3.2.0(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/react@14.3.1)(@types/node@22.10.5)(@types/react-syntax-highlighter@15.5.13)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@18.3.1)
@@ -72595,9 +72610,9 @@ snapshots:
       '@teambit/mdx.generator.mdx-templates': 1.0.14
       '@teambit/mdx.ui.mdx-layout': 1.0.14(@mdx-js/react@3.1.1)(@teambit/mdx.ui.mdx-scope-context@1.1.1)(@testing-library/react@14.3.1)(@types/react-dom@19.2.4)(@types/react-syntax-highlighter@15.5.13)(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)(typescript@6.0.3)
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@18.3.1)
-      '@teambit/preview.react-preview': 1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+      '@teambit/preview.react-preview': 1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.eslint-config-bit-react': 2.0.10(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@6.0.3)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.28.3)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 3.0.0(react@18.3.1)
       '@types/react': 19.2.18
@@ -72629,7 +72644,6 @@ snapshots:
       - '@swc/css'
       - '@swc/helpers'
       - '@swc/html'
-      - '@testing-library/dom'
       - '@testing-library/react'
       - '@types/node'
       - '@types/react-syntax-highlighter'
@@ -73352,7 +73366,7 @@ snapshots:
 
   '@teambit/node.deps-detectors.parser-helper@0.0.6': {}
 
-  '@teambit/node.envs.node-babel-mocha@2.0.5(@babel/core@7.19.6)(@testing-library/dom@10.4.1)(supports-color@9.4.0)':
+  '@teambit/node.envs.node-babel-mocha@2.0.5(@babel/core@7.19.6)(supports-color@9.4.0)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.19.6)(supports-color@9.4.0)
       '@babel/preset-env': 7.28.3(@babel/core@7.19.6)(supports-color@9.4.0)
@@ -73366,7 +73380,7 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/typescript.typescript-compiler': 5.0.3(react@19.2.7)
       '@types/mocha': 10.0.10
       '@types/node': 22.10.5
@@ -73383,10 +73397,9 @@ snapshots:
       typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
-      - '@testing-library/dom'
       - supports-color
 
-  '@teambit/node.envs.node-babel-mocha@2.0.5(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(supports-color@9.4.0)':
+  '@teambit/node.envs.node-babel-mocha@2.0.5(@babel/core@7.28.3)(supports-color@9.4.0)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)(supports-color@9.4.0)
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)(supports-color@9.4.0)
@@ -73400,7 +73413,7 @@ snapshots:
       '@teambit/defender.prettier-formatter': 1.0.24
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
       '@teambit/oxc.linter.oxlint-linter': 2.0.5
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/typescript.typescript-compiler': 5.0.3(react@19.2.7)
       '@types/mocha': 10.0.10
       '@types/node': 22.10.5
@@ -73417,7 +73430,6 @@ snapshots:
       typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/core'
-      - '@testing-library/dom'
       - supports-color
 
   '@teambit/node.envs.node-typescript-mocha@2.0.2(@babel/core@7.28.3)(supports-color@9.4.0)':
@@ -73455,7 +73467,7 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  '@teambit/node.node@4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
+  '@teambit/node.node@4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       '@babel/core': 7.26.9(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)(supports-color@9.4.0)
@@ -73472,9 +73484,9 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.eslint-config-bit-react': 2.0.17(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@7.0.2)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 5.0.0(react@19.2.7)
       '@types/jest': 29.5.14
@@ -73506,7 +73518,6 @@ snapshots:
       - '@swc/css'
       - '@swc/helpers'
       - '@swc/html'
-      - '@testing-library/dom'
       - '@types/webpack'
       - babel-plugin-macros
       - browserslist
@@ -73545,7 +73556,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/node.node@4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
+  '@teambit/node.node@4.0.1(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
       '@babel/core': 7.26.9(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.20.2(@babel/core@7.26.9)(supports-color@9.4.0)
@@ -73562,9 +73573,9 @@ snapshots:
       '@teambit/mdx.ui.mdx-scope-context': 1.1.1(react@19.2.7)
       '@teambit/node.generator.node-starters': 1.0.0
       '@teambit/node.generator.node-templates': 1.0.22
-      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
+      '@teambit/preview.react-preview': 1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)
       '@teambit/react.eslint-config-bit-react': 2.0.17(eslint@8.56.0)(jest@29.3.1)(supports-color@9.4.0)(typescript@7.0.2)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.react-env': 2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@4.41.0)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 5.0.0(react@19.2.7)
       '@types/jest': 29.5.14
@@ -73596,7 +73607,6 @@ snapshots:
       - '@swc/css'
       - '@swc/helpers'
       - '@swc/html'
-      - '@testing-library/dom'
       - '@types/webpack'
       - babel-plugin-macros
       - browserslist
@@ -74264,10 +74274,10 @@ snapshots:
 
   '@teambit/preview.modules.preview-modules@1.0.3': {}
 
-  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@19.2.7)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@19.2.7)(supports-color@9.4.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74285,7 +74295,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74316,10 +74326,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.26.9)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.26.9)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@19.2.7)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@19.2.7)(supports-color@9.4.0)(typescript@7.0.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74337,7 +74347,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74368,10 +74378,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(supports-color@9.4.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74389,7 +74399,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74420,10 +74430,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.1.13(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.webpack.react-webpack': 1.0.59(@babel/core@7.28.3)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.0.19(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.0.26(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(supports-color@9.4.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74441,7 +74451,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74472,10 +74482,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.webpack.react-webpack': 1.0.60(@babel/core@7.28.3)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.1.0(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.1.0(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(supports-color@9.4.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74493,7 +74503,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74524,10 +74534,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.webpack.react-webpack': 1.0.60(@babel/core@7.28.3)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@18.3.1)(react@18.3.1)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@4.41.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.1.0(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.1.0(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@18.3.1)(supports-color@9.4.0)(typescript@6.0.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74545,7 +74555,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74576,10 +74586,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@teambit/preview.react-preview@1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@testing-library/dom@10.4.1)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@5.9.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
+  '@teambit/preview.react-preview@1.2.0(@babel/core@7.28.3)(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(@types/react@19.2.18)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(html-webpack-plugin@5.3.2)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@5.9.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@bitdev/react.preview.react-docs-app': 0.0.11
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.webpack.react-webpack': 1.0.60(@babel/core@7.28.3)(@rspack/core@1.7.12)(@types/webpack@5.28.5)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.63.6)(supports-color@9.4.0)(type-fest@0.21.3)(typescript@5.9.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)(webpack-hot-middleware@2.26.1)
       '@teambit/webpack.webpack-bundler': 1.1.0(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(esbuild@0.14.29)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@19.2.7)(uglify-js@3.19.3)
       '@teambit/webpack.webpack-dev-server': 1.1.0(@parcel/css@1.14.0)(@rspack/core@1.7.12)(@swc/css@0.0.20)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.4.45)(react@19.2.7)(supports-color@9.4.0)(typescript@5.9.2)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack@5.109.2)
@@ -74597,7 +74607,7 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - '@testing-library/dom'
+      - '@types/react'
       - '@types/webpack'
       - browserslist
       - bufferutil
@@ -74815,12 +74825,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 4.3.0
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -74880,12 +74892,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 4.3.0
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -74945,12 +74959,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 4.3.0
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -75010,12 +75026,14 @@ snapshots:
       camelcase: 6.2.0
       chai: 5.2.1
       chalk: 4.1.2
+      cross-fetch: 3.1.5
       filenamify: 4.2.0
       fs-extra: 10.0.0
       graphql-request: 6.1.0(graphql@15.8.0)
       graphql-tag: 2.12.1(graphql@15.8.0)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lru-cache: 10.4.3
       mime: 2.5.2
       normalize-path: 3.0.0
       object-hash: 2.1.1
@@ -75046,6 +75064,7 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(react@18.3.1)':
     dependencies:
       '@teambit/harmony': 0.4.12
+      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.2.7)(react@18.3.1)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@18.3.1)
       '@types/node': 22.10.5
       '@types/react': 19.2.18
@@ -75059,6 +75078,7 @@ snapshots:
   '@teambit/pubsub@file:scopes/harmony/pubsub(react@19.2.7)':
     dependencies:
       '@teambit/harmony': 0.4.12
+      '@teambit/ui-foundation.ui.is-browser': 0.0.500(react-dom@19.2.7)(react@19.2.7)
       '@testing-library/react': 14.3.1(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@types/node': 22.10.5
       '@types/react': 19.2.18
@@ -75608,29 +75628,29 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@teambit/react.mounter@1.1.9(@testing-library/dom@10.4.1)(react-dom@18.3.1)(react@18.3.1)':
+  '@teambit/react.mounter@1.1.9(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@bitdev/react.live-controls': 0.0.4(react@18.3.1)
       '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@18.3.1)
-      '@teambit/react.ui.highlighter-provider': file:scopes/react/ui/highlighter-provider(@testing-library/dom@10.4.1)(react@18.3.1)
+      '@teambit/react.ui.highlighter-provider': 0.0.228(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
       '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-error-boundary: 3.1.4(react@18.3.1)
     transitivePeerDependencies:
-      - '@testing-library/dom'
+      - '@types/react'
 
-  '@teambit/react.mounter@1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)':
+  '@teambit/react.mounter@1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@bitdev/react.live-controls': 0.0.4(react@19.2.7)
       '@teambit/react.modules.react-live-controls-from-schema': 0.0.2(react@19.2.7)
-      '@teambit/react.ui.highlighter-provider': file:scopes/react/ui/highlighter-provider(@testing-library/dom@10.4.1)(react@19.2.7)
+      '@teambit/react.ui.highlighter-provider': 0.0.228(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/react.ui.mounter.use-default-controls': 0.0.2(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-error-boundary: 3.1.4(react@19.2.7)
     transitivePeerDependencies:
-      - '@testing-library/dom'
+      - '@types/react'
 
   '@teambit/react.react-env@2.0.3(@babel/core@7.26.9)(@babel/traverse@7.29.8)(@parcel/css@1.14.0)(@swc/css@0.0.20)(@types/webpack@5.28.5)(babel-plugin-macros@3.1.0)(browserslist@4.23.3)(bufferutil@4.0.3)(clean-css@5.3.3)(cssnano@6.1.2)(csso@5.0.5)(debug@4.3.4)(esbuild@0.14.29)(eslint@8.56.0)(html-minifier-terser@6.1.0)(less@4.9.0)(lightningcss@1.33.0)(postcss@8.4.45)(react-refresh@0.10.0)(rollup@2.80.0)(sass-embedded@1.102.0)(supports-color@9.4.0)(type-fest@0.21.3)(uglify-js@3.19.3)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.26.1)(webpack@5.109.2)':
     dependencies:
@@ -75649,8 +75669,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.26.9)(@babel/traverse@7.29.8)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -75732,8 +75752,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.26.9)(@babel/traverse@7.29.8)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.26.9)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -75815,8 +75835,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.8)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -75898,8 +75918,8 @@ snapshots:
       '@teambit/react.generator.react-starters': 1.0.9
       '@teambit/react.generator.react-templates': 1.0.13
       '@teambit/react.jest.react-jest': 1.0.38(@babel/core@7.28.3)(@babel/traverse@7.29.8)(bufferutil@4.0.3)(jest@29.3.1)(supports-color@9.4.0)(utf-8-validate@5.0.5)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
-      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/rspack.dev-services.preview.react-preview': 1.0.14(@babel/core@7.28.3)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/typescript.typescript-compiler': 2.0.68(react@19.2.7)
       '@testing-library/dom': 10.4.1
@@ -76077,6 +76097,27 @@ snapshots:
       url-join: 4.0.1
       use-debounce: 6.0.1(react@19.2.7)
       uuid: 3.4.0
+
+  '@teambit/react.ui.component-highlighter@0.2.8(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 0.7.2(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/base-ui.routing.native-link': 1.0.1(react@18.3.1)
+      '@teambit/component-id': 1.2.2
+      '@teambit/component.modules.component-url': 0.0.188(react@18.3.1)
+      '@teambit/react.modules.dom-to-react': 0.2.1(react@18.3.1)
+      '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': 0.0.45(react-dom@18.3.1)(react@18.3.1)
+      '@teambit/react.ui.hover-selector': 0.2.1(react@18.3.1)
+      '@tippyjs/react': 4.2.0(react-dom@18.3.1)(react@18.3.1)
+      classnames: 2.5.1
+      get-xpath: 3.3.0
+      lodash.compact: 3.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      url-join: 4.0.1
+      use-debounce: 8.0.4(react@18.3.1)
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@teambit/react.ui.component-highlighter@0.2.8(@types/react@19.2.18)(react-dom@19.2.7)(react@18.3.1)':
     dependencies:
@@ -76481,6 +76522,26 @@ snapshots:
       react-error-boundary: 3.1.4(react@19.2.7)
     transitivePeerDependencies:
       - '@testing-library/dom'
+
+  '@teambit/react.ui.highlighter-provider@0.0.228(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)':
+    dependencies:
+      '@teambit/react.ui.component-highlighter': 0.2.8(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1)
+      classnames: 2.5.1
+      query-string: 7.0.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+
+  '@teambit/react.ui.highlighter-provider@0.0.228(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)':
+    dependencies:
+      '@teambit/react.ui.component-highlighter': 0.2.8(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
+      classnames: 2.5.1
+      query-string: 7.0.0
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
 
   '@teambit/react.ui.highlighter-provider@file:scopes/react/ui/highlighter-provider(@testing-library/dom@10.4.1)(react@18.3.1)':
     dependencies:
@@ -77579,6 +77640,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.45)
@@ -77727,6 +77789,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.45)
@@ -77875,6 +77938,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.45)
@@ -78023,6 +78087,7 @@ snapshots:
       less-loader: 10.0.0(less@4.9.0)(webpack@5.109.2)
       lodash: 4.17.21
       lodash.compact: 3.0.1
+      lodash.flatten: 4.4.0
       mini-css-extract-plugin: 2.2.2(webpack@5.109.2)
       new-url-loader: 0.1.1(webpack@5.109.2)
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.45)
@@ -78485,12 +78550,12 @@ snapshots:
       react-router-dom: 6.30.4(react-dom@19.2.7)(react@19.2.7)
       strip-ansi: 6.0.0
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.26.9)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.26.9)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)':
     dependencies:
       '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.10
       '@rspack/dev-server': 2.2.0(@rspack/core@2.1.10)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.26.9)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.26.9)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
@@ -78501,7 +78566,7 @@ snapshots:
       - '@babel/core'
       - '@module-federation/runtime-tools'
       - '@swc/helpers'
-      - '@testing-library/dom'
+      - '@types/react'
       - eslint
       - fibers
       - node-sass
@@ -78516,12 +78581,12 @@ snapshots:
       - vue-template-compiler
       - webpack
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.14(@babel/core@7.28.3)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)':
     dependencies:
       '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.10
       '@rspack/dev-server': 2.2.0(@rspack/core@2.1.10)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/rspack.rspack-bundler': 1.0.9(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/rspack.rspack-dev-server': 0.1.49(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@5.9.2)(webpack@5.109.2)
@@ -78532,7 +78597,7 @@ snapshots:
       - '@babel/core'
       - '@module-federation/runtime-tools'
       - '@swc/helpers'
-      - '@testing-library/dom'
+      - '@types/react'
       - eslint
       - fibers
       - node-sass
@@ -78547,12 +78612,12 @@ snapshots:
       - vue-template-compiler
       - webpack
 
-  '@teambit/rspack.dev-services.preview.react-preview@1.0.15(@babel/core@7.28.3)(@testing-library/dom@10.4.1)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@7.0.2)(webpack@5.109.2)':
+  '@teambit/rspack.dev-services.preview.react-preview@1.0.15(@babel/core@7.28.3)(@types/react@19.2.18)(eslint@8.56.0)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@7.0.2)(webpack@5.109.2)':
     dependencies:
       '@bitdev/react.preview.react-docs-template': 1.0.14(react-dom@19.2.7)(react@19.2.7)
       '@rspack/core': 2.1.10
       '@rspack/dev-server': 2.2.0(@rspack/core@2.1.10)
-      '@teambit/react.mounter': 1.1.9(@testing-library/dom@10.4.1)(react-dom@19.2.7)(react@19.2.7)
+      '@teambit/react.mounter': 1.1.9(@types/react@19.2.18)(react-dom@19.2.7)(react@19.2.7)
       '@teambit/rspack.modules.rspack-config-mutator': 1.0.23(react-refresh@0.10.0)(react@19.2.7)(webpack@5.109.2)
       '@teambit/rspack.rspack-bundler': 1.0.10(@babel/core@7.28.3)(react-dom@19.2.7)(react-refresh@0.10.0)(react@19.2.7)(rollup@2.80.0)(sass-embedded@1.102.0)(sass@1.72.0)(supports-color@9.4.0)(webpack@5.109.2)
       '@teambit/rspack.rspack-dev-server': 0.1.50(@babel/core@7.28.3)(eslint@8.56.0)(react-dom@19.2.7)(react@19.2.7)(rollup@2.80.0)(sass@1.72.0)(supports-color@9.4.0)(typescript@7.0.2)(webpack@5.109.2)
@@ -78563,7 +78628,7 @@ snapshots:
       - '@babel/core'
       - '@module-federation/runtime-tools'
       - '@swc/helpers'
-      - '@testing-library/dom'
+      - '@types/react'
       - eslint
       - fibers
       - node-sass

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -274,7 +274,7 @@
         "@teambit/gitconfig": "2.0.10",
         "@teambit/graph.cleargraph": "0.0.11",
         "@teambit/harmony": "0.4.12",
-        "@teambit/harmony.envs.core-aspect-env": "2.0.7",
+        "@teambit/harmony.envs.core-aspect-env": "2.0.8",
         "@teambit/html.modules.inject-html-element": "0.0.6",
         "@teambit/lane-id": "~0.0.312",
         "@teambit/lanes.ui.icons.lane-icon": "~0.0.9",


### PR DESCRIPTION
The previous env version matched preview runtime files with a composition pattern. Bit treated these files as dev files and moved their imports to devDependencies. The published package still shipped the runtime file, but it no longer installed that import. Because of this, `bit start --rebuild` failed to build the preview bundle, and the nightly e2e job failed.

Version 2.0.8 excludes preview runtime files from the pattern. This returns the imports to dependencies.