### PR TITLE
feat(install): profile timing for install phases

### DIFF
--- a/components/legacy/logger/logger.ts
+++ b/components/legacy/logger/logger.ts
@@ -221,7 +221,10 @@ class BitLogger implements IBitLogger {
     const msg = this.profiler.profile(id);
     if (!msg) return;
     const fullMsg = `${id}: ${msg}`;
-    shouldWriteToConsole ? this.console(fullMsg) : this[level](fullMsg);
+    // always record it in the log file, and also print it to the screen when requested. (previously
+    // these were mutually exclusive, so enabling console output silently dropped the debug.log entry)
+    this[level](fullMsg);
+    if (shouldWriteToConsole) this.console(fullMsg);
   }
 
   registerOnBeforeExitFn(fn: Function) {

--- a/components/legacy/logger/logger.ts
+++ b/components/legacy/logger/logger.ts
@@ -211,10 +211,14 @@ class BitLogger implements IBitLogger {
     // profiling keeps state per id and formats a message. when the line is going to be discarded
     // anyway, skip it altogether - otherwise turning the level off removes only the printing, not
     // the cost of the profiling itself.
-    // the level can change between the two calls of a measurement (the daemon switches the logger
-    // around every CLI request), so also drop the measurement this call would have closed. only the
-    // measurement of this id is dropped, to not touch the ones of a request that runs in parallel.
-    if (!shouldWriteToConsole && !this.logger.isLevelEnabled(level)) {
+    // the check (and later the write) use the dedicated file logger, not `this.logger` - which
+    // `switchToConsoleLogger`/`switchToSSELogger` can repoint at a console/SSE-only pino instance
+    // with its own level - so profiling always persists to debug.log regardless of the active
+    // display mode. the file logger's level can still change between the two calls of a
+    // measurement (e.g. via `bit --log`), so also drop the measurement this call would have
+    // closed. only the measurement of this id is dropped, to not touch the ones of a request that
+    // runs in parallel.
+    if (!shouldWriteToConsole && !pinoLogger.isLevelEnabled(level)) {
       this.profiler.discard(id);
       return;
     }
@@ -223,7 +227,7 @@ class BitLogger implements IBitLogger {
     const fullMsg = `${id}: ${msg}`;
     // always record it in the log file, and also print it to the screen when requested. (previously
     // these were mutually exclusive, so enabling console output silently dropped the debug.log entry)
-    this[level](fullMsg);
+    pinoLogger[level](this.withTracePrefix(level, fullMsg));
     if (shouldWriteToConsole) this.console(fullMsg);
   }
 

--- a/scopes/dependencies/pnpm/pnpm.package-manager.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.spec.ts
@@ -64,6 +64,7 @@ function createPackageManager(config: Partial<ResolvedConfig>) {
     {
       error: () => {},
       profile: () => {},
+      profileAsync: async (_id: string, fn: () => Promise<unknown>) => fn(),
     } as any,
     {
       getCurrentUser: async () => ({ username: 'test-user' }),

--- a/scopes/dependencies/pnpm/pnpm.package-manager.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.spec.ts
@@ -63,6 +63,7 @@ function createPackageManager(config: Partial<ResolvedConfig>) {
     } as any,
     {
       error: () => {},
+      profile: () => {},
     } as any,
     {
       getCurrentUser: async () => ({ username: 'test-user' }),

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -147,10 +147,12 @@ export class PnpmPackageManager implements PackageManager {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const { install } = require('./lynx');
 
+    this.logger.profile('install.pnpm.readConfig');
     const registries = await this.depResolver.getRegistries();
     const proxyConfig = await this.depResolver.getProxyConfig();
     const networkConfig = await this.depResolver.getNetworkConfig();
     const { config } = await this.readConfig(installOptions.packageManagerConfigRootDir);
+    this.logger.profile('install.pnpm.readConfig');
     if (
       installOptions.dependenciesGraph &&
       (installOptions.rootComponents || installOptions.rootComponentsForCapsules)
@@ -196,65 +198,77 @@ export class PnpmPackageManager implements PackageManager {
     // packages this process already loaded modules from must stay requireable even if this install
     // re-keys them to a new peer hash - see preserve-loaded-virtual-store-dirs.ts
     const loadedVirtualStoreDirs = snapshotLoadedVirtualStoreDirs(rootDir);
-    const { dependenciesChanged, rebuild, storeDir, depsRequiringBuild } = await install(
-      rootDir,
-      manifests,
-      config.storeDir,
-      config.cacheDir,
-      registries,
-      proxyConfig,
-      networkConfig,
-      {
-        autoInstallPeers: installOptions.autoInstallPeers ?? true,
-        dedupePeers: installOptions.dedupePeers ?? true,
-        enableModulesDir: installOptions.enableModulesDir,
-        engineStrict: installOptions.engineStrict ?? config.engineStrict,
-        excludeLinksFromLockfile: installOptions.excludeLinksFromLockfile,
-        lockfileOnly: installOptions.lockfileOnly,
-        minimumReleaseAge: installOptions.minimumReleaseAge,
-        minimumReleaseAgeExclude: installOptions.minimumReleaseAgeExclude,
-        neverBuiltDependencies: installOptions.neverBuiltDependencies,
-        allowScripts: installOptions.allowScripts,
-        dangerouslyAllowAllScripts: installOptions.dangerouslyAllowAllScripts,
-        nodeLinker: installOptions.nodeLinker,
-        nodeVersion: installOptions.nodeVersion ?? config.nodeVersion,
-        includeOptionalDeps: installOptions.includeOptionalDeps,
-        ignorePackageManifest: installOptions.ignorePackageManifest,
-        dedupeInjectedDeps: installOptions.dedupeInjectedDeps ?? false,
-        dryRun: installOptions.dependenciesGraph == null && installOptions.dryRun,
-        overrides: installOptions.overrides,
-        hoistPattern,
-        publicHoistPattern: config.shamefullyHoist
-          ? ['*']
-          : ['@eslint/plugin-*', '*eslint-plugin*', '@prettier/plugin-*', '*prettier-plugin-*'],
-        hoistWorkspacePackages: installOptions.hoistWorkspacePackages ?? false,
-        hoistInjectedDependencies: installOptions.hoistInjectedDependencies,
-        packageImportMethod: installOptions.packageImportMethod ?? config.packageImportMethod,
-        enableGlobalVirtualStore: installOptions.enableGlobalVirtualStore,
-        globalVirtualStoreDir: installOptions.globalVirtualStoreDir,
-        patchedDependencies: installOptions.patchedDependencies,
-        packageExtensions: installOptions.packageExtensions,
-        preferOffline: installOptions.preferOffline,
-        rootComponents: installOptions.rootComponents,
-        rootComponentsForCapsules: installOptions.rootComponentsForCapsules,
-        sideEffectsCacheRead: installOptions.sideEffectsCache ?? true,
-        sideEffectsCacheWrite: installOptions.sideEffectsCache ?? true,
-        pnpmHomeDir: config.pnpmHomeDir,
-        updateAll: installOptions.updateAll,
-        hidePackageManagerOutput: installOptions.hidePackageManagerOutput,
-        reportOptions: {
-          appendOnly: installOptions.optimizeReportForNonTerminal,
-          outputStream: process.env.BIT_CLI_SERVER_NO_TTY ? new ServerSendOutStream() : undefined,
-          throttleProgress: installOptions.throttleProgress,
-          hideProgressPrefix: installOptions.hideProgressPrefix,
-          hideLifecycleOutput: installOptions.hideLifecycleOutput,
-          peerDependencyRules: installOptions.peerDependencyRules,
+    this.logger.profile('install.pnpm.core');
+    let installResult: {
+      dependenciesChanged: boolean;
+      rebuild: RebuildFn;
+      storeDir: string;
+      depsRequiringBuild?: DepPath[];
+    };
+    try {
+      installResult = await install(
+        rootDir,
+        manifests,
+        config.storeDir,
+        config.cacheDir,
+        registries,
+        proxyConfig,
+        networkConfig,
+        {
+          autoInstallPeers: installOptions.autoInstallPeers ?? true,
+          dedupePeers: installOptions.dedupePeers ?? true,
+          enableModulesDir: installOptions.enableModulesDir,
+          engineStrict: installOptions.engineStrict ?? config.engineStrict,
+          excludeLinksFromLockfile: installOptions.excludeLinksFromLockfile,
+          lockfileOnly: installOptions.lockfileOnly,
+          minimumReleaseAge: installOptions.minimumReleaseAge,
+          minimumReleaseAgeExclude: installOptions.minimumReleaseAgeExclude,
+          neverBuiltDependencies: installOptions.neverBuiltDependencies,
+          allowScripts: installOptions.allowScripts,
+          dangerouslyAllowAllScripts: installOptions.dangerouslyAllowAllScripts,
+          nodeLinker: installOptions.nodeLinker,
+          nodeVersion: installOptions.nodeVersion ?? config.nodeVersion,
+          includeOptionalDeps: installOptions.includeOptionalDeps,
+          ignorePackageManifest: installOptions.ignorePackageManifest,
+          dedupeInjectedDeps: installOptions.dedupeInjectedDeps ?? false,
+          dryRun: installOptions.dependenciesGraph == null && installOptions.dryRun,
+          overrides: installOptions.overrides,
+          hoistPattern,
+          publicHoistPattern: config.shamefullyHoist
+            ? ['*']
+            : ['@eslint/plugin-*', '*eslint-plugin*', '@prettier/plugin-*', '*prettier-plugin-*'],
+          hoistWorkspacePackages: installOptions.hoistWorkspacePackages ?? false,
+          hoistInjectedDependencies: installOptions.hoistInjectedDependencies,
+          packageImportMethod: installOptions.packageImportMethod ?? config.packageImportMethod,
+          enableGlobalVirtualStore: installOptions.enableGlobalVirtualStore,
+          globalVirtualStoreDir: installOptions.globalVirtualStoreDir,
+          patchedDependencies: installOptions.patchedDependencies,
+          packageExtensions: installOptions.packageExtensions,
+          preferOffline: installOptions.preferOffline,
+          rootComponents: installOptions.rootComponents,
+          rootComponentsForCapsules: installOptions.rootComponentsForCapsules,
+          sideEffectsCacheRead: installOptions.sideEffectsCache ?? true,
+          sideEffectsCacheWrite: installOptions.sideEffectsCache ?? true,
+          pnpmHomeDir: config.pnpmHomeDir,
+          updateAll: installOptions.updateAll,
+          hidePackageManagerOutput: installOptions.hidePackageManagerOutput,
+          reportOptions: {
+            appendOnly: installOptions.optimizeReportForNonTerminal,
+            outputStream: process.env.BIT_CLI_SERVER_NO_TTY ? new ServerSendOutStream() : undefined,
+            throttleProgress: installOptions.throttleProgress,
+            hideProgressPrefix: installOptions.hideProgressPrefix,
+            hideLifecycleOutput: installOptions.hideLifecycleOutput,
+            peerDependencyRules: installOptions.peerDependencyRules,
+          },
+          returnListOfDepsRequiringBuild: installOptions.returnListOfDepsRequiringBuild,
+          forcedHarmonyVersion: installOptions.forcedHarmonyVersion,
         },
-        returnListOfDepsRequiringBuild: installOptions.returnListOfDepsRequiringBuild,
-        forcedHarmonyVersion: installOptions.forcedHarmonyVersion,
-      },
-      this.logger
-    );
+        this.logger
+      );
+    } finally {
+      this.logger.profile('install.pnpm.core');
+    }
+    const { dependenciesChanged, rebuild, storeDir, depsRequiringBuild } = installResult;
     if (!installOptions.hidePackageManagerOutput) {
       this.logger.on();
       // Make a divider row to improve output

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -147,12 +147,21 @@ export class PnpmPackageManager implements PackageManager {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const { install } = require('./lynx');
 
-    this.logger.profile('install.pnpm.readConfig');
-    const registries = await this.depResolver.getRegistries();
-    const proxyConfig = await this.depResolver.getProxyConfig();
-    const networkConfig = await this.depResolver.getNetworkConfig();
-    const { config } = await this.readConfig(installOptions.packageManagerConfigRootDir);
-    this.logger.profile('install.pnpm.readConfig');
+    const { registries, proxyConfig, networkConfig, config } = await this.logger.profileAsync(
+      'install.pnpm.readConfig',
+      async () => {
+        const readRegistries = await this.depResolver.getRegistries();
+        const readProxyConfig = await this.depResolver.getProxyConfig();
+        const readNetworkConfig = await this.depResolver.getNetworkConfig();
+        const { config: readConfigResult } = await this.readConfig(installOptions.packageManagerConfigRootDir);
+        return {
+          registries: readRegistries,
+          proxyConfig: readProxyConfig,
+          networkConfig: readNetworkConfig,
+          config: readConfigResult,
+        };
+      }
+    );
     if (
       installOptions.dependenciesGraph &&
       (installOptions.rootComponents || installOptions.rootComponentsForCapsules)
@@ -198,15 +207,13 @@ export class PnpmPackageManager implements PackageManager {
     // packages this process already loaded modules from must stay requireable even if this install
     // re-keys them to a new peer hash - see preserve-loaded-virtual-store-dirs.ts
     const loadedVirtualStoreDirs = snapshotLoadedVirtualStoreDirs(rootDir);
-    this.logger.profile('install.pnpm.core');
-    let installResult: {
+    const installResult = await this.logger.profileAsync<{
       dependenciesChanged: boolean;
       rebuild: RebuildFn;
       storeDir: string;
       depsRequiringBuild?: DepPath[];
-    };
-    try {
-      installResult = await install(
+    }>('install.pnpm.core', () =>
+      install(
         rootDir,
         manifests,
         config.storeDir,
@@ -264,10 +271,8 @@ export class PnpmPackageManager implements PackageManager {
           forcedHarmonyVersion: installOptions.forcedHarmonyVersion,
         },
         this.logger
-      );
-    } finally {
-      this.logger.profile('install.pnpm.core');
-    }
+      )
+    );
     const { dependenciesChanged, rebuild, storeDir, depsRequiringBuild } = installResult;
     if (!installOptions.hidePackageManagerOutput) {
       this.logger.on();

--- a/scopes/harmony/logger/logger.ts
+++ b/scopes/harmony/logger/logger.ts
@@ -151,6 +151,20 @@ export class Logger implements IBitLogger {
   }
 
   /**
+   * profile the given async function. opens the timer before invoking it and always closes it in
+   * a `finally`, so a rejection doesn't leave the measurement open - which would otherwise cause
+   * the next call using this id to (wrongly) close it and report a duration spanning both calls.
+   */
+  async profileAsync<T>(id: string, fn: () => Promise<T>, console?: boolean): Promise<T> {
+    this.profile(id, console);
+    try {
+      return await fn();
+    } finally {
+      this.profile(id, console);
+    }
+  }
+
+  /**
    * print to the screen with a red `✖` prefix. if message is empty, print the last logged message.
    */
   consoleFailure(message?: string) {

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -363,6 +363,14 @@ export class InstallMain {
 
   private async _installModules(options?: ModulesInstallOptions): Promise<ComponentMap<string>> {
     this.logger.profile('install.total');
+    try {
+      return await this._installModulesProfiled(options);
+    } finally {
+      this.logger.profile('install.total');
+    }
+  }
+
+  private async _installModulesProfiled(options?: ModulesInstallOptions): Promise<ComponentMap<string>> {
     if (options?.allowScripts) {
       this.dependencyResolver.updateAllowedScripts(options.allowScripts);
       await this.dependencyResolver.persistConfig('update allowScripts configuration');
@@ -394,25 +402,24 @@ export class InstallMain {
       linkDepsResolvedFromEnv: !hasRootComponents,
       linkNestedDepsInNM: !this.workspace.isLegacy && !hasRootComponents,
     };
-    this.logger.profile('install.calculateLinks');
-    const { linkedRootDeps } = await this.calculateLinks(linkOpts);
-    this.logger.profile('install.calculateLinks');
-    this.logger.profile('install.getComponentManifests');
-    // eslint-disable-next-line prefer-const
-    let { mergedRootPolicy, componentsAndManifests: current } = await this._getComponentsManifestsAndRootPolicy(
-      installer,
-      {
-        ...calcManifestsOpts,
-        addMissingDeps: options?.addMissingDeps,
-        skipUnavailable: options?.skipUnavailable,
-        linkedRootDeps,
-      }
+    const { linkedRootDeps } = await this.logger.profileAsync('install.calculateLinks', () =>
+      this.calculateLinks(linkOpts)
     );
-    this.logger.profile('install.getComponentManifests');
+    // eslint-disable-next-line prefer-const
+    let { mergedRootPolicy, componentsAndManifests: current } = await this.logger.profileAsync(
+      'install.getComponentManifests',
+      () =>
+        this._getComponentsManifestsAndRootPolicy(installer, {
+          ...calcManifestsOpts,
+          addMissingDeps: options?.addMissingDeps,
+          skipUnavailable: options?.skipUnavailable,
+          linkedRootDeps,
+        })
+    );
 
-    this.logger.profile('install.resolveDependenciesGraph');
-    const dependenciesGraph = await this.resolveDependenciesGraph(options, { hasRootComponents });
-    this.logger.profile('install.resolveDependenciesGraph');
+    const dependenciesGraph = await this.logger.profileAsync('install.resolveDependenciesGraph', () =>
+      this.resolveDependenciesGraph(options, { hasRootComponents })
+    );
     const pmInstallOptions: PackageManagerInstallOptions = {
       ...calcManifestsOpts,
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
@@ -452,30 +459,28 @@ export class InstallMain {
       // are not added to the manifests.
       // This is an issue when installation is done using root components.
       hasMissingLocalComponents = hasRootComponents && hasComponentsFromWorkspaceInMissingDeps(current);
-      let installResult: { dependenciesChanged: boolean };
-      this.logger.profile('install.packageManagerInstall');
-      try {
-        installResult = await installer.installComponents(
-          this.workspace.path,
-          current.manifests,
-          mergedRootPolicy,
-          current.componentDirectoryMap,
-          {
-            linkedDependencies,
-            installTeambitBit: false,
-            forcedHarmonyVersion,
-          },
-          pmInstallOptions
-        );
-      } catch (err: any) {
-        // when the package manager can't find a version, the culprit is usually a component dependency that
-        // resolves to a snap which was never published (e.g. a hidden lane update-dependent whose Ripple build
-        // failed or hasn't completed). replace the cryptic "No matching version found" with an actionable
-        // message. re-throws the original error otherwise.
-        throw this.enrichUnpublishedSnapDepError(err, current.componentDirectoryMap.components);
-      } finally {
-        this.logger.profile('install.packageManagerInstall');
-      }
+      const installResult = await this.logger.profileAsync('install.packageManagerInstall', async () => {
+        try {
+          return await installer.installComponents(
+            this.workspace.path,
+            current.manifests,
+            mergedRootPolicy,
+            current.componentDirectoryMap,
+            {
+              linkedDependencies,
+              installTeambitBit: false,
+              forcedHarmonyVersion,
+            },
+            pmInstallOptions
+          );
+        } catch (err: any) {
+          // when the package manager can't find a version, the culprit is usually a component dependency that
+          // resolves to a snap which was never published (e.g. a hidden lane update-dependent whose Ripple build
+          // failed or hasn't completed). replace the cryptic "No matching version found" with an actionable
+          // message. re-throws the original error otherwise.
+          throw this.enrichUnpublishedSnapDepError(err, current.componentDirectoryMap.components);
+        }
+      });
       const { dependenciesChanged } = installResult;
       this.workspace.inInstallAfterPmContext = true;
       // the install that switches a workspace onto the global virtual store runs with bootstrap's
@@ -486,19 +491,13 @@ export class InstallMain {
         ensureHoistedDependencyResolution(this.workspace.path);
       }
       let cacheCleared = false;
-      this.logger.profile('install.linkCodemods');
-      await this.linkCodemods(compDirMap);
-      this.logger.profile('install.linkCodemods');
-      this.logger.profile('install.syncCoreAspectLinksForEnvs');
-      await this.syncCoreAspectLinksForEnvs(compDirMap);
-      this.logger.profile('install.syncCoreAspectLinksForEnvs');
+      await this.logger.profileAsync('install.linkCodemods', () => this.linkCodemods(compDirMap));
+      await this.logger.profileAsync('install.syncCoreAspectLinksForEnvs', () =>
+        this.syncCoreAspectLinksForEnvs(compDirMap)
+      );
       const oldNonLoadedEnvs = this.setOldNonLoadedEnvs();
-      this.logger.profile('install.reloadMovedEnvs');
-      await this.reloadMovedEnvs();
-      this.logger.profile('install.reloadMovedEnvs');
-      this.logger.profile('install.reloadNonLoadedEnvs');
-      await this.reloadNonLoadedEnvs();
-      this.logger.profile('install.reloadNonLoadedEnvs');
+      await this.logger.profileAsync('install.reloadMovedEnvs', () => this.reloadMovedEnvs());
+      await this.logger.profileAsync('install.reloadNonLoadedEnvs', () => this.reloadNonLoadedEnvs());
 
       const shouldClearCacheOnInstall = this.shouldClearCacheOnInstall();
       if (options?.compile ?? true) {
@@ -510,14 +509,12 @@ export class InstallMain {
           // incorrectly in case the env was not loaded correctly before the installation.
           // We don't want to clear the failed to load envs because we want to show the warning at the end
           // await this.workspace.clearCache({ skipClearFailedToLoadEnvs: true });
-          this.logger.profile('install.clearCache');
-          await this.workspace.clearCache();
-          this.logger.profile('install.clearCache');
+          await this.logger.profileAsync('install.clearCache', () => this.workspace.clearCache());
           cacheCleared = true;
         }
-        this.logger.profile('install.compile');
-        await this.compiler.compileOnWorkspace([], { initiator: CompilationInitiator.Install });
-        this.logger.profile('install.compile');
+        await this.logger.profileAsync('install.compile', () =>
+          this.compiler.compileOnWorkspace([], { initiator: CompilationInitiator.Install })
+        );
 
         // Right now we don't need to load extensions/execute load slot at this point
         // await this.compiler.compileOnWorkspace([], { initiator: CompilationInitiator.Install }, undefined, {
@@ -527,9 +524,9 @@ export class InstallMain {
         this.logger.consoleSuccess(compileOutputMessage, compileStartTime);
       }
       if (options?.writeConfigFiles ?? true) {
-        this.logger.profile('install.writeConfigFiles');
-        await this.tryWriteConfigFiles(!cacheCleared && shouldClearCacheOnInstall);
-        this.logger.profile('install.writeConfigFiles');
+        await this.logger.profileAsync('install.writeConfigFiles', () =>
+          this.tryWriteConfigFiles(!cacheCleared && shouldClearCacheOnInstall)
+        );
       }
       if (!dependenciesChanged) break;
       if (!options?.recurringInstall) break;
@@ -542,13 +539,13 @@ export class InstallMain {
         // We need to clear cache before creating the new component manifests.
         // this.workspace.consumer.componentLoader.clearComponentsCache();
         // We don't want to clear the failed to load envs because we want to show the warning at the end
-        this.logger.profile('install.clearCache');
-        await this.workspace.clearCache({ skipClearFailedToLoadEnvs: true });
-        this.logger.profile('install.clearCache');
+        await this.logger.profileAsync('install.clearCache', () =>
+          this.workspace.clearCache({ skipClearFailedToLoadEnvs: true })
+        );
       }
-      this.logger.profile('install.getComponentManifests');
-      current = await this._getComponentsManifests(installer, mergedRootPolicy, calcManifestsOpts);
-      this.logger.profile('install.getComponentManifests');
+      current = await this.logger.profileAsync('install.getComponentManifests', () =>
+        this._getComponentsManifests(installer, mergedRootPolicy, calcManifestsOpts)
+      );
       installCycle += 1;
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
     // the core aspects are compiled by now, so drop the links added above and let the envs resolve
@@ -557,19 +554,16 @@ export class InstallMain {
     if (!options?.lockfileOnly && !options?.skipPrune) {
       // We clean node_modules only after the last install.
       // Otherwise, we might load an env from a location that we later remove.
-      this.logger.profile('install.pruneModules');
-      try {
-        await installer.pruneModules(this.workspace.path);
-        // Ignoring the error here as it's not critical and we don't want to fail the install process
-      } catch (err: any) {
-        this.logger.error(`failed running pnpm prune with error`, err);
-      } finally {
-        this.logger.profile('install.pruneModules');
-      }
+      await this.logger.profileAsync('install.pruneModules', async () => {
+        try {
+          await installer.pruneModules(this.workspace.path);
+          // Ignoring the error here as it's not critical and we don't want to fail the install process
+        } catch (err: any) {
+          this.logger.error(`failed running pnpm prune with error`, err);
+        }
+      });
       // After pruning we need reload moved envs, as during the pruning the old location might be deleted
-      this.logger.profile('install.reloadMovedEnvs');
-      await this.reloadMovedEnvs();
-      this.logger.profile('install.reloadMovedEnvs');
+      await this.logger.profileAsync('install.reloadMovedEnvs', () => this.reloadMovedEnvs());
     }
     // this is now commented out because we assume we don't need it anymore.
     // even when the env was not loaded before and it is loaded now, it should be fine because the dependencies-data
@@ -577,7 +571,6 @@ export class InstallMain {
     // disregard the dependencies-cache.
     // await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
     /* eslint-enable no-await-in-loop */
-    this.logger.profile('install.total');
     return current.componentDirectoryMap;
   }
 

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -362,6 +362,7 @@ export class InstallMain {
   }
 
   private async _installModules(options?: ModulesInstallOptions): Promise<ComponentMap<string>> {
+    this.logger.profile('install.total');
     if (options?.allowScripts) {
       this.dependencyResolver.updateAllowedScripts(options.allowScripts);
       await this.dependencyResolver.persistConfig('update allowScripts configuration');
@@ -393,7 +394,10 @@ export class InstallMain {
       linkDepsResolvedFromEnv: !hasRootComponents,
       linkNestedDepsInNM: !this.workspace.isLegacy && !hasRootComponents,
     };
+    this.logger.profile('install.calculateLinks');
     const { linkedRootDeps } = await this.calculateLinks(linkOpts);
+    this.logger.profile('install.calculateLinks');
+    this.logger.profile('install.getComponentManifests');
     // eslint-disable-next-line prefer-const
     let { mergedRootPolicy, componentsAndManifests: current } = await this._getComponentsManifestsAndRootPolicy(
       installer,
@@ -404,8 +408,11 @@ export class InstallMain {
         linkedRootDeps,
       }
     );
+    this.logger.profile('install.getComponentManifests');
 
+    this.logger.profile('install.resolveDependenciesGraph');
     const dependenciesGraph = await this.resolveDependenciesGraph(options, { hasRootComponents });
+    this.logger.profile('install.resolveDependenciesGraph');
     const pmInstallOptions: PackageManagerInstallOptions = {
       ...calcManifestsOpts,
       autoInstallPeers: this.dependencyResolver.config.autoInstallPeers,
@@ -446,6 +453,7 @@ export class InstallMain {
       // This is an issue when installation is done using root components.
       hasMissingLocalComponents = hasRootComponents && hasComponentsFromWorkspaceInMissingDeps(current);
       let installResult: { dependenciesChanged: boolean };
+      this.logger.profile('install.packageManagerInstall');
       try {
         installResult = await installer.installComponents(
           this.workspace.path,
@@ -465,6 +473,8 @@ export class InstallMain {
         // failed or hasn't completed). replace the cryptic "No matching version found" with an actionable
         // message. re-throws the original error otherwise.
         throw this.enrichUnpublishedSnapDepError(err, current.componentDirectoryMap.components);
+      } finally {
+        this.logger.profile('install.packageManagerInstall');
       }
       const { dependenciesChanged } = installResult;
       this.workspace.inInstallAfterPmContext = true;
@@ -476,11 +486,19 @@ export class InstallMain {
         ensureHoistedDependencyResolution(this.workspace.path);
       }
       let cacheCleared = false;
+      this.logger.profile('install.linkCodemods');
       await this.linkCodemods(compDirMap);
+      this.logger.profile('install.linkCodemods');
+      this.logger.profile('install.syncCoreAspectLinksForEnvs');
       await this.syncCoreAspectLinksForEnvs(compDirMap);
+      this.logger.profile('install.syncCoreAspectLinksForEnvs');
       const oldNonLoadedEnvs = this.setOldNonLoadedEnvs();
+      this.logger.profile('install.reloadMovedEnvs');
       await this.reloadMovedEnvs();
+      this.logger.profile('install.reloadMovedEnvs');
+      this.logger.profile('install.reloadNonLoadedEnvs');
       await this.reloadNonLoadedEnvs();
+      this.logger.profile('install.reloadNonLoadedEnvs');
 
       const shouldClearCacheOnInstall = this.shouldClearCacheOnInstall();
       if (options?.compile ?? true) {
@@ -492,10 +510,14 @@ export class InstallMain {
           // incorrectly in case the env was not loaded correctly before the installation.
           // We don't want to clear the failed to load envs because we want to show the warning at the end
           // await this.workspace.clearCache({ skipClearFailedToLoadEnvs: true });
+          this.logger.profile('install.clearCache');
           await this.workspace.clearCache();
+          this.logger.profile('install.clearCache');
           cacheCleared = true;
         }
+        this.logger.profile('install.compile');
         await this.compiler.compileOnWorkspace([], { initiator: CompilationInitiator.Install });
+        this.logger.profile('install.compile');
 
         // Right now we don't need to load extensions/execute load slot at this point
         // await this.compiler.compileOnWorkspace([], { initiator: CompilationInitiator.Install }, undefined, {
@@ -505,7 +527,9 @@ export class InstallMain {
         this.logger.consoleSuccess(compileOutputMessage, compileStartTime);
       }
       if (options?.writeConfigFiles ?? true) {
+        this.logger.profile('install.writeConfigFiles');
         await this.tryWriteConfigFiles(!cacheCleared && shouldClearCacheOnInstall);
+        this.logger.profile('install.writeConfigFiles');
       }
       if (!dependenciesChanged) break;
       if (!options?.recurringInstall) break;
@@ -518,9 +542,13 @@ export class InstallMain {
         // We need to clear cache before creating the new component manifests.
         // this.workspace.consumer.componentLoader.clearComponentsCache();
         // We don't want to clear the failed to load envs because we want to show the warning at the end
+        this.logger.profile('install.clearCache');
         await this.workspace.clearCache({ skipClearFailedToLoadEnvs: true });
+        this.logger.profile('install.clearCache');
       }
+      this.logger.profile('install.getComponentManifests');
       current = await this._getComponentsManifests(installer, mergedRootPolicy, calcManifestsOpts);
+      this.logger.profile('install.getComponentManifests');
       installCycle += 1;
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
     // the core aspects are compiled by now, so drop the links added above and let the envs resolve
@@ -529,14 +557,19 @@ export class InstallMain {
     if (!options?.lockfileOnly && !options?.skipPrune) {
       // We clean node_modules only after the last install.
       // Otherwise, we might load an env from a location that we later remove.
+      this.logger.profile('install.pruneModules');
       try {
         await installer.pruneModules(this.workspace.path);
         // Ignoring the error here as it's not critical and we don't want to fail the install process
       } catch (err: any) {
         this.logger.error(`failed running pnpm prune with error`, err);
+      } finally {
+        this.logger.profile('install.pruneModules');
       }
       // After pruning we need reload moved envs, as during the pruning the old location might be deleted
+      this.logger.profile('install.reloadMovedEnvs');
       await this.reloadMovedEnvs();
+      this.logger.profile('install.reloadMovedEnvs');
     }
     // this is now commented out because we assume we don't need it anymore.
     // even when the env was not loaded before and it is loaded now, it should be fine because the dependencies-data
@@ -544,6 +577,7 @@ export class InstallMain {
     // disregard the dependencies-cache.
     // await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
     /* eslint-enable no-await-in-loop */
+    this.logger.profile('install.total');
     return current.componentDirectoryMap;
   }
 


### PR DESCRIPTION
## Summary
- Add `logger.profile()` timing around each phase of `bit install` (link calculation, manifest generation, the package-manager/pnpm install, codemod linking, env reloads, cache clear, compile, config-file writes, prune)
- Add a dedicated `install.pnpm.core` timer isolating pure pnpm work in `pnpm.package-manager.ts`, separate from Bit-side overhead
- Fix `logger.profile()` to always write timing to `debug.log`, and additionally echo to the screen when `BIT_LOG=profile` is set (previously it was one or the other)

## Usage
Run with `BIT_LOG=profile bit install` to see live phase timings on screen; they're always recorded in `debug.log` too.

## Test plan
- [x] `npm run lint` (tsc + oxlint) passes with no new errors
- [x] Updated `pnpm.package-manager.spec.ts` mock logger to include `profile()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApsAidMPTXivbp9bFjcggE