### PR TITLE
test: assign a compiler env to the component peer dependency

### DIFF
--- a/e2e/functionalities/peer-dependencies.e2e.ts
+++ b/e2e/functionalities/peer-dependencies.e2e.ts
@@ -111,6 +111,8 @@ describe('peer-dependencies functionality', function () {
         'custom-env/env1'
       );
       helper.extensions.addExtensionToVariant('comp1', `${helper.scopes.remote}/custom-env/env1`, {});
+      // The peer needs a compiler too because comp1 references its TypeScript project during the build.
+      helper.extensions.addExtensionToVariant('comp2', `${helper.scopes.remote}/custom-env/env1`, {});
       helper.extensions.addExtensionToVariant('custom-env', 'teambit.envs/env', {});
       helper.workspaceJsonc.addPolicyToDependencyResolver({
         peerDependencies: { [`@${helper.scopes.remote}/comp2`]: '*' },


### PR DESCRIPTION
## Proposed Changes

The component-peer dependency e2e test gives `comp1` a custom TypeScript env but leaves `comp2` on the empty default env. With root components enabled, `comp1` references `comp2` as a TypeScript project even though the peer has no compiler to generate its tsconfig.

Assign the same custom env to `comp2` so both projects have a compiler. This fixes the test fixture while preserving its peer-dependency and hidden-peer assertions; it does not change the external compiler's handling of non-TypeScript dependencies.

Validation: `npm run lint` and `git diff --check` pass. Focused e2e runs were attempted under Node 22 with the local compiler reference-pruning patch disabled, but both original and corrected setups hit 18 unrelated local type errors mixing checkout types with an installed Bit version. A clean CI e2e result is still needed.
