### PR TITLE
docs(host-initializer): expand generated agent instructions

### DIFF
--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -117,7 +117,7 @@ bit validate                         # lint + type-check + tests (fast build) �
 bit test                             # run tests only
 bit lint                             # run linter only
 bit check-types --strict             # TypeScript type checker only (without --strict it exits 0 even on errors)
-bit ripple list --lane <scope>/<lane> # find the Ripple CI jobs for a lane
+bit ripple list --lane <scope>/<lane> # find the Ripple CI jobs for a lane (lane name is the sanitized branch)
 bit ripple log <job-id>              # check a Ripple CI build's status
 bit ripple errors <job-id>           # show build errors for a Ripple CI job
 bit ripple retry <job-id>            # retry a failed Ripple CI job
@@ -272,11 +272,13 @@ git push                                 # push your branch
 Those CI builds run as Ripple CI jobs on bit.cloud. **Identify the job explicitly** — the bare `bit ripple log` resolves a job from your current lane or from a local export record, and in a Git-integrated workspace you're on main and CI did the exporting, so it has neither to work from. Find the job first, then pass its id:
 
 ```bash
-bit ripple list --lane <scope>/<branch-name>   # the lane CI created from your Git branch
-bit ripple log <job-id>                        # follow that job
-bit ripple errors <job-id>                     # build errors for a failing job
-bit ripple retry <job-id>                      # retry a failed job
+bit ripple list --lane <default-scope>/<lane-name>   # the lane CI created from your Git branch
+bit ripple log <job-id>                              # follow that job
+bit ripple errors <job-id>                           # build errors for a failing job
+bit ripple retry <job-id>                            # retry a failed job
 ```
+
+The lane name is **not** the raw branch name: CI lowercases the branch and replaces every `/` and `.` with `-`, then prefixes the workspace's default scope. So branch `feature/New.Component` in scope `acme.billing` becomes lane `acme.billing/feature-new-component`. Derive it that way, or read the lane straight out of the CI job output.
 
 **Give the user the build link as soon as CI starts a job.** Don't sit silently through the build and don't wait for it to go green — post the link, then report the outcome once it finishes.
 
@@ -469,10 +471,10 @@ You never run the export yourself — CI does, at two separate points:
 So a build exists from the moment the PR opens. Don't wait for the merge to start reporting: follow the PR build and hand the user its link, then do the same again after the merge.
 
 ```bash
-bit ripple list --lane <scope>/<branch-name>   # find the job CI created
-bit ripple log <job-id>                        # build status
-bit ripple errors <job-id>                     # why a build failed
-bit ripple retry <job-id>                      # retry a failed job
+bit ripple list --lane <default-scope>/<lane-name>   # find the job CI created (see lane naming above)
+bit ripple log <job-id>                              # build status
+bit ripple errors <job-id>                           # why a build failed
+bit ripple retry <job-id>                            # retry a failed job
 ```
 
 Copy the URL that `bit ripple log` prints; never assemble one by hand. Its last segment is the job's slug, not the display name, so a hand-built link lands on "No CI job found".

--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -116,11 +116,11 @@ bit compile                          # rebuild dist/ — automatic while bit wat
 bit validate                         # lint + type-check + tests (fast build) — preferred check
 bit test                             # run tests only
 bit lint                             # run linter only
-bit check-types                      # TypeScript type checker only
-bit ripple list                      # recent Ripple CI jobs on bit.cloud
-bit ripple log                       # check a Ripple CI build's status
-bit ripple errors                    # show build errors for a Ripple CI job
-bit ripple retry                     # retry a failed Ripple CI job
+bit check-types --strict             # TypeScript type checker only (without --strict it exits 0 even on errors)
+bit ripple list --lane <scope>/<lane> # find the Ripple CI jobs for a lane
+bit ripple log <job-id>              # check a Ripple CI build's status
+bit ripple errors <job-id>           # show build errors for a Ripple CI job
+bit ripple retry <job-id>            # retry a failed Ripple CI job
 ```
 
 > **Never run `bit build`** unless absolutely necessary. Always use `bit validate` instead — it's faster and sufficient.
@@ -130,7 +130,7 @@ bit ripple retry                     # retry a failed Ripple CI job
 > **Use Bit for type checking and testing.** Never use `tsc` or `npx tsc` directly. Use `bit validate` for a full check, or scope to specific components:
 >
 > ```bash
-> bit check-types "[component-id1, component-id2]"
+> bit check-types --strict "[component-id1, component-id2]"
 > bit test "[component-id1, component-id2]"
 > bit validate "[component-id1, component-id2]"
 > ```
@@ -269,13 +269,13 @@ git push                                 # push your branch
 
 > Focus on development workflows: component creation, modification, testing, and local validation. Leave versioning and publishing to CI.
 
-Those CI builds run as Ripple CI jobs on bit.cloud:
+Those CI builds run as Ripple CI jobs on bit.cloud. **Identify the job explicitly** — the bare `bit ripple log` resolves a job from your current lane or from a local export record, and in a Git-integrated workspace you're on main and CI did the exporting, so it has neither to work from. Find the job first, then pass its id:
 
 ```bash
-bit ripple list                      # recent jobs
-bit ripple log                       # follow a job
-bit ripple errors                    # build errors for a failing job
-bit ripple retry                     # retry a failed job
+bit ripple list --lane <scope>/<branch-name>   # the lane CI created from your Git branch
+bit ripple log <job-id>                        # follow that job
+bit ripple errors <job-id>                     # build errors for a failing job
+bit ripple retry <job-id>                      # retry a failed job
 ```
 
 **Give the user the build link as soon as CI starts a job.** Don't sit silently through the build and don't wait for it to go green — post the link, then report the outcome once it finishes.
@@ -336,7 +336,7 @@ There are two ways to compose an app. Decide before creating anything:
 
 - **Do NOT default to Harmony/Symphony — most projects do not need it.** For personal sites, MVPs, small-to-medium apps and single-team projects, use the simple `platform` composition below.
 - Use **Harmony** only for large enterprise platforms with multiple teams that need extensibility, plugin architecture and IoC — or when the user explicitly asks for it.
-- To tell what an existing workspace uses: check `workspace.jsonc` for `teambit.harmony/harmony`, or the code for `symphonyPlatform`. If neither is present, use simple platform composition.
+- To tell what an existing workspace uses: check `workspace.jsonc` for `bitdev.symphony/symphony-platform`, or the code for `symphonyPlatform`. If neither is present, use simple platform composition.
 - When it's unclear which fits, ask: _"Are you building a simple app/site, or an enterprise platform that multiple teams will extend?"_
 
 ### Simple platform composition
@@ -469,9 +469,10 @@ You never run the export yourself — CI does, at two separate points:
 So a build exists from the moment the PR opens. Don't wait for the merge to start reporting: follow the PR build and hand the user its link, then do the same again after the merge.
 
 ```bash
-bit ripple log          # build status
-bit ripple errors       # why a build failed
-bit ripple retry        # retry a failed job
+bit ripple list --lane <scope>/<branch-name>   # find the job CI created
+bit ripple log <job-id>                        # build status
+bit ripple errors <job-id>                     # why a build failed
+bit ripple retry <job-id>                      # retry a failed job
 ```
 
 Copy the URL that `bit ripple log` prints; never assemble one by hand. Its last segment is the job's slug, not the display name, so a hand-built link lands on "No CI job found".

--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -57,7 +57,7 @@ bit templates                        # see what generators are available
 
 ## Scopes & the Bit Cloud MCP
 
-A **scope** is a remote registry for one business domain — and the unit a full-stack feature ships as (see _Full-Stack Apps_). Every component ID is `<owner>.<scope>/<namespace>/<name>`.
+A **scope** is a remote registry for one business domain — and the unit a full-stack feature ships as (see _Full-Stack Apps_). A component ID is `<owner>.<scope>/<name>`, optionally with a namespace before the name: `<owner>.<scope>/<namespace>/<name>`. The namespace is optional — don't add one to an ID that doesn't have it.
 
 This workspace ships with a `.mcp.json` that wires up the **Bit Cloud MCP** server (`https://mcp.bit.cloud/mcp`); the agent will prompt for OAuth on first use. Anything remote — scopes, components, apps — goes through the MCP, not the CLI. The server advertises its own tools; two rules about _ordering_ them:
 
@@ -476,7 +476,7 @@ bit ripple retry        # retry a failed job
 
 Copy the URL that `bit ripple log` prints; never assemble one by hand. Its last segment is the job's slug, not the display name, so a hand-built link lands on "No CI job found".
 
-Once a build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it. Production apps are served on `*.composed.app`; the PR preview is deployed separately, so call `list_apps` again after the merge instead of reusing the preview link. Component-only releases (no app) have no URL at all; point the user at the scope page instead.
+Once a build succeeds, an app that defines a deployment is live — get its URL with the `list_apps` MCP tool, don't guess or construct it. Production apps are served on `*.composed.app`; the PR preview is deployed separately, so call `list_apps` again after the merge instead of reusing the preview link. Component-only releases have no URL at all, and neither does an app that defines no deployment — a green build on its own is not proof that anything was deployed. If `list_apps` gives you no URL, say so rather than implying the app is live, and point the user at the scope page instead.
 
 Custom domains are a Bit Cloud settings flow with no CLI equivalent — send the user to `https://bit.cloud/<owner>/~settings/deployment`. Never claim to have connected a domain yourself.
 

--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -44,20 +44,6 @@ The workspace is defined by `workspace.jsonc`. The owner and default scope are s
 
 ---
 
-## Bit Cloud MCP
-
-This workspace ships with a `.mcp.json` that wires up the **Bit Cloud MCP** server (`https://mcp.bit.cloud/mcp`). When the MCP is connected and authenticated (the agent will prompt for OAuth on first use), it is the fastest way to discover and inspect components that live in remote scopes — prefer it over reading source files or installing packages just to look around.
-
-Key tools to reach for:
-
-- **`read_scopes`** — list scopes and their components for a given `owner` (read from `workspace.jsonc`). Prefer this over broad `search` for discovery.
-- **`read_components`** — structured type signatures, dependencies, and metadata for one or more remote components, in a single call. API references are included by default.
-- **`search`** — keyword search across remote scopes.
-
-When in doubt, ask the MCP before scaffolding anything new. If the MCP is not connected, fall back to the local `bit` CLI commands (`bit list`, `bit show`, `bit schema`).
-
----
-
 ## Project Orientation
 
 ```bash
@@ -67,18 +53,48 @@ bit status                           # check for pending changes
 bit templates                        # see what generators are available
 ```
 
-When using the Bit Cloud MCP, always pass the `owner` from `workspace.jsonc`. Prefer `read_scopes` over `search` for broader discovery.
+---
+
+## Scopes & the Bit Cloud MCP
+
+A **scope** is a remote registry for one business domain — and the unit a full-stack feature ships as (see _Full-Stack Apps_). Every component ID is `<owner>.<scope>/<namespace>/<name>`.
+
+This workspace ships with a `.mcp.json` that wires up the **Bit Cloud MCP** server (`https://mcp.bit.cloud/mcp`); the agent will prompt for OAuth on first use. Anything remote — scopes, components, apps — goes through the MCP, not the CLI. The server advertises its own tools; two rules about _ordering_ them:
+
+- Start with `orientation` when you don't know the account's topology, then `read_scope` to go deep on one domain. Reach for `search_components` only when you don't know which scope owns something.
+- Always pass the `owner` from `workspace.jsonc`.
+
+**If the MCP isn't connected, don't stop** — the CLI can read remotes too, just less efficiently. `bit list <owner>.<scope>` lists a remote scope's components, `bit show <owner>.<scope>/<name> --remote` inspects one, and `bit search <query>` searches by keyword across both the local workspace and Bit Cloud. Say that the MCP is unavailable and carry on; only scope creation has no CLI fallback.
+
+### Creating a scope
+
+**Don't create a scope up front — create it before the code that needs it reaches CI.** `bit create <template> <name> --scope <owner>.<scope>` only records the scope ID locally, so you can build, validate and iterate against a scope that doesn't exist on Bit Cloud yet. Creating one you never publish to just leaves an empty scope on the account.
+
+The gate is the pull request: CI runs `bit export` on merge, and an export to a scope that doesn't exist fails. Before you open the PR, confirm every scope your components target exists (`read_scope` → `existsOnCloud`) and create the missing ones.
+
+Scopes cannot be created from the CLI — use the `create_scope` MCP tool, or https://bit.cloud/create-scope in the browser.
+
+**Look before you create.** Run `orientation` first — if the work fits a domain that already exists, put the components there. Create a scope only when the domain is genuinely new.
+
+```
+create_scope({ owner: 'acme', scopeName: 'billing', displayName: 'Billing', description: 'Invoicing and subscriptions' })
+```
+
+- `scopeName` — lowercase letters, digits and dashes, starting with a letter (2 chars minimum). The resulting ID is `<owner>.<scopeName>`.
+- `owner` — defaults to the current account. You must be the account owner or an admin of that organization, otherwise the call is denied.
+- `visibility` — optional, `public` or `private`. Defaults to public on the free plan and private on paid plans.
+- `confirmed` — on paid plans the first call returns a **preview instead of creating**. Show it to the user, get approval, then call again with `confirmed: true`. On the free plan the scope is created on the first call.
 
 ---
 
 ## Understanding Component APIs
 
-When you need to understand how to **use** a component (its props, function signatures, return types), prefer structured API data over reading source files:
+When you need to understand how to **use** a component (its props, function signatures, return types), use structured API data instead of reading source files:
 
-- **Remote components:** use `read_components` (Bit Cloud MCP) — returns structured type signatures, dependencies, and metadata in a single call. API references are included by default. As a CLI fallback, run `bit show <owner>.<scope>/<name>`.
-- **Local workspace components:** run `bit schema <component-id>` — returns exported types, function signatures, and class methods.
+- **Remote components**: Use `read_components` (Bit Cloud MCP) — returns structured type signatures, dependencies, and metadata in a single call. API references are included by default. As a CLI fallback, run `bit show <owner>.<scope>/<name> --remote`.
+- **Local workspace components**: Run `bit schema <component-id>` — displays exported types, function signatures, and class methods.
 
-For understanding implementation details (how something works internally), read the source directly.
+These structured APIs are significantly more compact than reading source files. For understanding implementation details (how something works internally), use `read-file` or read the source directly.
 
 ---
 
@@ -96,12 +112,15 @@ bit import "<owner>.<scope>/**"      # import all components from a remote scope
 bit templates                        # list available generator templates
 bit create <template> <name>         # scaffold a new component
 bit install [pkg1] [pkg2] ...        # install package dependencies
-bit compile                          # manual compile (usually auto — use for troubleshooting)
+bit compile                          # rebuild dist/ — automatic while bit watch/start runs, manual otherwise
 bit validate                         # lint + type-check + tests (fast build) — preferred check
 bit test                             # run tests only
 bit lint                             # run linter only
 bit check-types                      # TypeScript type checker only
-bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — list/log/errors/retry/stop (jobs that build components in the cloud after export)
+bit ripple list                      # recent Ripple CI jobs on bit.cloud
+bit ripple log                       # check a Ripple CI build's status
+bit ripple errors                    # show build errors for a Ripple CI job
+bit ripple retry                     # retry a failed Ripple CI job
 ```
 
 > **Never run `bit build`** unless absolutely necessary. Always use `bit validate` instead — it's faster and sufficient.
@@ -145,9 +164,9 @@ render → identify gap → create ONE component → render again
    bit show <owner>.<scope>/<name>      # inspect a candidate
    ```
 
-   And via the MCP: `read_scopes` for the workspace `owner` to see existing components, or `search` for keyword discovery. A component may already exist locally or remotely. Don't duplicate.
+   And via the MCP: `orientation` for the account's topology, `read_scope` for one domain's components, or `search_components` for keyword discovery. A component may already exist locally or remotely. Don't duplicate.
 
-2. **Identify the entry point.** Depending on what you're building, the entry point could be a platform, app, or feature/aspect. Use the MCP (`read_scopes` / `read_components`) to list what exists in the scope before creating anything new.
+2. **Identify the entry point.** Depending on what you're building, the entry point could be a platform, app, or feature/aspect. Use the MCP (`read_scope` / `read_components`) to list what exists in the scope before creating anything new.
 
 3. **Create one component.** Scaffold it, wire it in, verify it compiles and renders.
 
@@ -244,9 +263,22 @@ git push                                 # push your branch
 # open a PR; CI runs `bit snap` + `bit export` on merge.
 ```
 
+`bit validate` is a hard gate — never push a branch that fails it, because CI's build will fail for the same reason. And talk to the user in outcomes, not CLI verbs: "ship this to production", not "tag it".
+
+> **Before you open the PR**, make sure every scope your components publish to exists on Bit Cloud — check `existsOnCloud` via `read_scope` and create the missing ones with `create_scope` (see _Creating a scope_). CI's export fails on a scope that doesn't exist.
+
 > Focus on development workflows: component creation, modification, testing, and local validation. Leave versioning and publishing to CI.
 
-Those CI builds run as Ripple CI jobs on bit.cloud. Use `bit ripple list` to see recent jobs, `bit ripple log` to follow one, and `bit ripple errors` to inspect build failures.
+Those CI builds run as Ripple CI jobs on bit.cloud:
+
+```bash
+bit ripple list                      # recent jobs
+bit ripple log                       # follow a job
+bit ripple errors                    # build errors for a failing job
+bit ripple retry                     # retry a failed job
+```
+
+**Give the user the build link as soon as CI starts a job.** Don't sit silently through the build and don't wait for it to go green — post the link, then report the outcome once it finishes.
 
 ---
 
@@ -265,6 +297,8 @@ Each component directory follows this convention:
 | `*-type.ts`              | Standalone type definitions          |
 
 > Add JSDocs to exported APIs, include two to three usage examples in the `.docs.mdx`, and two to three compositions for the live preview.
+
+JSDoc on exported members isn't optional polish — it's what renders as the component's API reference on Bit Cloud, and it's the first thing another agent reads when deciding whether to reuse the component. For the same reason, avoid `any` in a public signature: it erases the API for every consumer, and `bit check-types` gates publishing.
 
 ---
 
@@ -296,7 +330,102 @@ Generator environments (React, Vue, Node, Angular, etc.) are configured in `work
 
 ---
 
-## Runtime Code Crossing Environment Boundaries
+## Full-Stack Apps
+
+There are two ways to compose an app. Decide before creating anything:
+
+- **Do NOT default to Harmony/Symphony — most projects do not need it.** For personal sites, MVPs, small-to-medium apps and single-team projects, use the simple `platform` composition below.
+- Use **Harmony** only for large enterprise platforms with multiple teams that need extensibility, plugin architecture and IoC — or when the user explicitly asks for it.
+- To tell what an existing workspace uses: check `workspace.jsonc` for `teambit.harmony/harmony`, or the code for `symphonyPlatform`. If neither is present, use simple platform composition.
+- When it's unclear which fits, ask: _"Are you building a simple app/site, or an enterprise platform that multiple teams will extend?"_
+
+### Simple platform composition
+
+Never hand-write boilerplate — scaffold with `bit create <template> <name>`, and run `bit templates` first to see what this workspace offers. If a template you need is missing, enable its env in `workspace.jsonc` generators.
+
+A full-stack app is **three components composed by a platform**:
+
+1. `bit create platform <name>-platform` — the deployable unit
+2. `bit create react-app <name>-app` — the frontend
+3. `bit create express-server <name>-service` — the backend (name it after its domain; use the `-service` suffix, never `-api` or `-backend`)
+
+Then compose the app and the service in the platform and run `bit run <name>-platform`. The platform assigns ports and proxies, so the frontend never needs to know the backend port.
+
+**Reaching the backend from the frontend.** The platform exposes the backend base URL to the React app as the `BACKEND_URL` environment variable — read it with `process.env.BACKEND_URL`:
+
+```ts
+fetch(`${process.env.BACKEND_URL}/api/users`, { credentials: 'include' });
+```
+
+Every cross-origin call to `BACKEND_URL` **must** pass `credentials: 'include'` — `credentials: 'include'` in `fetch`, or in the Apollo `HttpLink`. The platform gateway is configured for credentialed CORS (origin reflection plus `Access-Control-Allow-Credentials: true`), and without it the browser blocks the response. Do NOT add a Vite proxy or switch to relative paths as a workaround — the gateway already handles CORS correctly once credentials are included. This works the same way in Bit Cloud workspaces and in production.
+
+MongoDB is already provisioned at `process.env.MONGO_URL`; never add an in-memory store or ask the user to set up a database.
+
+Other common templates: `react`, `react-hook`, `react-theme` (UI); `module`, `entity`, `graphql-server` (Node).
+
+---
+
+## Harmony Platforms
+
+**This section applies ONLY when the workspace uses Harmony/Symphony — if it doesn't, ignore everything here and use the simple platform composition above.**
+
+Templates: `harmony-platform` (the platform), `aspect` (a domain that plugs into it), `platform-aspect` (the platform's entry aspect), `bit-aspect` (extend Bit itself).
+
+An aspect is one domain's full vertical — its `*.node.runtime.ts` holds GraphQL, database and routes, its `*.browser.runtime.tsx` holds pages and routing, and neither may import the other's modules. Features register themselves into the platform; the platform never imports a feature.
+
+### Backend Registration
+
+All GraphQL schemas and REST routes must be registered through `symphonyPlatform.registerBackendServer`. This is the only correct way — never use `registerMiddlewares` for endpoint logic.
+
+```ts
+symphonyPlatform.registerBackendServer([
+  {
+    name: 'ai',       // sets the gateway prefix: /ai/...
+    gql: gqlSchema,   // optional — omit if no GraphQL
+    routes: [
+      {
+        path: '/stream',
+        method: 'post',
+        route: async (req, res) => { ... },
+      },
+    ],
+  },
+]);
+```
+
+### UI Layout Registration
+
+`symphonyPlatform.registerLayoutEntry` registers a component **globally** — it renders on every page. Use it only for truly global sticky chrome like the top navigation header.
+
+**Never use it for footers or any element that should appear on specific pages only.** Instead, import the component and render it directly inside the relevant page component(s).
+
+```tsx
+// Wrong — makes footer appear on every page, sticky
+symphonyPlatform.registerLayoutEntry([{ position: 'bottom', component: () => <Footer /> }]);
+
+// Correct — add Footer directly inside the page
+export function Homepage() {
+  return (
+    <div>
+      {/* page content */}
+      <Footer />
+    </div>
+  );
+}
+```
+
+### Gateway Routing
+
+The Symphony gateway proxies frontend calls to the backend, stripping the aspect name prefix:
+
+```
+Frontend:  /api/{name}/{path}
+Backend receives:  /{path}
+```
+
+For example, `POST /api/ai/stream` → backend receives `POST /stream`. The frontend **must always** include the `/api` prefix.
+
+### Troubleshooting: Runtime Code Crossing Environment Boundaries
 
 Importing frontend modules into Node.js runtime files or Node.js modules into browser runtime files causes app initialization failures. This typically happens when `index.ts` or runtime files import/export cross-environment modules by value instead of by type.
 
@@ -328,18 +457,74 @@ export { User } from './user.js';
 
 ---
 
+## Deploying
+
+**There is nothing to configure.** Exporting is deploying: when CI exports the components on merge, Ripple CI builds them, detects the app framework from the build artifacts, and deploys to a managed container automatically. Never add a deployer config or tell the user to set one up.
+
+You don't trigger this — the merge does. Follow the build and inspect failures with:
+
+```bash
+bit ripple log          # build status
+bit ripple errors       # why a build failed
+bit ripple retry        # retry a failed job
+```
+
+Once the build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it. Production apps are served on `*.composed.app`. Component-only releases (no app) have no URL at all; point the user at the scope page instead.
+
+Custom domains are a Bit Cloud settings flow with no CLI equivalent — send the user to `https://bit.cloud/<owner>/~settings/deployment`. Never claim to have connected a domain yourself.
+
+---
+
+## Troubleshooting
+
+### The app doesn't reflect your change
+
+**Most likely the `dist/` is stale.** Consumers import a component through `node_modules/<package>/dist/`, not its source, and `bit validate` type-checks _source_ — so it passes green while the running app still serves the old build. `bit watch` / `bit start` normally recompiles on save, but if either isn't running, or the change landed while it was down, the old `dist/` sits there.
+
+```bash
+bit compile             # rebuild dist/
+# then restart the app
+```
+
+Do this **before** re-reading and re-editing files. If the source is already correct, editing it again cannot help — a passing `bit validate` plus wrong runtime behavior is the signature of this bug, not of a code error.
+
+If compiling and restarting doesn't help, run `bit install`, then restart again.
+
+### Seeded or mock data doesn't update
+
+Seed logic usually writes only into an empty collection, so changing a seed or a `*.model.ts` has no effect on a database that already has rows — the stale documents stay, and may not even match the new shape. Clear the affected collections before restarting, or version the seed (write a marker document and re-seed when the version changes) so it re-runs on its own.
+
+### GraphQL data missing or malformed
+
+The backend schema and the query the frontend sends have drifted apart. Compare the two directly; don't debug the UI.
+
+### Apollo test imports fail to resolve
+
+Import from `@apollo/client/testing/react/index.js` — not `@apollo/client/testing`.
+
+---
+
 ## Common Mistakes to Avoid
 
-| Mistake                                                    | Correct approach                                                                                                   |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Creating multiple components upfront                       | Create one, validate, then decide what's next                                                                      |
-| Modifying an installed (node_modules) component            | Import it with `bit import` first                                                                                  |
-| Importing only the target component but not its dependents | Import the full chain top-down: platform → app → feature → page → component                                        |
-| Treating all components as UI widgets                      | Understand the type first — platform, app, feature/aspect, hook, entity, or UI component — it determines the chain |
-| Running `bit build`                                        | Use `bit validate` instead — faster and sufficient                                                                 |
-| Running `bit snap`, `bit tag`, or `bit export` locally     | These are handled by CI/CD on merge — don't run them in the workspace                                              |
-| Creating or managing Bit lanes                             | Use Git branches instead — this workspace is Git-integrated                                                        |
-| Guessing a component ID                                    | Check `package.json` under `componentId` or use `bit list`                                                         |
-| Creating a component that already exists                   | Always run `bit list` and check the Bit Cloud MCP (`read_scopes` / `search`) first                                 |
-| Using `npm install`, `yarn`, or `pnpm`                     | Use `bit install`                                                                                                  |
-| Using `tsc` or `npx tsc` to check types                    | Use `bit validate`, `bit check-types`, or `bit test`                                                               |
+| Mistake                                                                         | Correct approach                                                                                                          |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Creating multiple components upfront                                            | Create one, validate, then decide what's next                                                                             |
+| Modifying an installed (node_modules) component                                 | Import it with `bit import` first                                                                                         |
+| Importing only the target component but not its dependents                      | Import the full chain top-down: platform → app → feature → page → component                                               |
+| Treating all components as UI widgets                                           | Understand the type first — platform, app, feature/aspect, hook, entity, or UI component — it determines the chain        |
+| Running `bit build`                                                             | Use `bit validate` instead — faster and sufficient                                                                        |
+| Running `bit snap`, `bit tag`, or `bit export` locally                          | These are handled by CI/CD on merge — don't run them in the workspace                                                     |
+| Creating or managing Bit lanes                                                  | Use Git branches instead — this workspace is Git-integrated                                                               |
+| Pushing a branch that fails `bit validate`                                      | Fix it first — CI's build fails for the same reason                                                                       |
+| Guessing a component ID                                                         | Check `package.json` under `componentId` or use `bit list`                                                                |
+| Creating a component that already exists                                        | Always run `bit list` and check the Bit Cloud MCP (`orientation` / `search_components`) first                             |
+| Using `npm install`, `yarn`, or `pnpm`                                          | Use `bit install` — unless the workspace uses `externalPackageManager` mode                                               |
+| Using `tsc` or `npx tsc` to check types                                         | Use `bit validate`, `bit check-types`, or `bit test`                                                                      |
+| Trying to create a scope from the CLI                                           | Scopes only exist on Bit Cloud — use the `create_scope` MCP tool                                                          |
+| Creating a scope for a domain that already has one                              | Run `read_scope` / `list_components` first — reuse the existing scope                                                     |
+| Creating a scope up front, before any code exists                               | Create it before you open the PR — that's the point CI needs it to exist                                                  |
+| Creating a scope without asking                                                 | Confirm the name, owner and visibility with the user; on paid plans preview first, then call again with `confirmed: true` |
+| Going quiet while CI builds                                                     | Post the Ripple CI job link as soon as there is one, then report the result                                               |
+| Making the platform import a feature aspect                                     | Inverted — the feature aspect imports the platform and registers itself                                                   |
+| Importing React/SCSS in a node runtime, or Node.js modules in a browser runtime | Keep runtime code on its own side of the boundary and out of `index.ts`                                                   |
+| Hand-writing a platform, aspect or app                                          | Scaffold it with `bit create` — run `bit templates` to see what's available                                               |

--- a/scopes/harmony/host-initializer/agents-template-git.md
+++ b/scopes/harmony/host-initializer/agents-template-git.md
@@ -8,7 +8,7 @@ This file teaches AI agents how to work correctly inside a **Git-integrated Bit 
 
 Bit is a composable development platform where every piece of functionality is an independent, versioned, composed **component**. Components live in **scopes** (remote registries of business domains) and are managed through the `bit` CLI.
 
-In this workspace, **Git is the source of truth** for source code and collaboration. Bit's component versioning (`bit snap`, `bit tag`, `bit export`) runs in CI/CD on merge — not locally.
+In this workspace, **Git is the source of truth** for source code and collaboration. Bit's component versioning (`bit snap`, `bit tag`, `bit export`) runs in CI/CD — not locally.
 
 ### Component Types
 
@@ -70,7 +70,7 @@ This workspace ships with a `.mcp.json` that wires up the **Bit Cloud MCP** serv
 
 **Don't create a scope up front — create it before the code that needs it reaches CI.** `bit create <template> <name> --scope <owner>.<scope>` only records the scope ID locally, so you can build, validate and iterate against a scope that doesn't exist on Bit Cloud yet. Creating one you never publish to just leaves an empty scope on the account.
 
-The gate is the pull request: CI runs `bit export` on merge, and an export to a scope that doesn't exist fails. Before you open the PR, confirm every scope your components target exists (`read_scope` → `existsOnCloud`) and create the missing ones.
+The gate is the pull request: CI exports as soon as the PR is opened, and an export to a scope that doesn't exist fails. Before you open the PR, confirm every scope your components target exists (`read_scope` → `existsOnCloud`) and create the missing ones.
 
 Scopes cannot be created from the CLI — use the `create_scope` MCP tool, or https://bit.cloud/create-scope in the browser.
 
@@ -245,11 +245,11 @@ bit import "<owner>.<scope>/**"
 
 ## Saving and Publishing Changes (Git-Integrated Workflow)
 
-**This workspace is Git-integrated.** Git owns version control of source code; Bit's snap/tag/export are handled automatically by CI/CD on merge. Your collaboration unit is the Git branch, not a Bit lane.
+**This workspace is Git-integrated.** Git owns version control of source code; Bit's snap/tag/export are handled automatically by CI/CD. Your collaboration unit is the Git branch, not a Bit lane.
 
 **Do not run locally:**
 
-- `bit snap`, `bit tag`, `bit export` — CI/CD handles these on merge.
+- `bit snap`, `bit tag`, `bit export` — CI/CD handles these when the PR opens and again on merge.
 - `bit lane create` and `bit lane` management — use Git branches instead.
 
 **Your workflow:**
@@ -260,7 +260,7 @@ git checkout -b <branch-name>            # create a feature branch
 bit validate                             # confirm no build errors
 git add . && git commit -m "describe change"
 git push                                 # push your branch
-# open a PR; CI runs `bit snap` + `bit export` on merge.
+# open a PR; CI snaps and exports a preview lane, then tags on merge.
 ```
 
 `bit validate` is a hard gate — never push a branch that fails it, because CI's build will fail for the same reason. And talk to the user in outcomes, not CLI verbs: "ship this to production", not "tag it".
@@ -459,9 +459,14 @@ export { User } from './user.js';
 
 ## Deploying
 
-**There is nothing to configure.** Exporting is deploying: when CI exports the components on merge, Ripple CI builds them, detects the app framework from the build artifacts, and deploys to a managed container automatically. Never add a deployer config or tell the user to set one up.
+**There is nothing to configure.** Exporting is deploying: Ripple CI builds the exported components, detects the app framework from the build artifacts, and deploys to a managed container automatically. Never add a deployer config or tell the user to set one up.
 
-You don't trigger this — the merge does. Follow the build and inspect failures with:
+You never run the export yourself — CI does, at two separate points:
+
+- **When the pull request is opened or updated** (`bit ci pr`) — CI snaps and exports a feature lane, producing a **preview** deployment before merge.
+- **When the PR merges to main** (`bit ci merge`) — CI tags semantic versions and exports them, producing the **production** deployment.
+
+So a build exists from the moment the PR opens. Don't wait for the merge to start reporting: follow the PR build and hand the user its link, then do the same again after the merge.
 
 ```bash
 bit ripple log          # build status
@@ -469,7 +474,9 @@ bit ripple errors       # why a build failed
 bit ripple retry        # retry a failed job
 ```
 
-Once the build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it. Production apps are served on `*.composed.app`. Component-only releases (no app) have no URL at all; point the user at the scope page instead.
+Copy the URL that `bit ripple log` prints; never assemble one by hand. Its last segment is the job's slug, not the display name, so a hand-built link lands on "No CI job found".
+
+Once a build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it. Production apps are served on `*.composed.app`; the PR preview is deployed separately, so call `list_apps` again after the merge instead of reusing the preview link. Component-only releases (no app) have no URL at all; point the user at the scope page instead.
 
 Custom domains are a Bit Cloud settings flow with no CLI equivalent — send the user to `https://bit.cloud/<owner>/~settings/deployment`. Never claim to have connected a domain yourself.
 
@@ -500,7 +507,7 @@ The backend schema and the query the frontend sends have drifted apart. Compare 
 
 ### Apollo test imports fail to resolve
 
-Import from `@apollo/client/testing/react/index.js` — not `@apollo/client/testing`.
+`@apollo/client/testing` is the normal import and works on most versions. Only when it genuinely fails to resolve, import from `@apollo/client/testing/react/index.js` instead — don't rewrite an import that already works.
 
 ---
 
@@ -513,7 +520,7 @@ Import from `@apollo/client/testing/react/index.js` — not `@apollo/client/test
 | Importing only the target component but not its dependents                      | Import the full chain top-down: platform → app → feature → page → component                                               |
 | Treating all components as UI widgets                                           | Understand the type first — platform, app, feature/aspect, hook, entity, or UI component — it determines the chain        |
 | Running `bit build`                                                             | Use `bit validate` instead — faster and sufficient                                                                        |
-| Running `bit snap`, `bit tag`, or `bit export` locally                          | These are handled by CI/CD on merge — don't run them in the workspace                                                     |
+| Running `bit snap`, `bit tag`, or `bit export` locally                          | These are handled by CI/CD — don't run them in the workspace                                                              |
 | Creating or managing Bit lanes                                                  | Use Git branches instead — this workspace is Git-integrated                                                               |
 | Pushing a branch that fails `bit validate`                                      | Fix it first — CI's build fails for the same reason                                                                       |
 | Guessing a component ID                                                         | Check `package.json` under `componentId` or use `bit list`                                                                |

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -68,7 +68,7 @@ Anything remote — scopes, components, lanes, change requests — goes through 
 
 **Don't create a scope up front — create it before you export.** `bit create <template> <name> --scope <owner>.<scope>` only records the scope ID locally, so you can build, validate and iterate against a scope that doesn't exist on Bit Cloud yet. The scope only has to exist by the time you publish, and creating one you never export to just leaves an empty scope on the account.
 
-The gate is right before `bit snap`, `bit tag` or `bit export`: for every scope you're about to publish to, confirm it exists (`read_scope` → `existsOnCloud`) and create the missing ones first. An export to a scope that doesn't exist fails.
+The gate is right before `bit export`: for every scope you're about to publish to, confirm it exists (`read_scope` → `existsOnCloud`) and create the missing ones first. An export to a scope that doesn't exist fails. `bit snap` and `bit tag` only write to the local scope, so they don't need it.
 
 Scopes cannot be created from the CLI — use the `create_scope` MCP tool, or https://bit.cloud/create-scope in the browser.
 
@@ -257,14 +257,23 @@ bit export                           # push lane to remote
 
 > Always check `bit lane current` first. If you're already on a non-main lane, continue using it — don't create a new one.
 
-> **Before snapping, tagging or exporting**, make sure every scope you're publishing to exists on Bit Cloud — check `existsOnCloud` via `read_scope` and create the missing ones with `create_scope` (see _Creating a scope_). This is the point at which a scope must exist; don't create it earlier.
+> **Before exporting**, make sure every scope you're publishing to exists on Bit Cloud — check `existsOnCloud` via `read_scope` and create the missing ones with `create_scope` (see _Creating a scope_). This is the point at which a scope must exist; don't create it earlier.
 
 ### `bit snap` vs `bit tag`
 
 Where you are decides which one you run — it is not a preference:
 
 - **On a lane → `bit snap`.** Produces a hash, no version number. This is the default path.
-- **On main → `bit tag`.** Produces a semver version, releasing to production. Bumps the patch by default; use `--minor` / `--major` only when the user describes a minor, major, or breaking release.
+- **On main → `bit tag`.** Produces a semver version. Bumps the patch by default; use `--minor` / `--major` only when the user describes a minor, major, or breaking release.
+
+Both only write to the local scope. **`bit export` is what publishes** — until it runs, nothing has reached the remote scope or the deployment pipeline. Releasing to production from main is therefore tag _then_ export:
+
+```bash
+bit validate                         # hard gate
+bit tag --message "describe release"
+bit export
+bit ripple log                       # post the build link straight away
+```
 
 `bit tag` is **only possible on main** — it is not a thing you can do on a lane, so there is no choice to make once `bit lane current` tells you where you are. On a lane, snap. And even on main, tagging is rejected when the scope protects `main` or the account requires review; then the lane workflow is the only path (see _When main is protected_).
 
@@ -490,11 +499,9 @@ bit ripple errors       # why a build failed
 bit ripple retry        # retry a failed job
 ```
 
-**Give the user the build link as soon as you have it.** Right after `bit export` returns, run `bit ripple log` to pick up the job and post the link — don't sit silently through the build and don't wait for it to go green. The user can watch progress themselves, and if it fails they already have the page open:
+**Give the user the build link as soon as you have it.** Right after `bit export` returns, run `bit ripple log` to pick up the job and post the link it prints — don't sit silently through the build and don't wait for it to go green. The user can watch progress themselves, and if it fails they already have the page open.
 
-```
-https://bit.cloud/<owner>/<scope>/~lane/<lane-name>/~ripple-ci/job/<job-name>
-```
+Copy that URL verbatim; never assemble one by hand. Its last segment is the job's slug, not the display name, so a hand-built link lands on "No CI job found".
 
 Then report the outcome once it finishes. Once the build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it:
 
@@ -534,7 +541,7 @@ The backend schema and the query the frontend sends have drifted apart. Compare 
 
 ### Apollo test imports fail to resolve
 
-Import from `@apollo/client/testing/react/index.js` — not `@apollo/client/testing`.
+`@apollo/client/testing` is the normal import and works on most versions. Only when it genuinely fails to resolve, import from `@apollo/client/testing/react/index.js` instead — don't rewrite an import that already works.
 
 ---
 
@@ -555,7 +562,7 @@ Import from `@apollo/client/testing/react/index.js` — not `@apollo/client/test
 | Using `tsc` or `npx tsc` to check types                                         | Use `bit validate`, `bit check-types`, or `bit test`                                                                      |
 | Trying to create a scope from the CLI                                           | Scopes only exist on Bit Cloud — use the `create_scope` MCP tool                                                          |
 | Creating a scope for a domain that already has one                              | Run `read_scope` / `list_components` first — reuse the existing scope                                                     |
-| Creating a scope up front, before any code exists                               | Create it right before `bit snap`/`bit tag`/`bit export` — that's the only point it must exist                            |
+| Creating a scope up front, before any code exists                               | Create it right before `bit export` — that's the only point it must exist                                                 |
 | Creating a scope without asking                                                 | Confirm the name, owner and visibility with the user; on paid plans preview first, then call again with `confirmed: true` |
 | Exporting, then going quiet during the build                                    | Post the Ripple CI job link as soon as `bit export` returns, then report the result                                       |
 | Continuing to snap onto a lane that was already released                        | `bit switch main`, then `bit lane create` for the next piece of work                                                      |

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -221,7 +221,7 @@ cat node_modules/@<org>/<package-name>/package.json | grep -A3 '"componentId"'
 # → component ID: myorg.myfeature/pages/my-page
 ```
 
-### Importing Components
+### Importing Bit Components
 
 ```bash
 bit import <scope>/<name>
@@ -231,7 +231,7 @@ bit import myorg.myfeature/pages/my-page myorg.myfeature/pages/lobby-page
 
 Imported components land at `<scope-short-name>/<name>/` in the workspace.
 
-#### Importing Scopes
+#### Importing Entire Scopes
 
 ```bash
 bit import "<owner>.<scope>/**"

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -112,7 +112,7 @@ bit compile                          # rebuild dist/ — automatic while bit wat
 bit validate                         # lint + type-check + tests (fast build)
 bit test                             # run tests only
 bit lint                             # run linter only
-bit check-types                      # TypeScript type checker only
+bit check-types --strict             # TypeScript type checker only (without --strict it exits 0 even on errors)
 bit ripple log                       # check Ripple CI build status (auto-detects current lane)
 bit ripple errors                    # show build errors for a Ripple CI job
 bit ripple retry                     # retry a failed Ripple CI job
@@ -126,7 +126,7 @@ bit ripple stop                      # stop a running Ripple CI job
 > **Use Bit for type checking and testing.** Never use `tsc` or `npx tsc` directly. Use `bit validate` for a full check, or scope to specific components:
 >
 > ```bash
-> bit check-types "[component-id1, component-id2]"
+> bit check-types --strict "[component-id1, component-id2]"
 > bit test "[component-id1, component-id2]"
 > bit validate "[component-id1, component-id2]"
 > ```
@@ -368,7 +368,7 @@ There are two ways to compose an app. Decide before creating anything:
 
 - **Do NOT default to Harmony/Symphony — most projects do not need it.** For personal sites, MVPs, small-to-medium apps and single-team projects, use the simple `platform` composition below.
 - Use **Harmony** only for large enterprise platforms with multiple teams that need extensibility, plugin architecture and IoC — or when the user explicitly asks for it.
-- To tell what an existing workspace uses: check `workspace.jsonc` for `teambit.harmony/harmony`, or the code for `symphonyPlatform`. If neither is present, use simple platform composition.
+- To tell what an existing workspace uses: check `workspace.jsonc` for `bitdev.symphony/symphony-platform`, or the code for `symphonyPlatform`. If neither is present, use simple platform composition.
 - When it's unclear which fits, ask: _"Are you building a simple app/site, or an enterprise platform that multiple teams will extend?"_
 
 ### Simple platform composition

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -55,7 +55,7 @@ bit templates                        # see what generators are available
 
 ## Scopes & the Bit Cloud MCP
 
-A **scope** is a remote registry for one business domain — and the unit a full-stack feature ships as (see _Full-Stack Platforms & Harmony_). Every component ID is `<owner>.<scope>/<namespace>/<name>`.
+A **scope** is a remote registry for one business domain — and the unit a full-stack feature ships as (see _Full-Stack Apps_). A component ID is `<owner>.<scope>/<name>`, optionally with a namespace before the name: `<owner>.<scope>/<namespace>/<name>`. The namespace is optional — don't add one to an ID that doesn't have it.
 
 Anything remote — scopes, components, lanes, change requests — goes through the **Bit Cloud MCP**, not the CLI. The server advertises its own tools; two rules about _ordering_ them:
 
@@ -503,14 +503,14 @@ bit ripple retry        # retry a failed job
 
 Copy that URL verbatim; never assemble one by hand. Its last segment is the job's slug, not the display name, so a hand-built link lands on "No CI job found".
 
-Then report the outcome once it finishes. Once the build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it:
+Then report the outcome once it finishes. Once the build succeeds, an app that defines a deployment is live — get its URL with the `list_apps` MCP tool, don't guess or construct it:
 
 | Exported from     | Served on        |
 | ----------------- | ---------------- |
 | A lane (staging)  | `*.bit-app.dev`  |
 | main (production) | `*.composed.app` |
 
-**The URL changes when a change request is merged.** The lane's `bit-app.dev` URL is not the production one — after a release, call `list_apps` again and give the user the new `composed.app` URL. Component-only releases (no app) have no URL at all; point the user at the scope page instead.
+**The URL changes when a change request is merged.** The lane's `bit-app.dev` URL is not the production one — after a release, call `list_apps` again and give the user the new `composed.app` URL. Component-only releases have no URL at all, and neither does an app that defines no deployment — a green build on its own is not proof that anything was deployed. If `list_apps` gives you no URL, say so rather than implying the app is live, and point the user at the scope page instead.
 
 Custom domains are a Bit Cloud settings flow with no CLI equivalent — send the user to `https://bit.cloud/<owner>/~settings/deployment`. Never claim to have connected a domain yourself.
 

--- a/scopes/harmony/host-initializer/agents-template.md
+++ b/scopes/harmony/host-initializer/agents-template.md
@@ -16,8 +16,8 @@ Not all components are UI widgets. In Bit, a "component" can be any of these:
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | **Entity**           | Plain domain object — defines the shape and behavior of a domain model. No React, no side effects.                                                                                                  | `entities/user`, `entities/order`    |
 | **Hook**             | Encapsulates data fetching, mutations, or stateful logic for a domain. Consumed by UI components and pages.                                                                                         | `hooks/use-user`, `hooks/use-orders` |
-| **UI component**     | Reusable visual element, typically stateless or lightly stateful.                                                                                                                                   | `ui/button`, `ui/card`               |
-| **Feature / Aspect** | Self-contained domain slice — owns its entities, hooks, pages, and backend logic.                                                                                                                   | `customers`, `billing`               |
+| **UI component**     | Reusable visual element, typically stateless or lightly stateful                                                                                                                                    | `ui/button`, `ui/card`               |
+| **Feature / Aspect** | Self-contained domain slice — owns its entities, hooks, pages, and backend logic                                                                                                                    | `customers`, `billing`               |
 | **App**              | A standard deployable application — a React frontend, Node.js server, etc.                                                                                                                          | `my-react-app`, `my-node-server`     |
 | **Platform**         | The app-level composition that wires aspects together into a running system. Often named `*-platform`. Not a framework concept — just the component responsible for composing aspects into the app. | `my-platform`                        |
 | **Platform aspect**  | A special aspect that exposes the registration API other aspects use to plug in (routes, backend servers, etc.). Lives as its own aspect component, typically named `platform-aspect`.              | `platform-aspect`                    |
@@ -25,34 +25,20 @@ Not all components are UI widgets. In Bit, a "component" can be any of these:
 Understanding which type you're working with matters because it shapes the dependency chain. A typical full chain of a platform looks like:
 
 ```
-Platform  →  Feature/Aspect  →  Page  →  Hook  →  Entity
-                                      ↘  UI component
+Platform →  Feature/Aspect  →  Page  →  Hook  →  Entity
+                                     ↘  UI component
 ```
 
-For an app, the blueprint looks like:
+Where the blueprint of an app, look like this:
 
 ```
-App  →  Page  →  Hook (optional)  →  Entity (optional)
+App →  Page  →  Hook (optional) →  Entity (optional)
              ↘  UI component
 ```
 
-Entities and hooks sit at the bottom of the chain — they have no dependents of their own, so changes to them propagate upward. Everything above that consumes them must be local for your changes to take effect.
+Entities and hooks sit at the bottom of the chain — they have no dependents of their own, so changes to them propagate upward. You don't need to import anything below them, but everything above that consumes them must be local for your changes to take effect.
 
 The workspace is defined by `workspace.jsonc`. The owner and default scope are set there — always read them first.
-
----
-
-## Bit Cloud MCP
-
-This workspace ships with a `.mcp.json` that wires up the **Bit Cloud MCP** server (`https://mcp.bit.cloud/mcp`). When the MCP is connected and authenticated (the agent will prompt for OAuth on first use), it is the fastest way to discover and inspect components that live in remote scopes — prefer it over reading source files or installing packages just to look around.
-
-Key tools to reach for:
-
-- **`read_scopes`** — list scopes and their components for a given `owner` (read from `workspace.jsonc`). Prefer this over broad `search` for discovery.
-- **`read_components`** — structured type signatures, dependencies, and metadata for one or more remote components, in a single call. API references are included by default.
-- **`search`** — keyword search across remote scopes.
-
-When in doubt, ask the MCP before scaffolding anything new. If the MCP is not connected, fall back to the local `bit` CLI commands (`bit list`, `bit show`, `bit schema`).
 
 ---
 
@@ -65,18 +51,48 @@ bit status                           # check for pending changes
 bit templates                        # see what generators are available
 ```
 
-When using the Bit Cloud MCP, always pass the `owner` from `workspace.jsonc`. Prefer `read_scopes` over `search` for broader discovery.
+---
+
+## Scopes & the Bit Cloud MCP
+
+A **scope** is a remote registry for one business domain — and the unit a full-stack feature ships as (see _Full-Stack Platforms & Harmony_). Every component ID is `<owner>.<scope>/<namespace>/<name>`.
+
+Anything remote — scopes, components, lanes, change requests — goes through the **Bit Cloud MCP**, not the CLI. The server advertises its own tools; two rules about _ordering_ them:
+
+- Start with `orientation` when you don't know the account's topology, then `read_scope` to go deep on one domain. Reach for `search_components` only when you don't know which scope owns something.
+- Always pass the `owner` from `workspace.jsonc`.
+
+**If the MCP isn't connected, don't stop** — the CLI can read remotes too, just less efficiently. `bit list <owner>.<scope>` lists a remote scope's components, `bit show <owner>.<scope>/<name> --remote` inspects one, and `bit search <query>` searches by keyword across both the local workspace and Bit Cloud. Say that the MCP is unavailable and carry on; only scope creation has no CLI fallback.
+
+### Creating a scope
+
+**Don't create a scope up front — create it before you export.** `bit create <template> <name> --scope <owner>.<scope>` only records the scope ID locally, so you can build, validate and iterate against a scope that doesn't exist on Bit Cloud yet. The scope only has to exist by the time you publish, and creating one you never export to just leaves an empty scope on the account.
+
+The gate is right before `bit snap`, `bit tag` or `bit export`: for every scope you're about to publish to, confirm it exists (`read_scope` → `existsOnCloud`) and create the missing ones first. An export to a scope that doesn't exist fails.
+
+Scopes cannot be created from the CLI — use the `create_scope` MCP tool, or https://bit.cloud/create-scope in the browser.
+
+**Look before you create.** Run `orientation` first — if the work fits a domain that already exists, put the components there. Create a scope only when the domain is genuinely new.
+
+```
+create_scope({ owner: 'acme', scopeName: 'billing', displayName: 'Billing', description: 'Invoicing and subscriptions' })
+```
+
+- `scopeName` — lowercase letters, digits and dashes, starting with a letter (2 chars minimum). The resulting ID is `<owner>.<scopeName>`.
+- `owner` — defaults to the current account. You must be the account owner or an admin of that organization, otherwise the call is denied.
+- `visibility` — optional, `public` or `private`. Defaults to public on the free plan and private on paid plans.
+- `confirmed` — on paid plans the first call returns a **preview instead of creating**. Show it to the user, get approval, then call again with `confirmed: true`. On the free plan the scope is created on the first call.
 
 ---
 
 ## Understanding Component APIs
 
-When you need to understand how to **use** a component (its props, function signatures, return types), prefer structured API data over reading source files:
+When you need to understand how to **use** a component (its props, function signatures, return types), use structured API data instead of reading source files:
 
-- **Remote components:** use `read_components` (Bit Cloud MCP) — returns structured type signatures, dependencies, and metadata in a single call. API references are included by default. As a CLI fallback, run `bit show <owner>.<scope>/<name>`.
-- **Local workspace components:** run `bit schema <component-id>` — returns exported types, function signatures, and class methods.
+- **Remote components**: Use `read_components` (Bit Cloud MCP) — returns structured type signatures, dependencies, and metadata in a single call. API references are included by default.
+- **Local workspace components**: Run `bit schema <component-id>` — displays exported types, function signatures, and class methods.
 
-For understanding implementation details (how something works internally), read the source directly.
+These structured APIs are significantly more compact than reading source files. For understanding implementation details (how something works internally), use `read-file` or read the source directly.
 
 ---
 
@@ -86,25 +102,26 @@ For understanding implementation details (how something works internally), read 
 bit status                           # workspace health + pending changes
 bit start                            # dev server (default port 3000)
 bit run [app_name]                   # run the app
-bit list                             # all locally tracked components (do not pass args)
-bit search <query>                   # search components locally and on remote scopes (CLI fallback — prefer MCP for remote)
+bit list                             # all locally tracked components (do not pass args to the command)
 bit show <owner>.<scope>/<name>      # inspect a specific component
-bit schema <component-id>            # structured API of a local component
 bit import "<owner>.<scope>/**"      # import all components from a remote scope
 bit templates                        # list available generator templates
 bit create <template> <name>         # scaffold a new component
 bit install [pkg1] [pkg2] ...        # install package dependencies
-bit compile                          # manual compile (usually auto — use for troubleshooting)
-bit validate                         # lint + type-check + tests (fast build) — preferred check
+bit compile                          # rebuild dist/ — automatic while bit watch/start runs, manual otherwise
+bit validate                         # lint + type-check + tests (fast build)
 bit test                             # run tests only
 bit lint                             # run linter only
 bit check-types                      # TypeScript type checker only
-bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — list/log/errors/retry/stop (jobs that build components in the cloud after export)
+bit ripple log                       # check Ripple CI build status (auto-detects current lane)
+bit ripple errors                    # show build errors for a Ripple CI job
+bit ripple retry                     # retry a failed Ripple CI job
+bit ripple stop                      # stop a running Ripple CI job
 ```
 
 > **Never run `bit build`** unless absolutely necessary. Always use `bit validate` instead — it's faster and sufficient.
 >
-> **Always use `bit install`** to install packages. Never use `npm install`, `yarn`, or `pnpm` directly — unless the workspace is configured with `externalPackageManager` mode in `workspace.jsonc`, in which case use your configured package manager.
+> **Always use `bit install`** to install packages. Never use `npm install`, `yarn`, or `pnpm` directly.
 >
 > **Use Bit for type checking and testing.** Never use `tsc` or `npx tsc` directly. Use `bit validate` for a full check, or scope to specific components:
 >
@@ -118,13 +135,13 @@ bit ripple <sub-command>             # manage Ripple CI jobs on bit.cloud — li
 
 ## Discovering Apps
 
-```bash
+To list apps in the workspace run the following command:
+
+```
 bit app list
 ```
 
-Use the Bit Cloud MCP to list remote apps in a given scope. Use `bit import` to fetch remote apps and run them locally.
-
----
+Use the Bit Cloud MCP to list remote apps. Use `bit import` to fetch remote apps and run them locally.
 
 ## The Golden Rule: One Component at a Time
 
@@ -134,20 +151,20 @@ Never scaffold multiple components upfront. Bit development is an **iterative lo
 render → identify gap → create ONE component → render again
 ```
 
-### Step-by-step
+### Step-by-step Process
 
-1. **Look before you create.** Search the workspace and the Bit Cloud MCP first:
+1. **Look before you create.** Search the workspace and Bit Cloud MCP first:
 
    ```bash
-   bit list                             # what's already local
-   bit show <owner>.<scope>/<name>      # inspect a candidate
+   bit list
+   bit show <owner>.<scope>/<name>
    ```
 
-   And via the MCP: `read_scopes` for the workspace `owner` to see existing components, or `search` for keyword discovery. A component may already exist locally or remotely. Don't duplicate.
+   A component may already exist locally or remotely. Don't duplicate.
 
-2. **Identify the entry point.** Depending on what you're building, the entry point could be a platform, app, or feature/aspect. Use the MCP (`read_scopes` / `read_components`) to list what exists in the scope before creating anything new.
+2. **Identify the entry point.** Depending on what you're building, the entry point could be a platform, app, or feature/aspect. Use the MCP to list what exists in the scope before creating anything new.
 
-3. **Create one component.** Scaffold it, wire it in, verify it compiles and renders.
+3. **Create one component.** Scaffold it, wire it into the app, and verify it compiles and renders.
 
 4. **Validate before moving on:**
 
@@ -159,15 +176,15 @@ render → identify gap → create ONE component → render again
 
 6. **Repeat.** Never pre-plan a list of components and create them all at once.
 
-#### Example
+#### Example Commands
 
-Create a UI component:
+Create UI component:
 
 ```bash
 bit create react pages/login --scope acme.people
 ```
 
-Create a data entity:
+Create data entity:
 
 ```bash
 bit create entity entities/user --scope acme.people
@@ -181,19 +198,19 @@ Bit resolves **local workspace components** over their installed package version
 
 ### The full dependency chain must be local
 
-When modifying any component, import every component in the chain from the top down to your target:
+When modifying any component, import every component in the chain from the top down to your target. The chain depends on what type of component you're working with:
 
 ```
 Platform  →  App  →  Feature/Aspect  →  Page  →  UI component
 ```
 
-You don't always need the full chain — only the layers in the dependency path of your change. But every layer between the entry point and your target must be local. If any layer in between is still installed as a package (not local), the app will ignore your changes to the layers below it.
+You don't always need the full chain — only the layers that are in the dependency path of your change. But every layer between the entry point and your target must be local. If any layer in between is still installed as a package (not local), the app will ignore your changes to the layers below it.
 
 **Examples:**
 
-- Changing a UI component used by a feature page → import the feature, the page, and the UI component.
-- Changing a feature's backend logic → import the platform, the app, and the feature/aspect.
-- Changing the platform itself → import the platform only (everything downstream will pick it up once local).
+- Changing a UI component used by a feature page → import the feature, the page, and the UI component
+- Changing a feature's backend logic → import the platform, the app, and the feature/aspect
+- Changing the platform itself → import the platform only (everything downstream will pick it up once local)
 
 ### Finding the component ID
 
@@ -204,7 +221,7 @@ cat node_modules/@<org>/<package-name>/package.json | grep -A3 '"componentId"'
 # → component ID: myorg.myfeature/pages/my-page
 ```
 
-### Importing
+### Importing Components
 
 ```bash
 bit import <scope>/<name>
@@ -214,30 +231,77 @@ bit import myorg.myfeature/pages/my-page myorg.myfeature/pages/lobby-page
 
 Imported components land at `<scope-short-name>/<name>/` in the workspace.
 
-#### Importing whole scopes
+#### Importing Scopes
 
 ```bash
 bit import "<owner>.<scope>/**"
+# e.g.
+bit import "myorg.myfeature/**"
 ```
-
----
 
 ## Saving and Publishing Changes
 
 **Never push directly to the main lane.** Always create a lane and submit a change request.
 
-Git does not manage component versions in a Bit workspace — use Bit for version control of components.
+Git does not exist in the workspace. Use only Bit for version control.
+
+A **lane** collects and proposes component changes, in a similar fashion to a branch in Git. It can contain new components, changed components, and deletions. A lane is identified as `<scope>/<lane-name>` — for example `acme.billing/fix-invoice`. Never put a slash inside the lane name itself.
 
 ```bash
-bit lane create <your-lane-name>     # create a new lane
+bit lane current                     # which lane am I on? check before anything else
+bit lane create <your-lane-name>     # create a lane and switch to it
 bit validate                         # confirm no build errors first
 bit snap --message "describe change" # persist component versions
 bit export                           # push lane to remote
 ```
 
-> Always run `bit lane create` first. If you're already on a non-main lane, continue using it — don't create a new one.
+> Always check `bit lane current` first. If you're already on a non-main lane, continue using it — don't create a new one.
 
-After exporting, components are built in the cloud by Ripple CI. Use `bit ripple log` to follow the current lane's job and `bit ripple errors` to inspect any build failures (or `bit ripple retry` to re-run it).
+> **Before snapping, tagging or exporting**, make sure every scope you're publishing to exists on Bit Cloud — check `existsOnCloud` via `read_scope` and create the missing ones with `create_scope` (see _Creating a scope_). This is the point at which a scope must exist; don't create it earlier.
+
+### `bit snap` vs `bit tag`
+
+Where you are decides which one you run — it is not a preference:
+
+- **On a lane → `bit snap`.** Produces a hash, no version number. This is the default path.
+- **On main → `bit tag`.** Produces a semver version, releasing to production. Bumps the patch by default; use `--minor` / `--major` only when the user describes a minor, major, or breaking release.
+
+`bit tag` is **only possible on main** — it is not a thing you can do on a lane, so there is no choice to make once `bit lane current` tells you where you are. On a lane, snap. And even on main, tagging is rejected when the scope protects `main` or the account requires review; then the lane workflow is the only path (see _When main is protected_).
+
+Run `bit validate` before either — it's a hard gate, never snap or tag on a failing validate. And talk to the user in outcomes, not CLI verbs: "deploy to production" and "deploy to a preview lane", not "tag" and "snap".
+
+### Change requests
+
+After exporting, open a change request so the lane can be reviewed and released:
+
+- `submit_change_request` (Bit Cloud MCP) — open the change request for your lane
+- `list_change_requests` — check its status
+- `edit_change_request` — update its title or description
+
+Ripple CI builds every export. Run `bit ripple log` as soon as the export returns, give the user the job link straight away (see _Deploying_), and check the build is green before asking anyone to review:
+
+```bash
+bit ripple log                       # build status for the current lane
+bit ripple errors                    # build errors for a failing job
+bit ripple retry                     # retry a failed job
+```
+
+### After the lane is released
+
+When the change request is **released** (merged to main), the lane is finished — but your workspace is still sitting on it. Switch back before starting anything new:
+
+```bash
+bit lane current                     # confirm which lane you're on
+bit switch main                      # move the workspace to main and fetch the released versions
+bit status                           # verify a clean workspace on main
+bit lane remove <your-lane-name>     # optional: drop the now-merged local lane
+```
+
+Never keep snapping onto a released lane — those snaps land somewhere nobody will review again. Start the next piece of work with a fresh `bit lane create`.
+
+### When main is protected
+
+Scopes can protect `main`, and some accounts don't allow agents to release to it. If `bit export` or `bit tag` is rejected for that reason, do not retry and do not try to work around it — create a lane, snap, export, and open a change request instead.
 
 ---
 
@@ -249,13 +313,15 @@ Each component directory follows this convention:
 | ------------------------ | ------------------------------------ |
 | `<name>.tsx`             | Main implementation                  |
 | `index.ts`               | Public barrel export                 |
-| `<name>.spec.tsx`        | Tests                                |
+| `<name>.spec.tsx`        | Vitest tests                         |
 | `<name>.composition.tsx` | Live previews (shown in `bit start`) |
 | `<name>.docs.mdx`        | Documentation                        |
 | `<name>.mock.ts`         | Mock data / fixtures                 |
 | `*-type.ts`              | Standalone type definitions          |
 
-> Add JSDocs to exported APIs, include two to three usage examples in the `.docs.mdx`, and two to three compositions for the live preview.
+> Ensure proper JSDocs documentation, complete MDX docs with two to three usage examples. Add two to three composition for the component live preview.
+
+JSDoc on exported members isn't optional polish — it's what renders as the component's API reference on Bit Cloud, and it's the first thing another agent reads when deciding whether to reuse the component. For the same reason, avoid `any` in a public signature: it erases the API for every consumer, and `bit check-types` gates publishing.
 
 ---
 
@@ -273,7 +339,7 @@ Never use relative paths across component boundaries. Always use the package not
 
 ## Environment Setup
 
-Generator environments (React, Vue, Node, Angular, etc.) are configured in `workspace.jsonc`. Some may be commented out. Enable the relevant environment before creating components for a specific framework.
+Generator environments (React, Vue, Node, etc.) are configured in `workspace.jsonc`. Some may be commented out. Enable the relevant environment before creating components for a specific framework.
 
 ---
 
@@ -287,9 +353,104 @@ Generator environments (React, Vue, Node, Angular, etc.) are configured in `work
 
 ---
 
-## Runtime Code Crossing Environment Boundaries
+## Full-Stack Apps
 
-Importing frontend modules into Node.js runtime files or Node.js modules into browser runtime files causes app initialization failures. This typically happens when `index.ts` or runtime files import/export cross-environment modules by value instead of by type.
+There are two ways to compose an app. Decide before creating anything:
+
+- **Do NOT default to Harmony/Symphony — most projects do not need it.** For personal sites, MVPs, small-to-medium apps and single-team projects, use the simple `platform` composition below.
+- Use **Harmony** only for large enterprise platforms with multiple teams that need extensibility, plugin architecture and IoC — or when the user explicitly asks for it.
+- To tell what an existing workspace uses: check `workspace.jsonc` for `teambit.harmony/harmony`, or the code for `symphonyPlatform`. If neither is present, use simple platform composition.
+- When it's unclear which fits, ask: _"Are you building a simple app/site, or an enterprise platform that multiple teams will extend?"_
+
+### Simple platform composition
+
+Never hand-write boilerplate — scaffold with `bit create <template> <name>`, and run `bit templates` first to see what this workspace offers. If a template you need is missing, enable its env in `workspace.jsonc` generators.
+
+A full-stack app is **three components composed by a platform**:
+
+1. `bit create platform <name>-platform` — the deployable unit
+2. `bit create react-app <name>-app` — the frontend
+3. `bit create express-server <name>-service` — the backend (name it after its domain; use the `-service` suffix, never `-api` or `-backend`)
+
+Then compose the app and the service in the platform and run `bit run <name>-platform`. The platform assigns ports and proxies, so the frontend never needs to know the backend port.
+
+**Reaching the backend from the frontend.** The platform exposes the backend base URL to the React app as the `BACKEND_URL` environment variable — read it with `process.env.BACKEND_URL`:
+
+```ts
+fetch(`${process.env.BACKEND_URL}/api/users`, { credentials: 'include' });
+```
+
+Every cross-origin call to `BACKEND_URL` **must** pass `credentials: 'include'` — `credentials: 'include'` in `fetch`, or in the Apollo `HttpLink`. The platform gateway is configured for credentialed CORS (origin reflection plus `Access-Control-Allow-Credentials: true`), and without it the browser blocks the response. Do NOT add a Vite proxy or switch to relative paths as a workaround — the gateway already handles CORS correctly once credentials are included. This works the same way in Bit Cloud workspaces and in production.
+
+MongoDB is already provisioned at `process.env.MONGO_URL`; never add an in-memory store or ask the user to set up a database.
+
+Other common templates: `react`, `react-hook`, `react-theme` (UI); `module`, `entity`, `graphql-server` (Node).
+
+---
+
+## Harmony Platforms
+
+**This section applies ONLY when the workspace uses Harmony/Symphony — if it doesn't, ignore everything here and use the simple platform composition above.**
+
+Templates: `harmony-platform` (the platform), `aspect` (a domain that plugs into it), `platform-aspect` (the platform's entry aspect), `bit-aspect` (extend Bit itself).
+
+An aspect is one domain's full vertical — its `*.node.runtime.ts` holds GraphQL, database and routes, its `*.browser.runtime.tsx` holds pages and routing, and neither may import the other's modules. Features register themselves into the platform; the platform never imports a feature.
+
+### Backend Registration
+
+All GraphQL schemas and REST routes must be registered through `symphonyPlatform.registerBackendServer`. This is the only correct way — never use `registerMiddlewares` for endpoint logic.
+
+```ts
+symphonyPlatform.registerBackendServer([
+  {
+    name: 'ai',       // sets the gateway prefix: /ai/...
+    gql: gqlSchema,   // optional — omit if no GraphQL
+    routes: [
+      {
+        path: '/stream',
+        method: 'post',
+        route: async (req, res) => { ... },
+      },
+    ],
+  },
+]);
+```
+
+### UI Layout Registration
+
+`symphonyPlatform.registerLayoutEntry` registers a component **globally** — it renders on every page. Use it only for truly global sticky chrome like the top navigation header.
+
+**Never use it for footers or any element that should appear on specific pages only.** Instead, import the component and render it directly inside the relevant page component(s).
+
+```tsx
+// Wrong — makes footer appear on every page, sticky
+symphonyPlatform.registerLayoutEntry([{ position: 'bottom', component: () => <Footer /> }]);
+
+// Correct — add Footer directly inside the page
+export function Homepage() {
+  return (
+    <div>
+      {/* page content */}
+      <Footer />
+    </div>
+  );
+}
+```
+
+### Gateway Routing
+
+The Symphony gateway proxies frontend calls to the backend, stripping the aspect name prefix:
+
+```
+Frontend:  /api/{name}/{path}
+Backend receives:  /{path}
+```
+
+For example, `POST /api/ai/stream` → backend receives `POST /stream`. The frontend **must always** include the `/api` prefix.
+
+### Troubleshooting: Runtime Code Crossing Environment Boundaries
+
+Importing frontend modules into Node.js or Node.js modules into the browser causes app initialization failures. This happens when `index.ts` or runtime files import/export cross-environment modules by value instead of by type.
 
 **Rules for aspect `index.ts` files:**
 
@@ -315,22 +476,89 @@ export { User } from './user.js';
 
 **Rules for `*.browser.runtime.tsx` files:**
 
-- Must not import Node.js modules (`fs`, `path`, server-only libraries) by value. Use `import type` if only the type is needed.
+- Must not import Node.js modules (fs, path, server-only libraries) by value. Use `import type` if only the type is needed.
+
+---
+
+## Deploying
+
+**There is nothing to configure.** Exporting is deploying: Ripple CI builds the exported components, detects the app framework from the build artifacts, and deploys to a managed container automatically. Never add a deployer config or tell the user to set one up.
+
+```bash
+bit ripple log          # build status (auto-detects the current lane)
+bit ripple errors       # why a build failed
+bit ripple retry        # retry a failed job
+```
+
+**Give the user the build link as soon as you have it.** Right after `bit export` returns, run `bit ripple log` to pick up the job and post the link — don't sit silently through the build and don't wait for it to go green. The user can watch progress themselves, and if it fails they already have the page open:
+
+```
+https://bit.cloud/<owner>/<scope>/~lane/<lane-name>/~ripple-ci/job/<job-name>
+```
+
+Then report the outcome once it finishes. Once the build succeeds the app is live — get the URL with the `list_apps` MCP tool, don't guess or construct it:
+
+| Exported from     | Served on        |
+| ----------------- | ---------------- |
+| A lane (staging)  | `*.bit-app.dev`  |
+| main (production) | `*.composed.app` |
+
+**The URL changes when a change request is merged.** The lane's `bit-app.dev` URL is not the production one — after a release, call `list_apps` again and give the user the new `composed.app` URL. Component-only releases (no app) have no URL at all; point the user at the scope page instead.
+
+Custom domains are a Bit Cloud settings flow with no CLI equivalent — send the user to `https://bit.cloud/<owner>/~settings/deployment`. Never claim to have connected a domain yourself.
+
+---
+
+## Troubleshooting
+
+### The app doesn't reflect your change
+
+**Most likely the `dist/` is stale.** Consumers import a component through `node_modules/<package>/dist/`, not its source, and `bit validate` type-checks _source_ — so it passes green while the running app still serves the old build. `bit watch` / `bit start` normally recompiles on save, but if either isn't running, or the change landed while it was down, the old `dist/` sits there.
+
+```bash
+bit compile             # rebuild dist/
+# then restart the app
+```
+
+Do this **before** re-reading and re-editing files. If the source is already correct, editing it again cannot help — a passing `bit validate` plus wrong runtime behavior is the signature of this bug, not of a code error.
+
+If compiling and restarting doesn't help, run `bit install`, then restart again.
+
+### Seeded or mock data doesn't update
+
+Seed logic usually writes only into an empty collection, so changing a seed or a `*.model.ts` has no effect on a database that already has rows — the stale documents stay, and may not even match the new shape. Clear the affected collections before restarting, or version the seed (write a marker document and re-seed when the version changes) so it re-runs on its own.
+
+### GraphQL data missing or malformed
+
+The backend schema and the query the frontend sends have drifted apart. Compare the two directly; don't debug the UI.
+
+### Apollo test imports fail to resolve
+
+Import from `@apollo/client/testing/react/index.js` — not `@apollo/client/testing`.
 
 ---
 
 ## Common Mistakes to Avoid
 
-| Mistake                                                    | Correct approach                                                                                                   |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Creating multiple components upfront                       | Create one, validate, then decide what's next                                                                      |
-| Modifying an installed (node_modules) component            | Import it with `bit import` first                                                                                  |
-| Importing only the target component but not its dependents | Import the full chain top-down: platform → app → feature → page → component                                        |
-| Treating all components as UI widgets                      | Understand the type first — platform, app, feature/aspect, hook, entity, or UI component — it determines the chain |
-| Running `bit build`                                        | Use `bit validate` instead — faster and sufficient                                                                 |
-| Pushing to the main lane                                   | Always create a lane, snap, then export                                                                            |
-| Using git to version components                            | Bit manages component versions — use `bit snap` / `bit export`                                                     |
-| Guessing a component ID                                    | Check `package.json` under `componentId` or use `bit list`                                                         |
-| Creating a component that already exists                   | Always run `bit list` and check the Bit Cloud MCP (`read_scopes` / `search`) first                                 |
-| Using `npm install`, `yarn`, or `pnpm`                     | Use `bit install`                                                                                                  |
-| Using `tsc` or `npx tsc` to check types                    | Use `bit validate`, `bit check-types`, or `bit test`                                                               |
+| Mistake                                                                         | Correct approach                                                                                                          |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Creating multiple components upfront                                            | Create one, validate, then decide what's next                                                                             |
+| Modifying an installed (node_modules) component                                 | Import it with `bit import` first                                                                                         |
+| Importing only the target component but not its dependents                      | Import the full chain top-down: platform → app → feature → page → component                                               |
+| Treating all components as UI widgets                                           | Understand the type first — platform, app, feature/aspect, or UI component — it determines the chain                      |
+| Running `bit build`                                                             | Use `bit validate` instead                                                                                                |
+| Pushing to main lane                                                            | Always create a lane, snap, then export                                                                                   |
+| Using git for version control                                                   | Bit only — no git in the workspace                                                                                        |
+| Guessing a component ID                                                         | Check `package.json` under `componentId` or use `bit list`                                                                |
+| Creating a component that already exists                                        | Always `bit list` and search MCP first                                                                                    |
+| Using `npm install`, `yarn`, or `pnpm`                                          | Use `bit install` to install packages                                                                                     |
+| Using `tsc` or `npx tsc` to check types                                         | Use `bit validate`, `bit check-types`, or `bit test`                                                                      |
+| Trying to create a scope from the CLI                                           | Scopes only exist on Bit Cloud — use the `create_scope` MCP tool                                                          |
+| Creating a scope for a domain that already has one                              | Run `read_scope` / `list_components` first — reuse the existing scope                                                     |
+| Creating a scope up front, before any code exists                               | Create it right before `bit snap`/`bit tag`/`bit export` — that's the only point it must exist                            |
+| Creating a scope without asking                                                 | Confirm the name, owner and visibility with the user; on paid plans preview first, then call again with `confirmed: true` |
+| Exporting, then going quiet during the build                                    | Post the Ripple CI job link as soon as `bit export` returns, then report the result                                       |
+| Continuing to snap onto a lane that was already released                        | `bit switch main`, then `bit lane create` for the next piece of work                                                      |
+| Making the platform import a feature aspect                                     | Inverted — the feature aspect imports the platform and registers itself                                                   |
+| Importing React/SCSS in a node runtime, or Node.js modules in a browser runtime | Keep runtime code on its own side of the boundary and out of `index.ts`                                                   |
+| Hand-writing a platform, aspect or app                                          | Scaffold it with `bit create` — run `bit templates` to see what's available                                               |


### PR DESCRIPTION
This change expands the two AGENTS.md templates. `bit init` writes one of them into each new workspace. It selects `agents-template-git.md` when the directory contains `.git`, and `agents-template.md` when it does not.

New content in both templates:

- Scopes and the Bit Cloud MCP. Create the scope immediately before you publish, not earlier.
- Full-stack apps. Do not use Harmony for small projects.
- Harmony platforms: backend registration, layout registration, and gateway routing.
- Deployment. An export starts the deployment. Give the Ripple CI link immediately.
- Troubleshooting. A stale `dist/` is the usual cause when the app does not show a change.

The two templates keep their different workflows. The lanes template adds `bit snap` against `bit tag`, change requests, and the steps after a lane release. The Git template keeps the Git branch workflow. CI does the snap, the tag and the export.

This change also corrects the MCP tool names. `read_scopes` and `search` are obsolete. The correct names are `orientation`, `read_scope`, and `search_components`.
