### PR TITLE
chore: replace the community Slack links with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <a href="https://github.com/teambit/bit/blob/master/CONTRIBUTING.md"><img alt="prs" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
 <a href="https://circleci.com/gh/teambit/bit/tree/master"><img alt="Circle Status" src="https://circleci.com/gh/teambit/bit/tree/master.svg?style=shield">
 <a href="https://github.com/prettier/prettier"><img alt ="Styled with Prettier" src="https://img.shields.io/badge/styled_with-prettier-ff69b4.svg">
-<a href="https://join.slack.com/t/bit-dev-community/shared_invite/zt-1vq1vcxxu-CEVobR1p9BurmW8QnQFh1w" ><img alt="Join Slack" src="https://img.shields.io/badge/Slack-Join%20Bit%20Slack-blueviolet"/></a>
+<a href="https://discord.bit.cloud/" ><img alt="Join Discord" src="https://img.shields.io/badge/Discord-Join%20Bit%20Discord-5865F2"/></a>
 
 [Bit](https://bit.dev) is the build system to connect components and apps from development to CI in the AI era. Bit organizes source code into composable components, empowering to build reliable, scalable and consistent applications. It enables AI agents to intelligenly create and reuse components via MCP preventing duplication and accelerating development.
 

--- a/scopes/cloud/cloud/cloud.ui.runtime.tsx
+++ b/scopes/cloud/cloud/cloud.ui.runtime.tsx
@@ -118,8 +118,8 @@ export class CloudUI {
                     link: 'https://support.bit.cloud',
                   },
                   {
-                    label: 'Bit Community Slack',
-                    link: 'https://join.slack.com/t/bit-dev-community/shared_invite/zt-29pmawrp1-ehfEzYbQyuAC3CNA_jYPvA',
+                    label: 'Bit Community Discord',
+                    link: 'https://discord.bit.cloud/',
                   },
                 ] as any,
               }}


### PR DESCRIPTION
The community Slack is not active. The community moved to Discord.

This change replaces the Slack links with `https://discord.bit.cloud/`:

- The community badge in the README.
- The "Bit Community Slack" item in the Support menu of the Bit UI.

The two files had different Slack invite links. Both links are now obsolete. The new URL is a permanent redirect to the current Discord invite. Thus it does not expire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)